### PR TITLE
Added: Testing for 8888 to 565 clean round trips; and moved decoded blocks to common crate.

### DIFF
--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -60,11 +60,18 @@ Data:    | C0-C1 | I0-I3 |   | C2-C3 | I4-I8 |
          +-------+-------+   +-------+-------+
 ```
 
-When an entire block is solid, we set colour `C0` to the colour of the block, and then set
-C1, I0-I3 all to `0x00`. This results in a nice repetition of `0x00`.
+Sometimes there is a clean conversion between `8888` and `565` colour, meaning that it's possible
+to represent a colour using only 1 out of the 2 colour components, i.e. only `C0` or `C1`.
 
-Do note that this can only be done when the block does not use 1-bit alpha, i.e. when neither 
-`color0 <= color1` and one of the indices being `11` is true. 
+When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
+colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`.
+This results in a nice repetition of `0x00` across 6 bytes.
+
+For fully transparent blocks, we instead set all the bits to `1`, so block becomes filled with `0xFF`. 
+
+If the block consists of both transparent and non-transparent pixels, i.e. `color0 <= color1` 
+and there is a mix of `11` and non `11` indices, then we leave the block intact; we can't do much
+with it.
 
 ### Decorrelating Colours
 

--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -67,7 +67,7 @@ When an entire block is solid, and a clean conversion between `8888` and `565` i
 colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`.
 This results in a nice repetition of `0x00` across 6 bytes.
 
-For fully transparent blocks, we instead set all the bits to `1`, so block becomes filled with `0xFF`. 
+For fully transparent blocks, we instead set all the bits to `1`, so the block becomes filled with `0xFF`. 
 
 If the block consists of both transparent and non-transparent pixels, i.e. `color0 <= color1` 
 and there is a mix of `11` and non `11` indices, then we leave the block intact; we can't do much

--- a/projects/dxt-lossless-transform-bc1/benches/block_decode/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/block_decode/main.rs
@@ -1,6 +1,7 @@
 use core::alloc::Layout;
 use criterion::{criterion_group, criterion_main, Criterion};
-use dxt_lossless_transform_bc1::util::{decode_bc1_block, DecodedBc1Block};
+use dxt_lossless_transform_bc1::util::decode_bc1_block;
+use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
 use safe_allocator_api::RawAlloc;
 
 #[cfg(not(target_os = "windows"))]
@@ -20,7 +21,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     // Allocate memory for input BC1 data and output pixels
     let input = allocate_align_64(bc1_size);
-    let mut output = allocate_align_64(blocks_count * size_of::<DecodedBc1Block>());
+    let mut output = allocate_align_64(blocks_count * size_of::<Decoded4x4Block>());
 
     // Initialize input with test data (simple pattern for BC1 blocks)
     unsafe {
@@ -43,7 +44,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     let input_ptr = input.as_ptr();
-    let output_blocks = output.as_mut_ptr() as *mut DecodedBc1Block;
+    let output_blocks = output.as_mut_ptr() as *mut Decoded4x4Block;
     group.throughput(criterion::Throughput::Bytes(bc1_size as u64));
 
     // Benchmark the BC1 decoding function with raw pointers

--- a/projects/dxt-lossless-transform-bc1/src/util/bc1_decode.rs
+++ b/projects/dxt-lossless-transform-bc1/src/util/bc1_decode.rs
@@ -14,7 +14,7 @@ use dxt_lossless_transform_common::{
 ///
 /// # Returns
 ///
-/// A [`DecodedBc1Block`] containing all 16 decoded pixels
+/// A [`Decoded4x4Block`] containing all 16 decoded pixels
 ///
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc1/src/util/bc1_decode.rs
+++ b/projects/dxt-lossless-transform-bc1/src/util/bc1_decode.rs
@@ -2,75 +2,9 @@
 //! <https://github.com/wolfpld/etcpak> and MSDN
 //! <https://learn.microsoft.com/en-us/windows/win32/direct3d9/opaque-and-1-bit-alpha-textures>
 
-use core::mem::transmute;
-use dxt_lossless_transform_common::{color_565::Color565, color_8888::Color8888};
-
-/// Represents a decoded 4x4 block of BC1 pixels
-#[derive(Debug, Clone, Copy)]
-pub struct DecodedBc1Block {
-    /// The 16 pixels in the block (row-major order)
-    pub pixels: [Color8888; 16],
-}
-
-impl DecodedBc1Block {
-    /// Constructs a new decoded BC1 block initialised with 16 copies of the provided pixel.
-    /// This function creates a 4x4 block where every pixel is set to the specified value.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use dxt_lossless_transform_common::color_8888::Color8888;
-    /// use dxt_lossless_transform_bc1::util::DecodedBc1Block;
-    ///
-    /// let pixel = Color8888::new(255, 0, 0, 255);
-    /// let block = DecodedBc1Block::new(pixel);
-    /// assert!(block.pixels.iter().all(|&p| p == pixel));
-    /// ```
-    pub fn new(pixel: Color8888) -> Self {
-        Self {
-            pixels: [pixel; 16],
-        }
-    }
-
-    /// Gets a pixel at the specified coordinates (0-3, 0-3) without bounds checking
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `x < 4` and `y < 4`.
-    #[inline]
-    pub unsafe fn get_pixel_unchecked(&self, x: usize, y: usize) -> Color8888 {
-        *self.pixels.get_unchecked(y * 4 + x)
-    }
-
-    /// Sets a pixel at the specified coordinates (0-3, 0-3) without bounds checking
-    ///
-    /// # Safety
-    ///
-    /// The caller must ensure that `x < 4` and `y < 4`.
-    #[inline]
-    pub unsafe fn set_pixel_unchecked(&mut self, x: usize, y: usize, pixel: Color8888) {
-        *self.pixels.get_unchecked_mut(y * 4 + x) = pixel;
-    }
-
-    /// Checks if all pixels in the block have the same color values
-    ///
-    /// # Returns
-    /// `true` if all pixels in the block are identical, `false` otherwise
-    #[inline]
-    pub fn has_identical_pixels(&self) -> bool {
-        // Assert at compile time that Color8888 is the same size as u32
-        const _: () = assert!(size_of::<Color8888>() == size_of::<u32>());
-
-        // Cast first pixel to u32
-        let first_pixel_u32: u32 = unsafe { transmute(self.pixels[0]) };
-
-        // Compare all other pixels to the first one after casting to u32
-        self.pixels.iter().all(|pixel| {
-            let pixel_u32: u32 = unsafe { transmute(*pixel) };
-            pixel_u32 == first_pixel_u32
-        })
-    }
-}
+use dxt_lossless_transform_common::{
+    color_565::Color565, color_8888::Color8888, decoded_4x4_block::Decoded4x4Block,
+};
 
 /// Decodes a BC1 block into a structured representation of pixels
 ///
@@ -102,7 +36,7 @@ impl DecodedBc1Block {
 /// }
 /// ```
 #[inline(always)]
-pub unsafe fn decode_bc1_block(src: *const u8) -> DecodedBc1Block {
+pub unsafe fn decode_bc1_block(src: *const u8) -> Decoded4x4Block {
     // Extract color endpoints and index data
     let c0_raw: u16 = u16::from_le_bytes([*src, *src.add(1)]);
     let c1_raw: u16 = u16::from_le_bytes([*src.add(2), *src.add(3)]);
@@ -148,7 +82,7 @@ pub unsafe fn decode_bc1_block(src: *const u8) -> DecodedBc1Block {
     }
 
     // Initialize the result block
-    let mut result = DecodedBc1Block::new(Color8888::new(0, 0, 0, 0));
+    let mut result = Decoded4x4Block::new(Color8888::new(0, 0, 0, 0));
 
     // Decode indices and set pixels
     let mut index_pos = 0;
@@ -169,7 +103,7 @@ pub unsafe fn decode_bc1_block(src: *const u8) -> DecodedBc1Block {
 ///
 /// A decoded block, else [`None`] if the slice is too short.
 #[inline(always)]
-pub fn decode_bc1_block_from_slice(src: &[u8]) -> Option<DecodedBc1Block> {
+pub fn decode_bc1_block_from_slice(src: &[u8]) -> Option<Decoded4x4Block> {
     if src.len() < 8 {
         return None;
     }
@@ -178,6 +112,8 @@ pub fn decode_bc1_block_from_slice(src: &[u8]) -> Option<DecodedBc1Block> {
 
 #[cfg(test)]
 mod tests {
+    use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+
     use super::*;
 
     #[test]
@@ -223,10 +159,10 @@ mod tests {
     #[test]
     fn has_identical_pixels() {
         // Create a block where all pixels are the same
-        let identical_block = DecodedBc1Block::new(Color8888::new(100, 150, 200, 255));
+        let identical_block = Decoded4x4Block::new(Color8888::new(100, 150, 200, 255));
 
         // Create a block where one pixel is different
-        let mut different_block = DecodedBc1Block::new(Color8888::new(100, 150, 200, 255));
+        let mut different_block = Decoded4x4Block::new(Color8888::new(100, 150, 200, 255));
         different_block.pixels[10] = Color8888::new(101, 150, 200, 255);
 
         // Test the function

--- a/projects/dxt-lossless-transform-common/README.MD
+++ b/projects/dxt-lossless-transform-common/README.MD
@@ -11,7 +11,7 @@ This crate provides shared components between various implementations of [dxt-lo
 ## Core Types
 
 - [Color565](./src/color_565.rs): A color type representing a 5-bit red, 6-bit green, and 5-bit blue component.
-- [Color8888](./src/color_8888.rs): A color type representing a 8-bit red, 8-bit green, 8-bit blue, and 8-bit alpha component.
+- [Color8888](./src/color_8888.rs): A color type representing an 8-bit red, 8-bit green, 8-bit blue, and 8-bit alpha component.
 
 ## Development
 

--- a/projects/dxt-lossless-transform-common/README.MD
+++ b/projects/dxt-lossless-transform-common/README.MD
@@ -10,8 +10,8 @@ This crate provides shared components between various implementations of [dxt-lo
 
 ## Core Types
 
-- [Color565](./src/color_565.rs)
-- [Color8888](./src/color_8888.rs)
+- [Color565](./src/color_565.rs): A color type representing a 5-bit red, 6-bit green, and 5-bit blue component.
+- [Color8888](./src/color_8888.rs): A color type representing a 8-bit red, 8-bit green, 8-bit blue, and 8-bit alpha component.
 
 ## Development
 

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -1,3 +1,5 @@
+use crate::color_8888::Color8888;
+
 /// Represents a 16-bit RGB565 color (5 bits red, 6 bits green, 5 bits blue)
 /// As encountered in many of the BC1 formats.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -14,11 +16,17 @@ impl Color565 {
     }
 
     /// Creates a new [`Color565`] from separate RGB components
+    ///
+    /// # Parameters
+    ///
+    /// - `r`: The red component (0-255)
+    /// - `g`: The green component (0-255)
+    /// - `b`: The blue component (0-255)
     #[inline]
     pub fn from_rgb(r: u8, g: u8, b: u8) -> Self {
-        let r = (r as u16 >> 3) & 0x1F;
-        let g = (g as u16 >> 2) & 0x3F;
-        let b = (b as u16 >> 3) & 0x1F;
+        let r = (r as u16 >> 3) & 0b11111;
+        let g = (g as u16 >> 2) & 0b111111;
+        let b = (b as u16 >> 3) & 0b11111;
 
         Self {
             value: (r << 11) | (g << 5) | b,
@@ -34,27 +42,63 @@ impl Color565 {
     /// Extracts the expanded 8-bit red component
     #[inline]
     pub fn red(&self) -> u8 {
-        let r = (self.value & 0xF800) >> 11;
+        let r = (self.value & 0b11111000_00000000) >> 11;
         ((r << 3) | (r >> 2)) as u8
     }
 
     /// Extracts the expanded 8-bit green component
     #[inline]
     pub fn green(&self) -> u8 {
-        let g = (self.value & 0x07E0) >> 5;
+        let g = (self.value & 0b00000111_11100000) >> 5;
         ((g << 2) | (g >> 4)) as u8
     }
 
     /// Extracts the expanded 8-bit blue component
     #[inline]
     pub fn blue(&self) -> u8 {
-        let b = self.value & 0x001F;
+        let b = self.value & 0b00000000_00011111;
         ((b << 3) | (b >> 2)) as u8
     }
 
-    /// Compares two `Color565` values
+    /// Compares two [`Color565`] values
     #[inline]
     pub fn greater_than(&self, other: &Self) -> bool {
         self.value > other.value
+    }
+
+    /// Converts this [`Color565`] to a [`Color8888`] with full opacity (alpha=255)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let rgb565 = Color565::from_rgb(255, 0, 0);
+    /// let rgba8888 = rgb565.to_color_8888();
+    /// assert_eq!(rgba8888.r, 255);
+    /// assert_eq!(rgba8888.g, 0);
+    /// assert_eq!(rgba8888.b, 0);
+    /// assert_eq!(rgba8888.a, 255);
+    /// ```
+    pub fn to_color_8888(&self) -> Color8888 {
+        Color8888::new(self.red(), self.green(), self.blue(), 255)
+    }
+
+    /// Converts this RGB565 color to a RGBA8888 color with the specified alpha value
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let rgb565 = Color565::from_rgb(255, 0, 0);
+    /// let rgba8888 = rgb565.to_color_8888_with_alpha(128);
+    /// assert_eq!(rgba8888.r, 255);
+    /// assert_eq!(rgba8888.g, 0);
+    /// assert_eq!(rgba8888.b, 0);
+    /// assert_eq!(rgba8888.a, 128);
+    /// ```
+    pub fn to_color_8888_with_alpha(&self, alpha: u8) -> Color8888 {
+        Color8888::new(self.red(), self.green(), self.blue(), alpha)
     }
 }

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -24,13 +24,25 @@ impl Color565 {
     /// - `b`: The blue component (0-255)
     #[inline]
     pub fn from_rgb(r: u8, g: u8, b: u8) -> Self {
-        let r = (r as u16 >> 3) & 0b11111;
-        let g = (g as u16 >> 2) & 0b111111;
-        let b = (b as u16 >> 3) & 0b11111;
-
+        // Implementation matches etcpak's optimized to565 function
+        // Source: https://github.com/wolfpld/etcpak/blob/master/ProcessDxtc.cpp
+        // This approach calculates the entire value in one expression, potentially allowing
+        // better compiler optimizations.
         Self {
-            value: (r << 11) | (g << 5) | b,
+            value: ((r as u16 & 0xF8) << 8) | ((g as u16 & 0xFC) << 3) | (b as u16 >> 3),
         }
+
+        // Original implementation (me):
+        //   Computes to same thing, but just for compiler's sake, using the above.
+        //
+        // let r = (r as u16 >> 3) & 0b11111;
+        // let g = (g as u16 >> 2) & 0b111111;
+        // let b = b as u16 >> 3;
+        //
+        // Self {
+        //     value: (r << 11) | (g << 5) | b,
+        // }
+        //
     }
 
     /// Returns the raw 16-bit value

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -39,6 +39,12 @@ impl Color565 {
         self.value
     }
 
+    // NOTE: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
+    // BC1 as written in the D3D11 functional spec first expands the endpoint values from 5 or 6 bits
+    // to 8 bits by replicating the top bits; all three vendors appear to do this or something equivalent,
+    // and then convert the result from 8-bit UNorm to float exactly.
+    // Thanks ryg!! I know am decoding the colour endpoints right!!
+
     /// Extracts the expanded 8-bit red component
     #[inline]
     pub fn red(&self) -> u8 {

--- a/projects/dxt-lossless-transform-common/src/color_8888.rs
+++ b/projects/dxt-lossless-transform-common/src/color_8888.rs
@@ -1,3 +1,5 @@
+use crate::color_565::Color565;
+
 /// Represents a single RGBA8888 pixel color from a decoded BC1 block
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Color8888 {
@@ -29,5 +31,22 @@ impl Color8888 {
     /// ```
     pub fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
         Self { r, g, b, a }
+    }
+
+    /// Converts this [`Color8888`] to a [`Color565`]
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_8888::Color8888;
+    ///
+    /// let pixel = Color8888::new(255, 0, 0, 255);
+    /// let rgb565 = pixel.to_color_565();
+    /// assert_eq!(rgb565.red(), 255);
+    /// assert_eq!(rgb565.green(), 0);
+    /// assert_eq!(rgb565.blue(), 0);
+    /// ```
+    pub fn to_color_565(&self) -> Color565 {
+        Color565::from_rgb(self.r, self.g, self.b)
     }
 }

--- a/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
+++ b/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
@@ -1,0 +1,69 @@
+use crate::color_8888::Color8888;
+use core::mem::transmute;
+
+/// Represents a decoded 4x4 block of BC pixels
+#[derive(Debug, Clone, Copy)]
+pub struct Decoded4x4Block {
+    /// The 16 pixels in the block (row-major order)
+    pub pixels: [Color8888; 16],
+}
+
+impl Decoded4x4Block {
+    /// Constructs a new decoded block initialised with 16 copies of the provided pixel.
+    /// This function creates a 4x4 block where every pixel is set to the specified value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_8888::Color8888;
+    /// use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+    ///
+    /// let pixel = Color8888::new(255, 0, 0, 255);
+    /// let block = Decoded4x4Block::new(pixel);
+    /// assert!(block.pixels.iter().all(|&p| p == pixel));
+    /// ```
+    pub fn new(pixel: Color8888) -> Self {
+        Self {
+            pixels: [pixel; 16],
+        }
+    }
+
+    /// Gets a pixel at the specified coordinates (0-3, 0-3) without bounds checking
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `x < 4` and `y < 4`.
+    #[inline]
+    pub unsafe fn get_pixel_unchecked(&self, x: usize, y: usize) -> Color8888 {
+        *self.pixels.get_unchecked(y * 4 + x)
+    }
+
+    /// Sets a pixel at the specified coordinates (0-3, 0-3) without bounds checking
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that `x < 4` and `y < 4`.
+    #[inline]
+    pub unsafe fn set_pixel_unchecked(&mut self, x: usize, y: usize, pixel: Color8888) {
+        *self.pixels.get_unchecked_mut(y * 4 + x) = pixel;
+    }
+
+    /// Checks if all pixels in the block have the same color values
+    ///
+    /// # Returns
+    /// `true` if all pixels in the block are identical, `false` otherwise
+    #[inline]
+    pub fn has_identical_pixels(&self) -> bool {
+        // Assert at compile time that Color8888 is the same size as u32
+        const _: () = assert!(size_of::<Color8888>() == size_of::<u32>());
+
+        // Cast first pixel to u32
+        let first_pixel_u32: u32 = unsafe { transmute(self.pixels[0]) };
+
+        // Compare all other pixels to the first one after casting to u32
+        self.pixels.iter().all(|pixel| {
+            let pixel_u32: u32 = unsafe { transmute(*pixel) };
+            pixel_u32 == first_pixel_u32
+        })
+    }
+}

--- a/projects/dxt-lossless-transform-common/src/lib.rs
+++ b/projects/dxt-lossless-transform-common/src/lib.rs
@@ -3,3 +3,7 @@
 
 pub mod color_565;
 pub mod color_8888;
+pub mod decoded_4x4_block;
+
+#[cfg(test)]
+mod tests;

--- a/projects/dxt-lossless-transform-common/src/tests/color_conversion_tests.rs
+++ b/projects/dxt-lossless-transform-common/src/tests/color_conversion_tests.rs
@@ -59,9 +59,9 @@ fn can_convert_color_565_to_8888() {
 fn can_round_trip_8888_to_565() {
     // Test colors that should perfectly round-trip from 8888 to 565 and back.
     let test_colors = [
-        Color8888::new(255, 0, 0, 255),     // Blue
-        Color8888::new(0, 255, 0, 255),     // Red
-        Color8888::new(0, 0, 255, 255),     // Green
+        Color8888::new(255, 0, 0, 255),     // Red
+        Color8888::new(0, 255, 0, 255),     // Green
+        Color8888::new(0, 0, 255, 255),     // Blue
         Color8888::new(0, 0, 0, 255),       // Black
         Color8888::new(255, 255, 255, 255), // White
         Color8888::new(132, 130, 132, 255), // Gray (with small error)

--- a/projects/dxt-lossless-transform-common/src/tests/color_conversion_tests.rs
+++ b/projects/dxt-lossless-transform-common/src/tests/color_conversion_tests.rs
@@ -1,0 +1,118 @@
+use crate::color_565::Color565;
+use crate::color_8888::Color8888;
+
+#[test]
+fn can_convert_color_8888_to_565() {
+    // Test with pure colors
+    let red = Color8888::new(255, 0, 0, 255);
+    let green = Color8888::new(0, 255, 0, 255);
+    let blue = Color8888::new(0, 0, 255, 255);
+
+    let red_565 = red.to_color_565();
+    let green_565 = green.to_color_565();
+    let blue_565 = blue.to_color_565();
+
+    // Test that the converted colors have the correct components
+    // The implementation in Color565 expands values to use all bits
+    assert_eq!(red_565.red(), 255);
+    assert_eq!(red_565.green(), 0);
+    assert_eq!(red_565.blue(), 0);
+
+    assert_eq!(green_565.red(), 0);
+    assert_eq!(green_565.green(), 255);
+    assert_eq!(green_565.blue(), 0);
+
+    assert_eq!(blue_565.red(), 0);
+    assert_eq!(blue_565.green(), 0);
+    assert_eq!(blue_565.blue(), 255);
+}
+
+#[test]
+fn can_convert_color_565_to_8888() {
+    // Test with pure colors
+    let red_565 = Color565::from_rgb(255, 0, 0);
+    let green_565 = Color565::from_rgb(0, 255, 0);
+    let blue_565 = Color565::from_rgb(0, 0, 255);
+
+    let red_8888 = red_565.to_color_8888();
+    let green_8888 = green_565.to_color_8888();
+    let blue_8888 = blue_565.to_color_8888();
+
+    // Test that the converted colors have the correct components
+    assert_eq!(red_8888.r, 255);
+    assert_eq!(red_8888.g, 0);
+    assert_eq!(red_8888.b, 0);
+    assert_eq!(red_8888.a, 255);
+
+    assert_eq!(green_8888.r, 0);
+    assert_eq!(green_8888.g, 255);
+    assert_eq!(green_8888.b, 0);
+    assert_eq!(green_8888.a, 255);
+
+    assert_eq!(blue_8888.r, 0);
+    assert_eq!(blue_8888.g, 0);
+    assert_eq!(blue_8888.b, 255);
+    assert_eq!(blue_8888.a, 255);
+}
+
+#[test]
+fn can_round_trip_8888_to_565() {
+    // Test various colors for round trip conversion
+    let test_colors = [
+        Color8888::new(255, 0, 0, 255),     // Red
+        Color8888::new(0, 255, 0, 255),     // Green
+        Color8888::new(0, 0, 255, 255),     // Blue
+        Color8888::new(255, 255, 0, 255),   // Yellow
+        Color8888::new(255, 0, 255, 255),   // Magenta
+        Color8888::new(0, 255, 255, 255),   // Cyan
+        Color8888::new(128, 128, 128, 255), // Gray
+        Color8888::new(255, 128, 64, 255),  // Orange
+        Color8888::new(64, 128, 255, 255),  // Light Blue
+    ];
+
+    for original in &test_colors {
+        // Convert to RGB565 and back
+        let color_565 = original.to_color_565();
+        let round_trip = color_565.to_color_8888();
+
+        // Due to precision loss in RGB565 format, we can't expect exact equality
+        // Instead, check that the difference is within acceptable bounds (≤ 8 for each channel)
+        let r_diff = if original.r >= round_trip.r {
+            original.r - round_trip.r
+        } else {
+            round_trip.r - original.r
+        };
+        let g_diff = if original.g >= round_trip.g {
+            original.g - round_trip.g
+        } else {
+            round_trip.g - original.g
+        };
+        let b_diff = if original.b >= round_trip.b {
+            original.b - round_trip.b
+        } else {
+            round_trip.b - original.b
+        };
+
+        assert!(
+            r_diff <= 8,
+            "Red channel difference too large: {} vs {}",
+            original.r,
+            round_trip.r
+        );
+        assert!(
+            g_diff <= 4,
+            "Green channel difference too large: {} vs {}",
+            original.g,
+            round_trip.g
+        );
+        assert!(
+            b_diff <= 8,
+            "Blue channel difference too large: {} vs {}",
+            original.b,
+            round_trip.b
+        );
+
+        // Alpha should always be preserved as 255
+        assert_eq!(round_trip.a, 255);
+    }
+}

--- a/projects/dxt-lossless-transform-common/src/tests/color_conversion_tests.rs
+++ b/projects/dxt-lossless-transform-common/src/tests/color_conversion_tests.rs
@@ -57,17 +57,17 @@ fn can_convert_color_565_to_8888() {
 
 #[test]
 fn can_round_trip_8888_to_565() {
-    // Test various colors for round trip conversion
+    // Test colors that should perfectly round-trip from 8888 to 565 and back.
     let test_colors = [
-        Color8888::new(255, 0, 0, 255),     // Red
-        Color8888::new(0, 255, 0, 255),     // Green
-        Color8888::new(0, 0, 255, 255),     // Blue
-        Color8888::new(255, 255, 0, 255),   // Yellow
-        Color8888::new(255, 0, 255, 255),   // Magenta
+        Color8888::new(255, 0, 0, 255),     // Blue
+        Color8888::new(0, 255, 0, 255),     // Red
+        Color8888::new(0, 0, 255, 255),     // Green
+        Color8888::new(0, 0, 0, 255),       // Black
+        Color8888::new(255, 255, 255, 255), // White
+        Color8888::new(132, 130, 132, 255), // Gray (with small error)
         Color8888::new(0, 255, 255, 255),   // Cyan
-        Color8888::new(128, 128, 128, 255), // Gray
-        Color8888::new(255, 128, 64, 255),  // Orange
-        Color8888::new(64, 128, 255, 255),  // Light Blue
+        Color8888::new(255, 0, 255, 255),   // Magenta
+        Color8888::new(255, 255, 0, 255),   // Yellow
     ];
 
     for original in &test_colors {
@@ -75,41 +75,20 @@ fn can_round_trip_8888_to_565() {
         let color_565 = original.to_color_565();
         let round_trip = color_565.to_color_8888();
 
-        // Due to precision loss in RGB565 format, we can't expect exact equality
-        // Instead, check that the difference is within acceptable bounds (≤ 8 for each channel)
-        let r_diff = if original.r >= round_trip.r {
-            original.r - round_trip.r
-        } else {
-            round_trip.r - original.r
-        };
-        let g_diff = if original.g >= round_trip.g {
-            original.g - round_trip.g
-        } else {
-            round_trip.g - original.g
-        };
-        let b_diff = if original.b >= round_trip.b {
-            original.b - round_trip.b
-        } else {
-            round_trip.b - original.b
-        };
-
-        assert!(
-            r_diff <= 8,
-            "Red channel difference too large: {} vs {}",
-            original.r,
-            round_trip.r
+        assert_eq!(
+            original.r, round_trip.r,
+            "Red channel should be preserved exactly for values divisible by 8: {} vs {}",
+            original.r, round_trip.r
         );
-        assert!(
-            g_diff <= 4,
-            "Green channel difference too large: {} vs {}",
-            original.g,
-            round_trip.g
+        assert_eq!(
+            original.g, round_trip.g,
+            "Green channel should be preserved exactly for values divisible by 4: {} vs {}",
+            original.g, round_trip.g
         );
-        assert!(
-            b_diff <= 8,
-            "Blue channel difference too large: {} vs {}",
-            original.b,
-            round_trip.b
+        assert_eq!(
+            original.b, round_trip.b,
+            "Blue channel should be preserved exactly for values divisible by 8: {} vs {}",
+            original.b, round_trip.b
         );
 
         // Alpha should always be preserved as 255

--- a/projects/dxt-lossless-transform-common/src/tests/mod.rs
+++ b/projects/dxt-lossless-transform-common/src/tests/mod.rs
@@ -1,0 +1,1 @@
+mod color_conversion_tests;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified handling of solid and transparent blocks, and enhanced descriptions of color types for improved user understanding.
- **New Features**
  - Introduced new methods to convert between color formats, ensuring more accurate representation.
  - Added a new struct for handling decoded 4x4 blocks of pixels.
- **Tests**
  - Added comprehensive tests for color conversion routines to guarantee consistent and reliable behavior.
- **Refactor**
  - Streamlined the underlying image block decoding process to optimize conversion efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->