### PR TITLE
Added: Ability to unsplit colours given separate pointers for BC1-BC3 blocks.

### DIFF
--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
@@ -136,15 +136,29 @@ pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn permd_detransform_unroll_2(
-    mut input_ptr: *const u8,
+pub unsafe fn permd_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    // Process as many 128-byte blocks as possible
+    let indices_ptr = input_ptr.add(len / 2);
+    let colors_ptr = input_ptr;
+
+    permd_detransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
+}
+
+/// # Safety
+///
+/// - output_ptr must be valid for writes of len bytes
+/// - indices_ptr must be valid for reads of len/2 bytes
+/// - colors_ptr must be valid for reads of len/2 bytes
+#[allow(unused_assignments)]
+#[target_feature(enable = "avx2")]
+pub unsafe fn permd_detransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
+    mut indices_ptr: *const u8,
+    mut colors_ptr: *const u8,
 ) {
-    // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
-    let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let mut colors_aligned_end = colors_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -182,7 +196,7 @@ pub unsafe fn permd_detransform_unroll_2(
                 "cmp {colors_ptr}, {end}",
                 "jb 2b",
 
-                colors_ptr = inout(reg) input_ptr,
+                colors_ptr = inout(reg) colors_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
                 end = inout(reg) colors_aligned_end,
@@ -203,7 +217,7 @@ pub unsafe fn permd_detransform_unroll_2(
     let remaining = len - aligned_len;
     if remaining > 0 {
         u32_detransform_with_separate_pointers(
-            input_ptr as *const u32,
+            colors_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
             remaining,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
@@ -11,7 +11,7 @@ pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
     let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let colors_aligned_end = input_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -108,7 +108,7 @@ pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
                 colors_ptr = inout(reg) input_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 ymm0 = out(ymm_reg) _,
                 ymm1 = out(ymm_reg) _,
                 ymm2 = out(ymm_reg) _,
@@ -157,8 +157,9 @@ pub unsafe fn permd_detransform_unroll_2_with_components(
     mut indices_ptr: *const u8,
     mut colors_ptr: *const u8,
 ) {
+    debug_assert!(len % 8 == 0, "len must be divisible by 8");
     let aligned_len = len - (len % 128);
-    let mut colors_aligned_end = colors_ptr.add(aligned_len / 2);
+    let colors_aligned_end = colors_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -199,7 +200,7 @@ pub unsafe fn permd_detransform_unroll_2_with_components(
                 colors_ptr = inout(reg) colors_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 ymm0 = out(ymm_reg) _,
                 ymm1 = out(ymm_reg) _,
                 ymm2 = out(ymm_reg) _,
@@ -235,7 +236,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
     let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let colors_aligned_end = input_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -268,7 +269,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
                 colors_ptr = inout(reg) input_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 ymm0 = out(ymm_reg) _,
                 ymm1 = out(ymm_reg) _,
                 ymm2 = out(ymm_reg) _,
@@ -303,7 +304,7 @@ pub unsafe fn unpck_detransform_unroll_2(
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
     let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let colors_aligned_end = input_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -348,7 +349,7 @@ pub unsafe fn unpck_detransform_unroll_2(
                 colors_ptr = inout(reg) input_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 ymm0 = out(ymm_reg) _,
                 ymm1 = out(ymm_reg) _,
                 ymm2 = out(ymm_reg) _,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
@@ -64,6 +64,92 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     }
 }
 
+unsafe fn unsplit_block_with_separate_pointers_x86(
+    colors_ptr: *const u32,
+    indices_ptr: *const u32,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    {
+        if std::is_x86_feature_detected!("avx2") {
+            avx2::permd_detransform_unroll_2_with_components(
+                output_ptr,
+                len,
+                indices_ptr as *const u8,
+                colors_ptr as *const u8,
+            );
+            return;
+        }
+
+        if std::is_x86_feature_detected!("sse2") {
+            sse2::unpck_detransform_unroll_2_with_components(
+                output_ptr,
+                len,
+                indices_ptr as *const u8,
+                colors_ptr as *const u8,
+            );
+            return;
+        }
+    }
+
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
+        if cfg!(target_feature = "avx2") {
+            avx2::permd_detransform_unroll_2_with_components(
+                output_ptr,
+                len,
+                indices_ptr as *const u8,
+                colors_ptr as *const u8,
+            );
+            return;
+        }
+
+        if cfg!(target_feature = "sse2") {
+            sse2::unpck_detransform_unroll_2_with_components(
+                output_ptr,
+                len,
+                indices_ptr as *const u8,
+                colors_ptr as *const u8,
+            );
+            return;
+        }
+    }
+
+    // Fallback to portable implementation
+    u32_detransform_with_separate_pointers(colors_ptr, indices_ptr, output_ptr, len)
+}
+
+/// Unsplit BC1 blocks, putting them back into standard interleaved format from a separated color/index format
+/// using the best known implementation for the current CPU.
+///
+/// # Safety
+///
+/// - colors_ptr must be valid for reads of len/2 bytes
+/// - indices_ptr must be valid for reads of len/2 bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 8
+/// - It is recommended that colors_ptr and indices_ptr are at least 16-byte aligned (recommended 32-byte align)
+#[inline]
+pub unsafe fn unsplit_block_with_separate_pointers(
+    colors_ptr: *const u32,
+    indices_ptr: *const u32,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 8 == 0);
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        unsplit_block_with_separate_pointers_x86(colors_ptr, indices_ptr, output_ptr, len)
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+    {
+        u32_detransform_with_separate_pointers(colors_ptr, indices_ptr, output_ptr, len)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::testutils::allocate_align_64;
@@ -71,20 +157,18 @@ mod tests {
 
     /// Helper to assert implementation results match reference implementation
     pub(crate) fn assert_implementation_matches_reference(
-        expected: &[u8], 
-        actual: &[u8], 
-        impl_name: &str, 
-        num_blocks: usize
+        expected: &[u8],
+        actual: &[u8],
+        impl_name: &str,
+        num_blocks: usize,
     ) {
         assert_eq!(
-            expected,
-            actual,
+            expected, actual,
             "{} implementation produced different results than reference for {} blocks.\n\
             First differing block will have predictable values:\n\
             Colors: Sequential 0-3 + (block_num * 4)\n\
             Indices: Sequential 128-131 + (block_num * 4)",
-            impl_name,
-            num_blocks
+            impl_name, num_blocks
         );
     }
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
@@ -64,6 +64,8 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     }
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[inline(always)]
 unsafe fn unsplit_block_with_separate_pointers_x86(
     colors_ptr: *const u32,
     indices_ptr: *const u32,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
@@ -68,15 +68,28 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn unpck_detransform_unroll_2(
-    mut input_ptr: *const u8,
+pub unsafe fn unpck_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    // Process as many 64-byte blocks as possible
+    let indices_ptr = input_ptr.add(len / 2);
+    let colors_ptr = input_ptr;
+    unpck_detransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
+}
+
+/// # Safety
+///
+/// - output_ptr must be valid for writes of len bytes
+/// - indices_ptr must be valid for reads of len/2 bytes
+/// - colors_ptr must be valid for reads of len/2 bytes
+#[allow(unused_assignments)]
+#[target_feature(enable = "sse2")]
+pub unsafe fn unpck_detransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
+    mut indices_ptr: *const u8,
+    mut colors_ptr: *const u8,
 ) {
-    // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
-    let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let mut colors_aligned_end = colors_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -112,7 +125,7 @@ pub unsafe fn unpck_detransform_unroll_2(
                 "cmp {colors_ptr}, {end}",
                 "jb 2b",
 
-                colors_ptr = inout(reg) input_ptr,
+                colors_ptr = inout(reg) colors_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
                 end = inout(reg) colors_aligned_end,
@@ -131,7 +144,7 @@ pub unsafe fn unpck_detransform_unroll_2(
     let remaining = len - aligned_len;
     if remaining > 0 {
         u32_detransform_with_separate_pointers(
-            input_ptr as *const u32,
+            colors_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
             remaining,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
@@ -11,7 +11,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);
     let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let colors_aligned_end = input_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -41,7 +41,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
                 colors_ptr = inout(reg) input_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 xmm0 = out(xmm_reg) _,
                 xmm1 = out(xmm_reg) _,
                 xmm2 = out(xmm_reg) _,
@@ -89,7 +89,7 @@ pub unsafe fn unpck_detransform_unroll_2_with_components(
     mut colors_ptr: *const u8,
 ) {
     let aligned_len = len - (len % 64);
-    let mut colors_aligned_end = colors_ptr.add(aligned_len / 2);
+    let colors_aligned_end = colors_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -128,7 +128,7 @@ pub unsafe fn unpck_detransform_unroll_2_with_components(
                 colors_ptr = inout(reg) colors_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 xmm0 = out(xmm_reg) _,
                 xmm1 = out(xmm_reg) _,
                 xmm2 = out(xmm_reg) _,
@@ -167,7 +167,7 @@ pub unsafe fn unpck_detransform_unroll_4(
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
     let mut indices_ptr = input_ptr.add(len / 2);
-    let mut colors_aligned_end = input_ptr.add(aligned_len / 2);
+    let colors_aligned_end = input_ptr.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -222,7 +222,7 @@ pub unsafe fn unpck_detransform_unroll_4(
                 colors_ptr = inout(reg) input_ptr,
                 indices_ptr = inout(reg) indices_ptr,
                 dst_ptr = inout(reg) output_ptr,
-                end = inout(reg) colors_aligned_end,
+                end = in(reg) colors_aligned_end,
                 xmm0 = out(xmm_reg) _,
                 xmm1 = out(xmm_reg) _,
                 xmm2 = out(xmm_reg) _,

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -64,6 +64,107 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     }
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[inline(always)]
+unsafe fn unsplit_block_with_separate_pointers_x86(
+    alphas_ptr: *const u64,
+    colors_ptr: *const u32,
+    indices_ptr: *const u32,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    {
+        if std::is_x86_feature_detected!("avx2") {
+            avx2::avx2_shuffle_with_components(
+                output_ptr,
+                len,
+                alphas_ptr as *const u8,
+                colors_ptr as *const u8,
+                indices_ptr as *const u8,
+            );
+            return;
+        }
+
+        if std::is_x86_feature_detected!("sse2") {
+            sse2::shuffle_with_components(
+                output_ptr,
+                len,
+                alphas_ptr as *const u8,
+                colors_ptr as *const u8,
+                indices_ptr as *const u8,
+            );
+            return;
+        }
+    }
+
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
+        if cfg!(target_feature = "avx2") {
+            avx2::avx2_shuffle_with_components(
+                output_ptr,
+                len,
+                alphas_ptr as *const u8,
+                colors_ptr as *const u8,
+                indices_ptr as *const u8,
+            );
+            return;
+        }
+
+        if cfg!(target_feature = "sse2") {
+            sse2::shuffle_with_components(
+                output_ptr,
+                len,
+                alphas_ptr as *const u8,
+                colors_ptr as *const u8,
+                indices_ptr as *const u8,
+            );
+            return;
+        }
+    }
+
+    // Fallback to portable implementation
+    u32_detransform_with_separate_pointers(alphas_ptr, colors_ptr, indices_ptr, output_ptr, len)
+}
+
+/// Unsplit BC2 blocks, putting them back into standard interleaved format from a separated alpha/color/index format
+/// using the best known implementation for the current CPU.
+///
+/// # Safety
+///
+/// - alphas_ptr must be valid for reads of len/2 bytes
+/// - colors_ptr must be valid for reads of len/4 bytes
+/// - indices_ptr must be valid for reads of len/4 bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 16
+/// - It is recommended that alphas_ptr, colors_ptr and indices_ptr are at least 16-byte aligned (recommended 32-byte align)
+#[inline]
+pub unsafe fn unsplit_block_with_separate_pointers(
+    alphas_ptr: *const u64,
+    colors_ptr: *const u32,
+    indices_ptr: *const u32,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 16 == 0);
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        unsplit_block_with_separate_pointers_x86(
+            alphas_ptr,
+            colors_ptr,
+            indices_ptr,
+            output_ptr,
+            len,
+        )
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+    {
+        u32_detransform_with_separate_pointers(alphas_ptr, colors_ptr, indices_ptr, output_ptr, len)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::testutils::allocate_align_64;
@@ -71,21 +172,19 @@ mod tests {
 
     /// Helper to assert implementation results match reference implementation
     pub(crate) fn assert_implementation_matches_reference(
-        expected: &[u8], 
-        actual: &[u8], 
-        impl_name: &str, 
-        num_blocks: usize
+        expected: &[u8],
+        actual: &[u8],
+        impl_name: &str,
+        num_blocks: usize,
     ) {
         assert_eq!(
-            expected,
-            actual,
+            expected, actual,
             "{} implementation produced different results than reference for {} blocks.\n\
             First differing block will have predictable values:\n\
             Alpha: Sequential 0-7 + (block_num * 8)\n\
             Colors: Sequential 128-131 + (block_num * 4)\n\
             Indices: Sequential 192-195 + (block_num * 4)",
-            impl_name,
-            num_blocks
+            impl_name, num_blocks
         );
     }
 

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -170,6 +170,8 @@ mod tests {
     use crate::testutils::allocate_align_64;
     use safe_allocator_api::RawAlloc;
 
+    use super::{unsplit_block_with_separate_pointers, unsplit_blocks};
+
     /// Helper to assert implementation results match reference implementation
     pub(crate) fn assert_implementation_matches_reference(
         expected: &[u8],
@@ -237,5 +239,35 @@ mod tests {
         ];
         let output = generate_bc2_transformed_test_data(3);
         assert_eq!(output.as_slice(), expected.as_slice());
+    }
+
+    #[test]
+    fn unsplit_block_with_separate_pointers_matches_unsplit_blocks() {
+        for num_blocks in 1..=512 {
+            let mut transformed = generate_bc2_transformed_test_data(num_blocks);
+            let len = transformed.len();
+            let mut output_ref = allocate_align_64(len);
+            let mut output_sep = allocate_align_64(len);
+
+            unsafe {
+                // Reference: contiguous pointers
+                unsplit_blocks(transformed.as_mut_ptr(), output_ref.as_mut_ptr(), len);
+                // Test separate pointers variant
+                unsplit_block_with_separate_pointers(
+                    transformed.as_ptr() as *const u64,
+                    transformed.as_ptr().add(len / 2) as *const u32,
+                    transformed.as_ptr().add(len * 3 / 4) as *const u32,
+                    output_sep.as_mut_ptr(),
+                    len,
+                );
+            }
+
+            assert_implementation_matches_reference(
+                output_ref.as_slice(),
+                output_sep.as_slice(),
+                "unsplit_block_with_separate_pointers",
+                num_blocks,
+            );
+        }
     }
 }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/sse2.rs
@@ -20,7 +20,7 @@ pub unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 ///
 /// - alpha_ptr must be valid for reads of len/2 bytes
 /// - colors_ptr must be valid for reads of len/4 bytes
-/// - indices_ptr must be valid for reads of len/4 bytes 
+/// - indices_ptr must be valid for reads of len/4 bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
@@ -31,6 +31,11 @@ pub unsafe fn shuffle_with_components(
     mut colors_ptr: *const u8,
     mut indices_ptr: *const u8,
 ) {
+    debug_assert!(
+        len % 16 == 0,
+        "BC2 shuffle expects `len` to be a multiple of 16 (block size)"
+    );
+
     let aligned_len = len - (len % 64);
     let alpha_ptr_aligned_end = alpha_ptr.add(aligned_len / 2);
     // End pointer for the loop based on aligned length

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
@@ -43,7 +43,93 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        u32_detransform(input_ptr, output_ptr, len)
+        u32_detransform_v2(input_ptr, output_ptr, len)
+    }
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[inline(always)]
+unsafe fn unsplit_block_with_separate_pointers_x86(
+    alpha_byte_ptr: *const u8,
+    alpha_bit_ptr: *const u8,
+    color_byte_ptr: *const u8,
+    index_byte_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    // SSE2 is required by x86-64, so no check needed
+    // On i686, this is slower, so skipped.
+    #[cfg(target_arch = "x86_64")]
+    {
+        sse2::u64_detransform_sse2_separate_components(
+            alpha_byte_ptr as *const u64,
+            alpha_bit_ptr as *const u64,
+            color_byte_ptr as *const core::arch::x86_64::__m128i,
+            index_byte_ptr as *const core::arch::x86_64::__m128i,
+            output_ptr,
+            len,
+        );
+    }
+
+    #[cfg(target_arch = "x86")]
+    {
+        portable::u32_detransform_with_separate_pointers(
+            alpha_byte_ptr as *const u16,
+            alpha_bit_ptr as *const u16,
+            color_byte_ptr as *const u32,
+            index_byte_ptr as *const u32,
+            output_ptr,
+            len,
+        );
+    }
+}
+
+/// Unsplit BC3 blocks, putting them back into standard interleaved format from separated component pointers
+/// using the best known implementation for the current CPU.
+///
+/// # Safety
+///
+/// - alpha_byte_ptr must be valid for reads of len * 2 / 16 bytes (alpha endpoints)
+/// - alpha_bit_ptr must be valid for reads of len * 6 / 16 bytes (alpha indices)
+/// - color_byte_ptr must be valid for reads of len * 4 / 16 bytes (color endpoints)
+/// - index_byte_ptr must be valid for reads of len * 4 / 16 bytes (color indices)
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 16
+/// - It is recommended that input pointers are at least 16-byte aligned (recommended 32-byte align)
+#[inline]
+pub unsafe fn unsplit_block_with_separate_pointers(
+    alpha_byte_ptr: *const u8,
+    alpha_bit_ptr: *const u8,
+    color_byte_ptr: *const u8,
+    index_byte_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 16 == 0);
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        unsplit_block_with_separate_pointers_x86(
+            alpha_byte_ptr,
+            alpha_bit_ptr,
+            color_byte_ptr,
+            index_byte_ptr,
+            output_ptr,
+            len,
+        )
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+    {
+        // Cast pointers to types expected by portable implementation
+        portable::u32_detransform_with_separate_pointers(
+            alpha_byte_ptr as *const u16,
+            alpha_bit_ptr as *const u16,
+            color_byte_ptr as *const u32,
+            index_byte_ptr as *const u32,
+            output_ptr,
+            len,
+        )
     }
 }
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new functions for unsplitting BC1, BC2, and BC3 blocks from separate component pointers, providing improved modularity and optimized architecture-specific paths.
  - Added public APIs to handle separated alpha, color, and index data for BC1, BC2, and BC3 formats with automatic CPU feature detection for optimal performance.

- **Refactor**
  - Refactored existing unsplit and shuffle functions to delegate processing to new helper functions that accept separate pointers for each component.
  - Improved clarity and maintainability by separating pointer management from core processing logic and standardizing function signatures.
  - Optimized detransform functions with loop unrolling and aligned processing for better performance on portable implementations.
  - Standardized assembly constraints and pointer immutability for correctness and clarity.

- **Documentation**
  - Enhanced safety and usage documentation for new and updated functions, clarifying pointer validity and alignment requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->