### PR TITLE
Added: Ability to normalize blocks (to improve compression ratio).

### DIFF
--- a/projects/dxt-lossless-transform-api/src/api.rs
+++ b/projects/dxt-lossless-transform-api/src/api.rs
@@ -1,4 +1,7 @@
 use core::ptr::copy_nonoverlapping;
+use dxt_lossless_transform_bc1::Bc1TransformDetails;
+use dxt_lossless_transform_bc2::BC2TransformDetails;
+use dxt_lossless_transform_bc3::BC3TransformDetails;
 pub use dxt_lossless_transform_dds::dds::*;
 
 /// Transforms data from the standard format to one that is more suitable for compression.
@@ -23,13 +26,13 @@ pub unsafe fn transform_format(
     match format {
         DdsFormat::Unknown => { /* no-op */ }
         DdsFormat::BC1 => {
-            dxt_lossless_transform_bc1::split_blocks::split_blocks(input_ptr, output_ptr, len)
+            dxt_lossless_transform_bc1::transform_bc1(input_ptr, output_ptr, len);
         }
         DdsFormat::BC2 => {
-            dxt_lossless_transform_bc2::split_blocks::split_blocks(input_ptr, output_ptr, len)
+            dxt_lossless_transform_bc2::transform_bc2(input_ptr, output_ptr, len);
         }
         DdsFormat::BC3 => {
-            dxt_lossless_transform_bc3::split_blocks::split_blocks(input_ptr, output_ptr, len)
+            dxt_lossless_transform_bc3::transform_bc3(input_ptr, output_ptr, len);
         }
         DdsFormat::BC7 => {
             copy_nonoverlapping(input_ptr, output_ptr, len);
@@ -59,13 +62,28 @@ pub unsafe fn untransform_format(
     match format {
         DdsFormat::Unknown => { /* no-op */ }
         DdsFormat::BC1 => {
-            dxt_lossless_transform_bc1::split_blocks::unsplit_blocks(input_ptr, output_ptr, len)
+            dxt_lossless_transform_bc1::untransform_bc1(
+                input_ptr,
+                output_ptr,
+                len,
+                &Bc1TransformDetails {},
+            );
         }
         DdsFormat::BC2 => {
-            dxt_lossless_transform_bc2::split_blocks::unsplit_blocks(input_ptr, output_ptr, len)
+            dxt_lossless_transform_bc2::untransform_bc2(
+                input_ptr,
+                output_ptr,
+                len,
+                BC2TransformDetails {},
+            );
         }
         DdsFormat::BC3 => {
-            dxt_lossless_transform_bc3::split_blocks::unsplit_blocks(input_ptr, output_ptr, len)
+            dxt_lossless_transform_bc3::untransform_bc3(
+                input_ptr,
+                output_ptr,
+                len,
+                BC3TransformDetails {},
+            );
         }
         DdsFormat::BC7 => todo!(),
     }

--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -19,12 +19,12 @@ no-runtime-cpu-detection = []
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
 likely_stable = "0.1.3"
+safe-allocator-api = "0.3.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 criterion = "0.5.1"
 rstest = "0.25.0"
-safe-allocator-api = "0.3.0"
 
 [target.'cfg(unix)'.dev-dependencies]
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }

--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -44,3 +44,8 @@ harness = false
 name = "block_decode"
 path = "benches/block_decode/main.rs"
 harness = false
+
+[[bench]]
+name = "normalize_blocks"
+path = "benches/normalize_blocks/main.rs"
+harness = false

--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -18,6 +18,7 @@ no-runtime-cpu-detection = []
 
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
+likely_stable = "0.1.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -65,7 +65,7 @@ to represent a colour using only 1 out of the 2 colour components, i.e. only `C0
 
 When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
 colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`.
-This results in a nice repetition of `0x00` across 6 bytes. In somew cases, it's beneficial to replicate
+This results in a nice repetition of `0x00` across 6 bytes. In some cases, it's beneficial to replicate
 the colour across `C0` and `C1`. We brute force to find the optimal choice.
 
 For fully transparent blocks, we instead set all the bits to `1`, so the block becomes filled with `0xFF`. 

--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -65,7 +65,8 @@ to represent a colour using only 1 out of the 2 colour components, i.e. only `C0
 
 When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
 colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`.
-This results in a nice repetition of `0x00` across 6 bytes.
+This results in a nice repetition of `0x00` across 6 bytes. In somew cases, it's beneficial to replicate
+the colour across `C0` and `C1`. We brute force to find the optimal choice.
 
 For fully transparent blocks, we instead set all the bits to `1`, so the block becomes filled with `0xFF`. 
 

--- a/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
@@ -53,7 +53,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Benchmark the normalize_blocks function
     group.bench_function("normalize_blocks", |b| {
         b.iter(|| unsafe {
-            normalize_blocks(input_ptr, output_ptr, file_size);
+            normalize_blocks(input_ptr, output_ptr, file_size, false);
         })
     });
 

--- a/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
@@ -1,0 +1,77 @@
+use core::{alloc::Layout, ptr::copy_nonoverlapping};
+use criterion::{criterion_group, criterion_main, Criterion};
+use dxt_lossless_transform_bc1::normalize_blocks::normalize_blocks;
+use safe_allocator_api::RawAlloc;
+use std::fs;
+
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+// Path to the BC1 file to benchmark with
+const TEST_FILE_PATH: &str = "/home/sewer/Downloads/texture-stuff/bc1-raw/202x-architecture-10.01/whiterun/wrwoodlattice01.dds";
+
+pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
+    let layout = Layout::from_size_align(num_bytes, 64).unwrap();
+    RawAlloc::new(layout).unwrap()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BC1 Normalize Blocks");
+
+    // Try to load the test file
+    let file_data = match fs::read(TEST_FILE_PATH) {
+        Ok(data) => {
+            println!("Successfully loaded test file: {}", TEST_FILE_PATH);
+            data
+        }
+        Err(_) => {
+            println!(
+                "Warning: Could not load test file '{}'. Exiting.",
+                TEST_FILE_PATH
+            );
+            return;
+        }
+    };
+
+    // Ensure we have a file size that's a multiple of 8 (BC1 block size)
+    let file_size = file_data.len();
+
+    // Allocate memory for input and output
+    let mut input = allocate_align_64(file_size);
+    let mut output = allocate_align_64(file_size);
+
+    // Copy file data to input buffer
+    unsafe {
+        copy_nonoverlapping(file_data.as_ptr(), input.as_mut_ptr(), file_size);
+    }
+
+    let input_ptr = input.as_ptr();
+    let output_ptr = output.as_mut_ptr();
+
+    group.throughput(criterion::Throughput::Bytes(file_size as u64));
+
+    // Benchmark the normalize_blocks function
+    group.bench_function("normalize_blocks", |b| {
+        b.iter(|| unsafe {
+            normalize_blocks(input_ptr, output_ptr, file_size);
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -47,7 +47,7 @@ pub unsafe fn transform_bc1(
     debug_assert!(len % 8 == 0);
 
     let mut normalized = RawAlloc::new(Layout::from_size_align_unchecked(len, 64)).unwrap();
-    normalize_blocks::normalize_blocks(input_ptr, normalized.as_mut_ptr(), len);
+    normalize_blocks::normalize_blocks(input_ptr, normalized.as_mut_ptr(), len, false);
     split_blocks(normalized.as_ptr(), output_ptr, len);
     Bc1TransformDetails {}
 }

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use split_blocks::{split::split_blocks, unsplit_blocks};
+pub mod normalize_blocks;
 pub mod split_blocks;
 pub mod util;
 

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::alloc::Layout;
+
+use safe_allocator_api::RawAlloc;
 use split_blocks::{split::split_blocks, unsplit_blocks};
 pub mod normalize_blocks;
 pub mod split_blocks;
@@ -42,7 +45,10 @@ pub unsafe fn transform_bc1(
     len: usize,
 ) -> Bc1TransformDetails {
     debug_assert!(len % 8 == 0);
-    split_blocks(input_ptr, output_ptr, len);
+
+    let mut normalized = RawAlloc::new(Layout::from_size_align_unchecked(len, 64)).unwrap();
+    normalize_blocks::normalize_blocks(input_ptr, normalized.as_mut_ptr(), len);
+    split_blocks(normalized.as_ptr(), output_ptr, len);
     Bc1TransformDetails {}
 }
 

--- a/projects/dxt-lossless-transform-bc1/src/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/normalize_blocks/mod.rs
@@ -324,11 +324,7 @@ mod tests {
     #[test]
     fn can_normalize_multiple_blocks() {
         // Create data for two blocks: one solid color and one transparent
-
-        // Block 1: Solid red
         let red565 = 0xF800u16.to_le_bytes();
-
-        // Block 2: Transparent
 
         // Source data for both blocks
         let mut source = [0u8; 16]; // Two blocks (8 bytes each)

--- a/projects/dxt-lossless-transform-bc1/src/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/normalize_blocks/mod.rs
@@ -80,7 +80,7 @@
 //! 4. Write the normalized block to the output
 
 use crate::util::decode_bc1_block;
-use core::ptr::copy_nonoverlapping;
+use core::ptr::{copy_nonoverlapping, write_bytes};
 use likely_stable::unlikely;
 
 /// Reads an input of blocks from `input_ptr` and writes the normalized blocks to `output_ptr`.
@@ -118,9 +118,7 @@ pub unsafe fn normalize_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: u
             // Check if the block is fully transparent
             if unlikely(pixel.a == 0) {
                 // Case 2: Fully transparent block - fill with 0xFF
-                for y in 0..8 {
-                    *dst_block_ptr.add(y) = 0xFF;
-                }
+                write_bytes(dst_block_ptr, 0xFF, 8);
             } else {
                 // Case 1: Solid color block
                 // Convert the color to RGB565

--- a/projects/dxt-lossless-transform-bc1/src/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/normalize_blocks/mod.rs
@@ -1,0 +1,382 @@
+//! # Block Normalization Process
+//!
+//! This module contains the code used to normalize BC1 blocks to improve compression ratio
+//! by making solid color blocks and transparent blocks have consistent representations.
+//!
+//! ## BC1 Block Format
+//!
+//! First, let's recall the BC1 block format:
+//!
+//! ```text
+//! Address: 0        2        4       8
+//!          +--------+--------+--------+
+//! Data:    | Color0 | Color1 | Indices|
+//!          +--------+--------+--------+
+//! ```
+//!
+//! Where:
+//! - `Color0` and `Color1` are 16-bit RGB565 color values (2 bytes each)
+//! - `Indices` are 4 bytes containing sixteen 2-bit indices (one for each pixel in the 4x4 block)
+//!
+//! ## Normalization Rules
+//!
+//! The normalization process applies the following rules to improve compression:
+//!
+//! ### 1. Solid Color Blocks
+//!
+//! When an entire block represents a single solid color with a clean conversion between RGBA8888
+//! and RGB565, we standardize the representation:
+//!
+//! ```text
+//! +--------+--------+--------+
+//! | Color  | 0x0000 |  0x00  |
+//! +--------+--------+--------+
+//! ```
+//!
+//! We place the block's color in `Color0`, set `Color1` to zero, and set all indices to zero
+//! (represented by all-zero bytes in the indices section).
+//!
+//! The implementation checks for this case by:
+//! 1. Decoding the block to get all 16 pixels
+//! 2. Checking that all pixels have the same color
+//! 3. Verifying the color can be cleanly round-tripped through RGB565 encoding
+//! 4. Constructing a new normalized block with the pattern above
+//!
+//! ### 2. Fully Transparent Blocks
+//!
+//! For blocks that are completely transparent (common in textures with alpha), we standardize
+//! the representation to all 1's:
+//!
+//! ```text
+//! +--------+--------+--------+
+//! | 0xFFFF | 0xFFFF | 0xFFFF |
+//! +--------+--------+--------+
+//! ```
+//!
+//! The implementation detects transparent blocks by:
+//! 1. Decoding all 16 pixels in the block
+//! 2. Checking if all pixels have alpha=0 (check if first pixel is transparent, after checking if all are equal)
+//! 3. Setting the entire block content to 0xFF bytes
+//!
+//! ### 3. Mixed Transparency Blocks
+//!
+//! In BC1, when `Color0 <= Color1`, the block is in "punch-through alpha" mode, where index `11`
+//! represents a transparent pixel. Blocks containing both opaque and transparent pixels
+//! (mixed alpha) use this mode.
+//!
+//! For these blocks, we can't apply significant normalization without changing the visual
+//! appearance, so we preserve them unchanged.
+//!
+//! ## Implementation Details
+//!
+//! The normalization process uses the BC1 decoder to analyze the block content, then rebuilds
+//! blocks according to the rules above.
+//!
+//! When normalizing blocks, we:
+//!
+//! 1. Look at the RGB565 color values to determine if we're in alpha mode (`Color0 <= Color1`)
+//! 2. Decode the block to get the 16 pixels with their colors
+//! 3. Apply one of the three normalization cases based on the block properties
+//! 4. Write the normalized block to the output
+
+use crate::util::decode_bc1_block;
+use core::ptr::copy_nonoverlapping;
+use likely_stable::unlikely;
+
+/// Reads an input of blocks from `input_ptr` and writes the normalized blocks to `output_ptr`.
+///
+/// # Parameters
+///
+/// - `input_ptr`: A pointer to the input data (input BC1 blocks)
+/// - `output_ptr`: A pointer to the output data (output BC1 blocks)
+/// - `len`: The length of the input data in bytes
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 8
+#[inline]
+pub unsafe fn normalize_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
+
+    // Calculate pointers to current block
+    let mut src_block_ptr = input_ptr;
+    let mut dst_block_ptr = output_ptr;
+    let src_end_ptr = input_ptr.add(len);
+
+    // Process each block
+    while src_block_ptr < src_end_ptr {
+        // Decode the block to analyze its content
+        let decoded_block = decode_bc1_block(src_block_ptr);
+
+        // Check if all pixels in the block are identical
+        if decoded_block.has_identical_pixels() {
+            // Get the first pixel (they're all the same)
+            let pixel = decoded_block.pixels[0];
+
+            // Check if the block is fully transparent
+            if unlikely(pixel.a == 0) {
+                // Case 2: Fully transparent block - fill with 0xFF
+                for y in 0..8 {
+                    *dst_block_ptr.add(y) = 0xFF;
+                }
+            } else {
+                // Case 1: Solid color block
+                // Convert the color to RGB565
+                let color565 = pixel.to_color_565();
+
+                // Check if color can be round-tripped cleanly through RGB565
+                let color8888 = color565.to_color_8888();
+
+                if unlikely(color8888 == pixel) {
+                    // Can be normalized - write the standard pattern:
+                    // Color0 = the color, Color1 = 0, indices = 0
+                    let color_bytes = color565.raw_value().to_le_bytes();
+
+                    // Write Color0 (the solid color)
+                    *dst_block_ptr = color_bytes[0];
+                    *dst_block_ptr.add(1) = color_bytes[1];
+
+                    // Write Color1 = 0
+                    *dst_block_ptr.add(2) = 0;
+                    *dst_block_ptr.add(3) = 0;
+
+                    // Write indices = 0
+                    *dst_block_ptr.add(4) = 0;
+                    *dst_block_ptr.add(5) = 0;
+                    *dst_block_ptr.add(6) = 0;
+                    *dst_block_ptr.add(7) = 0;
+                } else {
+                    // Case 3: Cannot normalize, copy source block as-is
+                    copy_nonoverlapping(src_block_ptr, dst_block_ptr, 8);
+                }
+            }
+        } else {
+            // Case 3: Mixed colors - copy source block as-is
+            copy_nonoverlapping(src_block_ptr, dst_block_ptr, 8);
+        }
+
+        // Move to the next block
+        src_block_ptr = src_block_ptr.add(8);
+        dst_block_ptr = dst_block_ptr.add(8);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test normalizing a solid color block
+    #[test]
+    fn can_normalize_solid_color_block() {
+        // Red in RGB565: (31, 0, 0) -> 0xF800
+        // This cleanly round trips into (255, 0, 0) and back to (31, 0, 0).
+        let red565 = 0xF800u16.to_le_bytes(); // Little endian: [0x00, 0xF8]
+
+        // This creates a BC1 block with the following characteristics:
+        // - Color0 = Red (RGB565)
+        // - Color1 = Another color (doesn't matter as long as Color0 > Color1)
+        // - Indices = All pointing to Color0 (all 0b00)
+        let mut block = [0u8; 8];
+        block[0] = red565[0]; // Color0 (low byte)
+        block[1] = red565[1]; // Color0 (high byte)
+        block[2] = 0x01; // Color1 (low byte) - smaller than Color0 to avoid punch-through alpha mode
+        block[3] = 0x01; // Color1 (high byte)
+
+        // All indices = 0, pointing to Color0
+        block[4] = 0x00;
+        block[5] = 0x00;
+        block[6] = 0x00;
+        block[7] = 0x00;
+
+        // Expected normalized block:
+        // - Color0 = the color (0xF800)
+        // - Color1 = 0
+        // - All indices = 0
+        let mut expected = [0u8; 8];
+        expected[0] = red565[0];
+        expected[1] = red565[1];
+        // All other bytes remain 0
+
+        // Output buffer for normalized block
+        let mut output = [0u8; 8];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(block.as_ptr(), output.as_mut_ptr(), 8);
+        }
+
+        // Check that the output matches expected
+        assert_eq!(output, expected, "Solid color block normalization failed");
+    }
+
+    /// Test normalizing a fully transparent block
+    #[test]
+    fn can_normalize_transparent_block() {
+        // Create a BC1 block that decodes to all transparent pixels
+        // In BC1, when Color0 <= Color1, index 3 refers to transparent
+
+        // So we'll create a block with:
+        // - Color0 = some value
+        // - Color1 = larger value (making Color0 <= Color1)
+        // - All indices = 3 (transparent)
+        let mut block = [0u8; 8];
+        block[0] = 0x00; // Color0 (low byte)
+        block[1] = 0x80; // Color0 (high byte) = 0x8000
+        block[2] = 0x00; // Color1 (low byte)
+        block[3] = 0xF8; // Color1 (high byte) = 0xF800, greater than Color0
+
+        // Set all indices to 3 (0b11)
+        block[4] = 0xFF; // 0b11111111
+        block[5] = 0xFF; // 0b11111111
+        block[6] = 0xFF; // 0b11111111
+        block[7] = 0xFF; // 0b11111111
+
+        // Expected normalized block: all FF
+        let expected = [0xFF; 8];
+
+        // Output buffer for normalized block
+        let mut output = [0u8; 8];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(block.as_ptr(), output.as_mut_ptr(), 8);
+        }
+
+        // Check that the output matches expected
+        assert_eq!(output, expected, "Transparent block normalization failed");
+    }
+
+    /// Test that a mixed color block is preserved as-is
+    #[test]
+    fn can_preserve_mixed_color_block() {
+        // Create a mixed color block with red and blue
+        // - Color0 = Red
+        // - Color1 = Blue
+        // - Indices = mix of 0 and 1
+
+        let red565 = 0xF800u16.to_le_bytes(); // Red: [0x00, 0xF8]
+        let blue565 = 0x001Fu16.to_le_bytes(); // Blue: [0x1F, 0x00]
+
+        let mut block = [0u8; 8];
+        block[0] = red565[0]; // Color0 (low byte)
+        block[1] = red565[1]; // Color0 (high byte)
+        block[2] = blue565[0]; // Color1 (low byte)
+        block[3] = blue565[1]; // Color1 (high byte)
+
+        // Mix of indices pointing to both colors
+        block[4] = 0b00010001; // 00010001 (alternating indices)
+        block[5] = 0b00010001;
+        block[6] = 0b00010001;
+        block[7] = 0b00010001;
+
+        // Output buffer for normalized block
+        let mut output = [0u8; 8];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(block.as_ptr(), output.as_mut_ptr(), 8);
+        }
+
+        // Check that the output is identical to the source (preserved as-is)
+        assert_eq!(output, block, "Mixed color block should be preserved as-is");
+    }
+
+    /// Test that a solid color block that can't be cleanly round-tripped is preserved as-is
+    #[test]
+    fn can_preserve_non_roundtrippable_color_block() {
+        // Create a mix of 2 colours that can't be cleanly round-tripped,
+        // this cannot be simplified down
+        let red565 = 0xF800u16.to_le_bytes(); // (31, 0, 0) -> 0xF800
+        let blue565 = 0x001Fu16.to_le_bytes(); // (0, 0, 31) -> 0x001F
+
+        // Create the source block that would decode to a solid non-roundtrippable color
+        let mut source = [0u8; 8];
+        source[0] = red565[0]; // Color0 (low byte)
+        source[1] = red565[1]; // Color0 (high byte)
+        source[2] = blue565[0]; // Color1 (low byte)
+        source[3] = blue565[1]; // Color1 (high byte)
+                                // All indices pointing at 2/3 color0, 1/3 color1
+        source[4] = 0b10101010; // 0b10101010
+        source[5] = 0b10101010;
+        source[6] = 0b10101010;
+        source[7] = 0b10101010;
+
+        // Output buffer for normalized block
+        // Decoded 8888: (170, 0, 85, 255)
+        // Round Tripped 8888: (173, 0, 82)
+        let mut output = [0u8; 8];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(source.as_ptr(), output.as_mut_ptr(), 8);
+        }
+
+        // Check that the output is identical to the source (preserved as-is)
+        assert_eq!(
+            output, source,
+            "Non-roundtrippable color block should be preserved as-is"
+        );
+    }
+
+    /// Test normalizing multiple blocks in one call
+    #[test]
+    fn can_normalize_multiple_blocks() {
+        // Create data for two blocks: one solid color and one transparent
+
+        // Block 1: Solid red
+        let red565 = 0xF800u16.to_le_bytes();
+
+        // Block 2: Transparent
+
+        // Source data for both blocks
+        let mut source = [0u8; 16]; // Two blocks (8 bytes each)
+
+        // First block: solid red
+        source[0] = red565[0]; // Color0 (low byte)
+        source[1] = red565[1]; // Color0 (high byte)
+        source[2] = 0x00; // Color1 (low byte)
+        source[3] = 0x00; // Color1 (high byte)
+                          // All indices pointing to Color0
+        source[4] = 0x00;
+        source[5] = 0x00;
+        source[6] = 0x00;
+        source[7] = 0x00;
+
+        // Second block: transparent
+        source[8] = 0x00; // Color0 (low byte)
+        source[9] = 0x80; // Color0 (high byte) = 0x8000
+        source[10] = 0x00; // Color1 (low byte)
+        source[11] = 0xF8; // Color1 (high byte) = 0xF800, greater than Color0
+                           // All indices set to 3 (0b11)
+        source[12] = 0xFF;
+        source[13] = 0xFF;
+        source[14] = 0xFF;
+        source[15] = 0xFF;
+
+        // Expected output
+        let mut expected = [0u8; 16];
+
+        // First block: normalized solid color
+        expected[0] = red565[0];
+        expected[1] = red565[1];
+        // Rest of first block is zeros
+
+        // Second block: normalized transparent (all FF)
+        (8..16).for_each(|x| {
+            expected[x] = 0xFF;
+        });
+
+        // Output buffer
+        let mut output = [0u8; 16];
+
+        // Normalize both blocks
+        unsafe {
+            normalize_blocks(source.as_ptr(), output.as_mut_ptr(), 16);
+        }
+
+        // Check that the output matches expected
+        assert_eq!(output, expected, "Multiple block normalization failed");
+    }
+}

--- a/projects/dxt-lossless-transform-cli/Cargo.toml
+++ b/projects/dxt-lossless-transform-cli/Cargo.toml
@@ -8,8 +8,13 @@ edition = "2021"
 # Currently a placeholder
 debug-bc7 = []
 
+# Debugging and Research Tools/Utilities for BC1
+debug-bc1 = ["dxt-lossless-transform-bc1", "safe-allocator-api"]
+
 [dependencies]
 argh = "0.1.13"
 rayon = "1.10.0"
 lightweight-mmap = "0.6.0"
 dxt-lossless-transform-api = { path = "../dxt-lossless-transform-api" }
+dxt-lossless-transform-bc1 = { optional = true, path = "../dxt-lossless-transform-bc1" }
+safe-allocator-api = { optional = true, version = "0.3.0" }

--- a/projects/dxt-lossless-transform-cli/Cargo.toml
+++ b/projects/dxt-lossless-transform-cli/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 debug-bc7 = []
 
 # Debugging and Research Tools/Utilities for BC1
+# This includes extra test code, extra benchmarks and extra utils. 
 debug-bc1 = ["dxt-lossless-transform-bc1", "safe-allocator-api"]
 
 [dependencies]

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
@@ -100,7 +100,12 @@ fn validate_normalize_single(path: &Path) -> Result<bool, TransformError> {
 
     // Process through normalize_blocks
     unsafe {
-        normalize_blocks(content.as_ptr(), normalized.as_mut_ptr(), content.len());
+        normalize_blocks(
+            content.as_ptr(),
+            normalized.as_mut_ptr(),
+            content.len(),
+            false,
+        );
     }
 
     // Validate each block

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
@@ -1,0 +1,136 @@
+use crate::{error::TransformError, util};
+use argh::FromArgs;
+use core::alloc::Layout;
+use dxt_lossless_transform_bc1::normalize_blocks::normalize_blocks;
+use dxt_lossless_transform_bc1::util::decode_bc1_block;
+use rayon::prelude::*;
+use safe_allocator_api::RawAlloc;
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+/// Debug commands for analyzing BC1 files
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "debug-bc1")]
+pub struct DebugCmd {
+    #[argh(subcommand)]
+    pub command: DebugCommands,
+}
+
+/// Commands for debugging BC1 files
+#[derive(FromArgs, Debug)]
+#[argh(subcommand)]
+pub enum DebugCommands {
+    ValidateNormalize(ValidateCommand),
+}
+
+/// Validate BC1 blocks by processing them through normalize_blocks and checking if pixels match
+#[derive(FromArgs, Debug)]
+#[argh(subcommand, name = "validate-normalize")]
+pub struct ValidateCommand {
+    /// input directory path containing BC1 files to validate
+    #[argh(positional)]
+    pub directory: PathBuf,
+}
+
+pub fn handle_debug_command(cmd: DebugCmd) -> Result<(), TransformError> {
+    match cmd.command {
+        DebugCommands::ValidateNormalize(cmd) => validate_normalize(cmd),
+    }
+}
+
+fn validate_normalize(cmd: ValidateCommand) -> Result<(), TransformError> {
+    // Collect all files recursively
+    let mut entries = Vec::new();
+    util::find_all_files(&cmd.directory, &mut entries)?;
+    println!("Found {} files to validate", entries.len());
+
+    // Process files in parallel
+    let results: Vec<_> = entries
+        .par_iter()
+        .map(|entry| {
+            let path = entry.path();
+            match validate_normalize_single(&path) {
+                Ok(result) => (path, result, None),
+                Err(e) => (path, false, Some(e)),
+            }
+        })
+        .collect();
+
+    // Print summary
+    let mut success_count = 0;
+    let mut failure_count = 0;
+
+    for (path, success, error) in results {
+        if success {
+            println!("✅ Validated: {}", path.display());
+            success_count += 1;
+        } else {
+            if let Some(err) = error {
+                println!("❌ Failed: {} - Error: {}", path.display(), err);
+            } else {
+                println!("❌ Failed: {} - Pixels don't match", path.display());
+            }
+            failure_count += 1;
+        }
+    }
+
+    println!(
+        "Validation complete: {} succeeded, {} failed",
+        success_count, failure_count
+    );
+
+    Ok(())
+}
+
+fn validate_normalize_single(path: &Path) -> Result<bool, TransformError> {
+    // Read file contents
+    let content = fs::read(path).map_err(TransformError::IoError)?;
+
+    // Skip if file is too small or not a multiple of 8 bytes (BC1 block size)
+    if content.len() < 8 || content.len() % 8 != 0 {
+        return Err(TransformError::IgnoredByFilter);
+    }
+
+    // Allocate buffer for normalized blocks
+    let mut normalized =
+        unsafe { RawAlloc::new(Layout::from_size_align_unchecked(content.len(), 64)) }.unwrap();
+
+    // Process through normalize_blocks
+    unsafe {
+        normalize_blocks(content.as_ptr(), normalized.as_mut_ptr(), content.len());
+    }
+
+    // Validate each block
+    let block_count = content.len() / 8;
+    for block_index in 0..block_count {
+        let src_offset = block_index * 8;
+
+        // Decode original block
+        let original_block = unsafe { decode_bc1_block(content.as_ptr().add(src_offset)) };
+
+        // Decode normalized block
+        let normalized_block = unsafe { decode_bc1_block(normalized.as_ptr().add(src_offset)) };
+
+        // Compare all pixels
+        for y in 0..4 {
+            for x in 0..4 {
+                let original_pixel = unsafe { original_block.get_pixel_unchecked(x, y) };
+                let normalized_pixel = unsafe { normalized_block.get_pixel_unchecked(x, y) };
+
+                if original_pixel != normalized_pixel {
+                    println!(
+                        "Pixel mismatch in file {}, block {}, coord ({},{}): Original: {:?}, Normalized: {:?}",
+                        path.display(), block_index, x, y, original_pixel, normalized_pixel
+                    );
+
+                    // Return early on first mismatch
+                    return Ok(false);
+                }
+            }
+        }
+    }
+
+    Ok(true)
+}

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
@@ -25,7 +25,8 @@ pub enum DebugCommands {
     ValidateNormalize(ValidateCommand),
 }
 
-/// Validate BC1 blocks by processing them through normalize_blocks and checking if pixels match
+/// Validate BC1 block normalization code by processing them through normalize_blocks and
+/// checking if pixels match
 #[derive(FromArgs, Debug)]
 #[argh(subcommand, name = "validate-normalize")]
 pub struct ValidateCommand {

--- a/projects/dxt-lossless-transform-cli/src/main.rs
+++ b/projects/dxt-lossless-transform-cli/src/main.rs
@@ -1,6 +1,8 @@
 #![allow(unexpected_cfgs)]
 #![cfg(not(tarpaulin_include))]
 
+#[cfg(feature = "debug-bc1")]
+mod debug_bc1;
 #[cfg(feature = "debug-bc7")]
 mod debug_bc7;
 
@@ -61,6 +63,8 @@ enum Commands {
     Detransform(DetransformCmd),
     #[cfg(feature = "debug-bc7")]
     DebugBc7(debug_bc7::DebugCmd),
+    #[cfg(feature = "debug-bc1")]
+    DebugBc1(debug_bc1::DebugCmd),
 }
 
 #[derive(FromArgs, Debug)]
@@ -159,6 +163,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         #[cfg(feature = "debug-bc7")]
         Commands::DebugBc7(cmd) => {
             debug_bc7::handle_debug_command(cmd)?;
+        }
+        #[cfg(feature = "debug-bc1")]
+        Commands::DebugBc1(cmd) => {
+            debug_bc1::handle_debug_command(cmd)?;
         }
     }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new block normalization capability that optimizes BC1 texture compression by intelligently handling solid color, fully transparent, and mixed pixel blocks.
  - Added a debugging feature for BC1 files, allowing users to validate and normalize blocks via a command-line interface.
  - Introduced a new benchmark for the normalization process to assess performance.
  - Added a new optional feature for debugging and research tools related to BC1.
  - Enhanced transformation and untransforming processes for BC1, BC2, and BC3 formats with specialized functions.

- **Bug Fixes**
  - Implemented safety checks in the normalization process to ensure pointer validity and data integrity.

- **Documentation**
  - Updated README to clarify the handling of solid blocks in the BC1 format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->