### PR TITLE
Added: Decorrelation via YCoCg for Color565

### DIFF
--- a/projects/dxt-lossless-transform-common/Cargo.toml
+++ b/projects/dxt-lossless-transform-common/Cargo.toml
@@ -18,3 +18,12 @@ no-runtime-cpu-detection = []
 
 [dev-dependencies]
 rstest = "0.25.0"
+criterion = "0.5.1"
+safe-allocator-api = "0.3.0"
+
+[target.'cfg(unix)'.dev-dependencies]
+pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
+
+[[bench]]
+name = "color_decorrelation"
+harness = false

--- a/projects/dxt-lossless-transform-common/benches/color_decorrelation/main.rs
+++ b/projects/dxt-lossless-transform-common/benches/color_decorrelation/main.rs
@@ -49,7 +49,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             // Benchmark: run on the fresh copy
             |(_, clone_colors)| {
                 for color in clone_colors.iter_mut() {
-                    color.decorrelate_ycocg_r();
+                    color.decorrelate_ycocg_r_var2();
                 }
             },
             criterion::BatchSize::SmallInput,
@@ -63,7 +63,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     for (x, color) in decorrelated_colors.iter_mut().enumerate() {
         *color = input_colors[x];
-        color.decorrelate_ycocg_r();
+        color.decorrelate_ycocg_r_var2();
     }
 
     group.bench_function("recorrelate_ycocg_r", |b| {
@@ -80,7 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             // Benchmark: run on the fresh copy
             |(_, clone_colors)| {
                 for color in clone_colors.iter_mut() {
-                    color.recorrelate_ycocg_r();
+                    color.recorrelate_ycocg_r_var2();
                 }
             },
             criterion::BatchSize::SmallInput,

--- a/projects/dxt-lossless-transform-common/benches/color_decorrelation/main.rs
+++ b/projects/dxt-lossless-transform-common/benches/color_decorrelation/main.rs
@@ -1,0 +1,107 @@
+use core::{alloc::Layout, slice};
+use criterion::{criterion_group, criterion_main, Criterion};
+use dxt_lossless_transform_common::color_565::Color565;
+use safe_allocator_api::RawAlloc;
+
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
+    let layout = Layout::from_size_align(num_bytes, 64).unwrap();
+    RawAlloc::new(layout).unwrap()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Color565 YCoCg-R Conversion");
+
+    // Set up test data - array of Color565 values to convert
+    const BYTES_PER_ITEM: usize = size_of::<Color565>();
+    const NUM_ITEMS: usize = 2_000_000; // 2 million colors, equivalent to 8MiB DXT1 texture
+                                        // 2M * 2 bytes = 4MiB == 50% of a 8MiB DXT1 texture
+
+    // Allocate memory for input data
+    let mut input = allocate_align_64(NUM_ITEMS * BYTES_PER_ITEM);
+    let input_colors =
+        unsafe { slice::from_raw_parts_mut(input.as_mut_ptr() as *mut Color565, NUM_ITEMS) };
+
+    // Fill with test data - sequential RGB565 values
+    for (x, color) in input_colors.iter_mut().enumerate() {
+        let r = ((x) % 32) as u8; // 5 bits (0-31)
+        let g = ((x >> 8) % 32) as u8; // 5 bits (0-31)
+        let b = ((x >> 16) % 32) as u8; // 5 bits (0-31)
+        *color = Color565::from_rgb(r, g, b);
+    }
+
+    group.throughput(criterion::Throughput::Bytes(
+        (NUM_ITEMS * BYTES_PER_ITEM) as u64,
+    ));
+    group.bench_function("decorrelate_ycocg_r", |b| {
+        b.iter_batched(
+            // Setup: create a fresh copy for each iteration
+            || {
+                let mut clone = allocate_align_64(NUM_ITEMS * BYTES_PER_ITEM);
+                let clone_colors = unsafe {
+                    slice::from_raw_parts_mut(clone.as_mut_ptr() as *mut Color565, NUM_ITEMS)
+                };
+                clone_colors.copy_from_slice(input_colors);
+                (clone, clone_colors)
+            },
+            // Benchmark: run on the fresh copy
+            |(_, clone_colors)| {
+                for color in clone_colors.iter_mut() {
+                    color.decorrelate_ycocg_r();
+                }
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    // Create a second test array for the recorrelation benchmark
+    let mut decorrelated = allocate_align_64(NUM_ITEMS * BYTES_PER_ITEM);
+    let decorrelated_colors =
+        unsafe { slice::from_raw_parts_mut(decorrelated.as_mut_ptr() as *mut Color565, NUM_ITEMS) };
+
+    for (x, color) in decorrelated_colors.iter_mut().enumerate() {
+        *color = input_colors[x];
+        color.decorrelate_ycocg_r();
+    }
+
+    group.bench_function("recorrelate_ycocg_r", |b| {
+        b.iter_batched(
+            // Setup: create a fresh copy for each iteration
+            || {
+                let mut clone = allocate_align_64(NUM_ITEMS * BYTES_PER_ITEM);
+                let clone_colors = unsafe {
+                    slice::from_raw_parts_mut(clone.as_mut_ptr() as *mut Color565, NUM_ITEMS)
+                };
+                clone_colors.copy_from_slice(decorrelated_colors);
+                (clone, clone_colors)
+            },
+            // Benchmark: run on the fresh copy
+            |(_, clone_colors)| {
+                for color in clone_colors.iter_mut() {
+                    color.recorrelate_ycocg_r();
+                }
+            },
+            criterion::BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -119,4 +119,168 @@ impl Color565 {
     pub fn to_color_8888_with_alpha(&self, alpha: u8) -> Color8888 {
         Color8888::new(self.red(), self.green(), self.blue(), alpha)
     }
+
+    /// Transforms RGB color to YCoCg-R (reversible YCoCg) color space.
+    ///
+    /// YCoCg-R is a lifting-based variation of YCoCg that offers perfect reversibility.
+    /// This implementation treats all channels as 5-bit values for consistency.
+    ///
+    /// The YCoCg-R transformation follows these steps:
+    /// 1. Co = R - B
+    /// 2. t = B + (Co >> 1)
+    /// 3. Cg = G - t
+    /// 4. Y = t + (Cg >> 1)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let mut color = Color565::from_rgb(255, 128, 64);
+    /// color.decorrelate_ycocg_r();
+    /// // Color is now in YCoCg-R form
+    /// ```
+    #[no_mangle]
+    pub fn decorrelate_ycocg_r(&mut self) {
+        // Extract RGB components
+        let r = (self.value >> 11) & 0b11111; // 5 bits for red
+        let g = (self.value >> 6) & 0b11111; // 5 top bits for green (ignoring bottom 1 bit)
+        let g_low = (self.value >> 5) & 0b1; // leftover bit for green
+        let b = self.value & 0b11111; // 5 bits for blue
+
+        // Apply YCoCg-R forward transform (all operations in 5-bit space)
+        // Step 1: Co = R - B
+        let co = (r as i16 - b as i16) & 0b11111;
+
+        // Step 2: t = B + (Co >> 1)
+        let t = (b as i16 + (co >> 1)) & 0b11111;
+
+        // Step 3: Cg = G - t
+        let cg = (g as i16 - t) & 0b11111;
+
+        // Step 4: Y = t + (Cg >> 1)
+        let y = (t + (cg >> 1)) & 0b11111;
+
+        // Pack into Color565 format:
+        // - Y (5 bits) in red position
+        // - Co (5 bits) in green position (shifted to use upper 5 bits of the 6-bit field)
+        // - Cg (5 bits) in blue position
+        self.value = ((y as u16) << 11) | ((co as u16) << 6) | (g_low << 5) | (cg as u16);
+    }
+
+    /// Transforms color from YCoCg-R back to RGB color space.
+    ///
+    /// This is the inverse of the decorrelation operation, following these steps:
+    /// 1. t = Y - (Cg >> 1)
+    /// 2. G = Cg + t
+    /// 3. B = t - (Co >> 1)
+    /// 4. R = B + Co
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let original = Color565::from_rgb(255, 128, 64);
+    /// let mut decorrelated = original;
+    /// decorrelated.decorrelate_ycocg_r();
+    ///
+    /// // Now recorrelate it back to original
+    /// decorrelated.recorrelate_ycocg_r();
+    /// assert_eq!(decorrelated.raw_value(), original.raw_value());
+    /// ```
+    #[no_mangle]
+    pub fn recorrelate_ycocg_r(&mut self) {
+        // Extract YCoCg-R components
+        let y = (self.value >> 11) & 0x1F; // 5 bits (Y in red position)
+        let co = (self.value >> 6) & 0x1F; // 5 bits (Co in upper 5 bits of green position)
+        let g_low = (self.value >> 5) & 0x1; // Extract the preserved low bit of green
+        let cg = self.value & 0x1F; // 5 bits (Cg in blue position)
+
+        // Apply YCoCg-R inverse transform (all operations in 5-bit space)
+        // Step 1: t = Y - (Cg >> 1)
+        let t = (y as i16 - ((cg as i16) >> 1)) & 0x1F;
+
+        // Step 2: G = Cg + t
+        let g = (cg as i16 + t) & 0x1F;
+
+        // Step 3: B = t - (Co >> 1)
+        let b = (t - ((co as i16) >> 1)) & 0x1F;
+
+        // Step 4: R = B + Co
+        let r = (b + co as i16) & 0x1F;
+
+        // Pack back into RGB565 format, preserving the original g_low bit
+        self.value = ((r as u16) << 11) | ((g as u16) << 6) | (g_low << 5) | (b as u16);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests that colors can be properly decorrelated and recorrelated
+    /// back to their original values, testing each color individually.
+    #[test]
+    fn can_decorrelate_recorrelate() {
+        // Create a variety of test colors to ensure coverage across the color space
+        let test_colors = [
+            Color565::from_rgb(255, 0, 0),     // Red
+            Color565::from_rgb(0, 255, 0),     // Green
+            Color565::from_rgb(0, 0, 255),     // Blue
+            Color565::from_rgb(255, 255, 0),   // Yellow
+            Color565::from_rgb(0, 255, 255),   // Cyan
+            Color565::from_rgb(255, 0, 255),   // Magenta
+            Color565::from_rgb(128, 128, 128), // Gray
+            Color565::from_rgb(255, 255, 255), // White
+            Color565::from_rgb(0, 0, 0),       // Black
+            Color565::from_rgb(255, 128, 64),  // Orange
+            Color565::from_rgb(128, 0, 255),   // Purple
+            Color565::from_rgb(0, 128, 64),    // Teal
+            Color565::from_rgb(31, 79, 83),    // Prime Numbers
+        ];
+
+        // Test each color individually in a loop for easier debugging
+        for (x, original_color) in test_colors.iter().enumerate() {
+            // Create a copy to transform
+            let mut color = *original_color;
+
+            // Step 1: Decorrelate
+            color.decorrelate_ycocg_r();
+
+            // Step 2: Recorrelate
+            color.recorrelate_ycocg_r();
+
+            // Verify the color is restored to its original value
+            assert_eq!(
+                color.raw_value(),
+                original_color.raw_value(),
+                "Color at index {} failed to restore.",
+                x
+            );
+        }
+    }
+
+    #[test]
+    fn can_individual_color_operations() {
+        // Test individual color transformations
+        let original = Color565::from_rgb(255, 128, 64);
+        let mut transformed = original;
+
+        // Decorrelate
+        transformed.decorrelate_ycocg_r();
+        assert_ne!(
+            transformed.raw_value(),
+            original.raw_value(),
+            "Color should change after decorrelation"
+        );
+
+        // Recorrelate
+        transformed.recorrelate_ycocg_r();
+        assert_eq!(
+            transformed.raw_value(),
+            original.raw_value(),
+            "Color should be restored after recorrelation"
+        );
+    }
 }

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -140,7 +140,7 @@ impl Color565 {
     /// color.decorrelate_ycocg_r();
     /// // Color is now in YCoCg-R form
     /// ```
-    #[no_mangle]
+    #[inline]
     pub fn decorrelate_ycocg_r(&mut self) {
         // 0x1F == 0b11111
         // Extract RGB components
@@ -190,7 +190,7 @@ impl Color565 {
     /// decorrelated.recorrelate_ycocg_r();
     /// assert_eq!(decorrelated.raw_value(), original.raw_value());
     /// ```
-    #[no_mangle]
+    #[inline]
     pub fn recorrelate_ycocg_r(&mut self) {
         // 0x1F == 0b11111
         // Extract YCoCg-R components

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -169,6 +169,7 @@ impl Color565 {
         self.value = ((y as u16) << 11) | ((co as u16) << 6) | (g_low << 5) | (cg as u16);
     }
 
+    /// [Variant 1: Usually compresses best]
     /// Transforms color from YCoCg-R back to RGB color space.
     ///
     /// This is the inverse of the decorrelation operation, following these steps:
@@ -216,6 +217,7 @@ impl Color565 {
         self.value = ((r as u16) << 11) | ((g as u16) << 6) | (g_low << 5) | (b as u16);
     }
 
+    /// [Variant 2: Faster recorrelate (marginally) for compression speed.]
     /// Transforms RGB color to YCoCg-R (reversible YCoCg) color space.
     ///
     /// YCoCg-R is a lifting-based variation of YCoCg that offers perfect reversibility.
@@ -266,6 +268,7 @@ impl Color565 {
         // Note: Marginal speed improvement on recorrelate by placing low bit in the top.
     }
 
+    /// [Variant 3: Sometimes better than variant 2.]
     /// Transforms color from YCoCg-R back to RGB color space.
     ///
     /// This is the inverse of the decorrelation operation, following these steps:

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -142,24 +142,25 @@ impl Color565 {
     /// ```
     #[no_mangle]
     pub fn decorrelate_ycocg_r(&mut self) {
+        // 0x1F == 0b11111
         // Extract RGB components
-        let r = (self.value >> 11) & 0b11111; // 5 bits for red
-        let g = (self.value >> 6) & 0b11111; // 5 top bits for green (ignoring bottom 1 bit)
-        let g_low = (self.value >> 5) & 0b1; // leftover bit for green
-        let b = self.value & 0b11111; // 5 bits for blue
+        let r = (self.value >> 11) & 0x1F; // 5 bits for red
+        let g = (self.value >> 6) & 0x1F; // 5 top bits for green (ignoring bottom 1 bit)
+        let g_low = (self.value >> 5) & 0x1; // leftover bit for green
+        let b = self.value & 0x1F; // 5 bits for blue
 
         // Apply YCoCg-R forward transform (all operations in 5-bit space)
         // Step 1: Co = R - B
-        let co = (r as i16 - b as i16) & 0b11111;
+        let co = (r as i16 - b as i16) & 0x1F;
 
         // Step 2: t = B + (Co >> 1)
-        let t = (b as i16 + (co >> 1)) & 0b11111;
+        let t = (b as i16 + (co >> 1)) & 0x1F;
 
         // Step 3: Cg = G - t
-        let cg = (g as i16 - t) & 0b11111;
+        let cg = (g as i16 - t) & 0x1F;
 
         // Step 4: Y = t + (Cg >> 1)
-        let y = (t + (cg >> 1)) & 0b11111;
+        let y = (t + (cg >> 1)) & 0x1F;
 
         // Pack into Color565 format:
         // - Y (5 bits) in red position
@@ -191,6 +192,7 @@ impl Color565 {
     /// ```
     #[no_mangle]
     pub fn recorrelate_ycocg_r(&mut self) {
+        // 0x1F == 0b11111
         // Extract YCoCg-R components
         let y = (self.value >> 11) & 0x1F; // 5 bits (Y in red position)
         let co = (self.value >> 6) & 0x1F; // 5 bits (Co in upper 5 bits of green position)

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -137,11 +137,11 @@ impl Color565 {
     /// use dxt_lossless_transform_common::color_565::Color565;
     ///
     /// let mut color = Color565::from_rgb(255, 128, 64);
-    /// color.decorrelate_ycocg_r();
+    /// color.decorrelate_ycocg_r_var1();
     /// // Color is now in YCoCg-R form
     /// ```
     #[inline]
-    pub fn decorrelate_ycocg_r(&mut self) {
+    pub fn decorrelate_ycocg_r_var1(&mut self) {
         // 0x1F == 0b11111
         // Extract RGB components
         let r = (self.value >> 11) & 0x1F; // 5 bits for red
@@ -184,14 +184,14 @@ impl Color565 {
     ///
     /// let original = Color565::from_rgb(255, 128, 64);
     /// let mut decorrelated = original;
-    /// decorrelated.decorrelate_ycocg_r();
+    /// decorrelated.decorrelate_ycocg_r_var1();
     ///
     /// // Now recorrelate it back to original
-    /// decorrelated.recorrelate_ycocg_r();
+    /// decorrelated.recorrelate_ycocg_r_var1();
     /// assert_eq!(decorrelated.raw_value(), original.raw_value());
     /// ```
     #[inline]
-    pub fn recorrelate_ycocg_r(&mut self) {
+    pub fn recorrelate_ycocg_r_var1(&mut self) {
         // 0x1F == 0b11111
         // Extract YCoCg-R components
         let y = (self.value >> 11) & 0x1F; // 5 bits (Y in red position)
@@ -215,16 +215,241 @@ impl Color565 {
         // Pack back into RGB565 format, preserving the original g_low bit
         self.value = ((r as u16) << 11) | ((g as u16) << 6) | (g_low << 5) | (b as u16);
     }
+
+    /// Transforms RGB color to YCoCg-R (reversible YCoCg) color space.
+    ///
+    /// YCoCg-R is a lifting-based variation of YCoCg that offers perfect reversibility.
+    /// This implementation treats all channels as 5-bit values for consistency.
+    ///
+    /// The YCoCg-R transformation follows these steps:
+    /// 1. Co = R - B
+    /// 2. t = B + (Co >> 1)
+    /// 3. Cg = G - t
+    /// 4. Y = t + (Cg >> 1)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let mut color = Color565::from_rgb(255, 128, 64);
+    /// color.decorrelate_ycocg_r_var2();
+    /// // Color is now in YCoCg-R form
+    /// ```
+    #[inline]
+    pub fn decorrelate_ycocg_r_var2(&mut self) {
+        // 0x1F == 0b11111
+        // Extract RGB components
+        let r = (self.value >> 11) & 0x1F; // 5 bits for red
+        let g = (self.value >> 6) & 0x1F; // 5 top bits for green (ignoring bottom 1 bit)
+        let g_low = (self.value >> 5) & 0x1; // leftover bit for green
+        let b = self.value & 0x1F; // 5 bits for blue
+
+        // Apply YCoCg-R forward transform (all operations in 5-bit space)
+        // Step 1: Co = R - B
+        let co = (r as i16 - b as i16) & 0x1F;
+
+        // Step 2: t = B + (Co >> 1)
+        let t = (b as i16 + (co >> 1)) & 0x1F;
+
+        // Step 3: Cg = G - t
+        let cg = (g as i16 - t) & 0x1F;
+
+        // Step 4: Y = t + (Cg >> 1)
+        let y = (t + (cg >> 1)) & 0x1F;
+
+        // Pack into Color565 format:
+        // - Y (5 bits) in red position
+        // - Co (5 bits) in green position (shifted to use upper 5 bits of the 6-bit field)
+        // - Cg (5 bits) in blue position
+        self.value = (g_low << 15) | ((y as u16) << 10) | ((co as u16) << 5) | (cg as u16);
+        // Note: Marginal speed improvement on recorrelate by placing low bit in the top.
+    }
+
+    /// Transforms color from YCoCg-R back to RGB color space.
+    ///
+    /// This is the inverse of the decorrelation operation, following these steps:
+    /// 1. t = Y - (Cg >> 1)
+    /// 2. G = Cg + t
+    /// 3. B = t - (Co >> 1)
+    /// 4. R = B + Co
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let original = Color565::from_rgb(255, 128, 64);
+    /// let mut decorrelated = original;
+    /// decorrelated.decorrelate_ycocg_r_var2();
+    ///
+    /// // Now recorrelate it back to original
+    /// decorrelated.recorrelate_ycocg_r_var2();
+    /// assert_eq!(decorrelated.raw_value(), original.raw_value());
+    /// ```
+    #[inline]
+    pub fn recorrelate_ycocg_r_var2(&mut self) {
+        // 0x1F == 0b11111
+        // Extract YCoCg-R components
+        let g_low = self.value >> 15; // Extract the preserved low bit of green
+        let y = (self.value >> 10) & 0x1F; // 5 bits (Y in red position)
+        let co = (self.value >> 5) & 0x1F; // 5 bits (Co in upper 5 bits of green position)
+        let cg = self.value & 0x1F; // 5 bits (Cg in blue position)
+
+        // Apply YCoCg-R inverse transform (all operations in 5-bit space)
+        // Step 1: t = Y - (Cg >> 1)
+        let t = (y as i16 - ((cg as i16) >> 1)) & 0x1F;
+
+        // Step 2: G = Cg + t
+        let g = (cg as i16 + t) & 0x1F;
+
+        // Step 3: B = t - (Co >> 1)
+        let b = (t - ((co as i16) >> 1)) & 0x1F;
+
+        // Step 4: R = B + Co
+        let r = (b + co as i16) & 0x1F;
+
+        // Pack back into RGB565 format, preserving the original g_low bit
+        self.value = ((r as u16) << 11) | ((g as u16) << 6) | (g_low << 5) | (b as u16);
+    }
+
+    /// Transforms RGB color to YCoCg-R (reversible YCoCg) color space.
+    ///
+    /// YCoCg-R is a lifting-based variation of YCoCg that offers perfect reversibility.
+    /// This implementation treats all channels as 5-bit values for consistency.
+    ///
+    /// The YCoCg-R transformation follows these steps:
+    /// 1. Co = R - B
+    /// 2. t = B + (Co >> 1)
+    /// 3. Cg = G - t
+    /// 4. Y = t + (Cg >> 1)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let mut color = Color565::from_rgb(255, 128, 64);
+    /// color.decorrelate_ycocg_r_var3();
+    /// // Color is now in YCoCg-R form
+    /// ```
+    #[inline]
+    pub fn decorrelate_ycocg_r_var3(&mut self) {
+        // 0x1F == 0b11111
+        // Extract RGB components
+        let r = (self.value >> 11) & 0x1F; // 5 bits for red
+        let g = (self.value >> 6) & 0x1F; // 5 top bits for green (ignoring bottom 1 bit)
+        let g_low = (self.value >> 5) & 0x1; // leftover bit for green
+        let b = self.value & 0x1F; // 5 bits for blue
+
+        // Apply YCoCg-R forward transform (all operations in 5-bit space)
+        // Step 1: Co = R - B
+        let co = (r as i16 - b as i16) & 0x1F;
+
+        // Step 2: t = B + (Co >> 1)
+        let t = (b as i16 + (co >> 1)) & 0x1F;
+
+        // Step 3: Cg = G - t
+        let cg = (g as i16 - t) & 0x1F;
+
+        // Step 4: Y = t + (Cg >> 1)
+        let y = (t + (cg >> 1)) & 0x1F;
+
+        // Pack into Color565 format:
+        // - Y (5 bits) in red position
+        // - Co (5 bits) in green position (shifted to use upper 5 bits of the 6-bit field)
+        // - Cg (5 bits) in blue position
+        self.value = ((y as u16) << 11) | ((co as u16) << 6) | ((cg as u16) << 1) | g_low;
+    }
+
+    /// Transforms color from YCoCg-R back to RGB color space.
+    ///
+    /// This is the inverse of the decorrelation operation, following these steps:
+    /// 1. t = Y - (Cg >> 1)
+    /// 2. G = Cg + t
+    /// 3. B = t - (Co >> 1)
+    /// 4. R = B + Co
+    ///
+    /// This variation has the g_low bit placed as the lowermost bit.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_565::Color565;
+    ///
+    /// let original = Color565::from_rgb(255, 128, 64);
+    /// let mut decorrelated = original;
+    /// decorrelated.decorrelate_ycocg_r_var3();
+    ///
+    /// // Now recorrelate it back to original
+    /// decorrelated.recorrelate_ycocg_r_var3();
+    /// assert_eq!(decorrelated.raw_value(), original.raw_value());
+    /// ```
+    #[inline]
+    pub fn recorrelate_ycocg_r_var3(&mut self) {
+        // 0x1F == 0b11111
+        // Extract YCoCg-R components
+        let y = (self.value >> 11) & 0x1F; // 5 bits (Y in red position)
+        let co = (self.value >> 6) & 0x1F; // 5 bits (Co in upper 5 bits of green position)
+        let cg = (self.value >> 1) & 0x1F; // 5 bits (Cg in bits 1-5)
+        let g_low = self.value & 0x1; // Extract the preserved low bit of green (lowermost bit)
+
+        // Apply YCoCg-R inverse transform (all operations in 5-bit space)
+        // Step 1: t = Y - (Cg >> 1)
+        let t = (y as i16 - ((cg as i16) >> 1)) & 0x1F;
+
+        // Step 2: G = Cg + t
+        let g = (cg as i16 + t) & 0x1F;
+
+        // Step 3: B = t - (Co >> 1)
+        let b = (t - ((co as i16) >> 1)) & 0x1F;
+
+        // Step 4: R = B + Co
+        let r = (b + co as i16) & 0x1F;
+
+        // Pack back into RGB565 format, preserving the original g_low bit
+        self.value = ((r as u16) << 11) | ((g as u16) << 6) | (g_low << 5) | (b as u16);
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rstest::rstest;
+
+    /// Represents a function variant for decoration/recorrelation operations
+    #[derive(Debug, Clone, Copy)]
+    enum YCoCgVariant {
+        Variant1,
+        Variant2,
+        Variant3,
+    }
+
+    /// Apply the specified decorrelation variant to a color
+    fn apply_decorrelation(color: &mut Color565, variant: YCoCgVariant) {
+        match variant {
+            YCoCgVariant::Variant1 => color.decorrelate_ycocg_r_var1(),
+            YCoCgVariant::Variant2 => color.decorrelate_ycocg_r_var2(),
+            YCoCgVariant::Variant3 => color.decorrelate_ycocg_r_var3(),
+        }
+    }
+
+    /// Apply the specified recorrelation variant to a color
+    fn apply_recorrelation(color: &mut Color565, variant: YCoCgVariant) {
+        match variant {
+            YCoCgVariant::Variant1 => color.recorrelate_ycocg_r_var1(),
+            YCoCgVariant::Variant2 => color.recorrelate_ycocg_r_var2(),
+            YCoCgVariant::Variant3 => color.recorrelate_ycocg_r_var3(),
+        }
+    }
 
     /// Tests that colors can be properly decorrelated and recorrelated
-    /// back to their original values, testing each color individually.
-    #[test]
-    fn can_decorrelate_recorrelate() {
+    /// back to their original values for all three variants.
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn can_decorrelate_recorrelate(#[case] variant: YCoCgVariant) {
         // Create a variety of test colors to ensure coverage across the color space
         let test_colors = [
             Color565::from_rgb(255, 0, 0),     // Red
@@ -248,41 +473,48 @@ mod tests {
             let mut color = *original_color;
 
             // Step 1: Decorrelate
-            color.decorrelate_ycocg_r();
+            apply_decorrelation(&mut color, variant);
 
             // Step 2: Recorrelate
-            color.recorrelate_ycocg_r();
+            apply_recorrelation(&mut color, variant);
 
             // Verify the color is restored to its original value
             assert_eq!(
                 color.raw_value(),
                 original_color.raw_value(),
-                "Color at index {} failed to restore.",
+                "{:?} - Color at index {} failed to restore.",
+                variant,
                 x
             );
         }
     }
 
-    #[test]
-    fn can_individual_color_operations() {
+    /// Tests individual color transformations for each variant
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn can_individual_color_operations(#[case] variant: YCoCgVariant) {
         // Test individual color transformations
         let original = Color565::from_rgb(255, 128, 64);
         let mut transformed = original;
 
         // Decorrelate
-        transformed.decorrelate_ycocg_r();
+        apply_decorrelation(&mut transformed, variant);
         assert_ne!(
             transformed.raw_value(),
             original.raw_value(),
-            "Color should change after decorrelation"
+            "{:?} - Color should change after decorrelation",
+            variant
         );
 
         // Recorrelate
-        transformed.recorrelate_ycocg_r();
+        apply_recorrelation(&mut transformed, variant);
         assert_eq!(
             transformed.raw_value(),
             original.raw_value(),
-            "Color should be restored after recorrelation"
+            "{:?} - Color should be restored after recorrelation",
+            variant
         );
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced reversible color conversion functionality that enables switching between RGB and YCoCg-R color spaces with multiple variants.

- **Tests**
  - Added tests to validate the accuracy of color transformations and ensure original values are preserved through round-trip conversions.

- **Chores**
  - Added new development dependencies for benchmarking and performance evaluation.
  - Introduced a new benchmark for evaluating the performance of color conversion functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->