### PR TITLE
Added: Missing debug bounds checks for BC1-BC3 blocks

### DIFF
--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx2.rs
@@ -8,6 +8,7 @@ use std::arch::asm;
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
 
@@ -90,6 +91,7 @@ pub unsafe fn permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: us
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn permute_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
 
@@ -176,6 +178,7 @@ pub unsafe fn permute_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn gather(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
 
@@ -249,6 +252,7 @@ pub unsafe fn gather(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usi
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn shuffle_permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
 
@@ -323,6 +327,7 @@ pub unsafe fn shuffle_permute_unroll_2(
     mut output_ptr: *mut u8,
     len: usize,
 ) {
+    debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/sse2.rs
@@ -8,6 +8,7 @@ use std::arch::asm;
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn punpckhqdq_unroll_4(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
 
@@ -89,6 +90,7 @@ pub unsafe fn punpckhqdq_unroll_4(mut input_ptr: *const u8, mut output_ptr: *mut
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn punpckhqdq_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);
 
@@ -158,6 +160,7 @@ pub unsafe fn punpckhqdq_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn shufps_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);
 
@@ -221,6 +224,7 @@ pub unsafe fn shufps_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8,
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn shufps_unroll_4(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
@@ -8,6 +8,7 @@ use std::arch::asm;
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
     let mut indices_ptr = input_ptr.add(len / 2);
@@ -137,6 +138,7 @@ pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn permd_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let indices_ptr = input_ptr.add(len / 2);
     let colors_ptr = input_ptr;
@@ -233,6 +235,7 @@ pub unsafe fn permd_detransform_unroll_2_with_components(
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
 pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
     let mut indices_ptr = input_ptr.add(len / 2);
@@ -301,6 +304,7 @@ pub unsafe fn unpck_detransform_unroll_2(
     mut output_ptr: *mut u8,
     len: usize,
 ) {
+    debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
     let mut indices_ptr = input_ptr.add(len / 2);

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
@@ -8,6 +8,7 @@ use std::arch::asm;
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);
     let mut indices_ptr = input_ptr.add(len / 2);
@@ -69,6 +70,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
 pub unsafe fn unpck_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let indices_ptr = input_ptr.add(len / 2);
     let colors_ptr = input_ptr;
@@ -88,6 +90,7 @@ pub unsafe fn unpck_detransform_unroll_2_with_components(
     mut indices_ptr: *const u8,
     mut colors_ptr: *const u8,
 ) {
+    debug_assert!(len % 8 == 0);
     let aligned_len = len - (len % 64);
     let colors_aligned_end = colors_ptr.add(aligned_len / 2);
 
@@ -164,6 +167,7 @@ pub unsafe fn unpck_detransform_unroll_4(
     mut output_ptr: *mut u8,
     len: usize,
 ) {
+    debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
     let mut indices_ptr = input_ptr.add(len / 2);

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
@@ -17,6 +17,8 @@ static PERMUTE_MASK: [u32; 8] = [0, 4, 1, 5, 2, 6, 3, 7];
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
 pub unsafe fn shuffle(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     let aligned_len = len - (len % 128);
 
     let mut colors_ptr = output_ptr.add(len / 2);

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
@@ -32,6 +32,8 @@ pub unsafe fn u32_with_separate_pointers(
     mut indices_ptr: *mut u32,
     len: usize,
 ) {
+    debug_assert!(len % 16 == 0);
+
     let max_ptr = input_ptr.add(len) as *mut u8;
     let mut input_ptr = input_ptr as *mut u8;
 
@@ -58,6 +60,8 @@ pub unsafe fn u32_with_separate_pointers(
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     let mut alphas_ptr = output_ptr as *mut u64;
     let mut colours_ptr = output_ptr.add(len / 2) as *mut u32;
     let mut indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;
@@ -119,6 +123,8 @@ pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 pub unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     let mut alphas_ptr = output_ptr as *mut u64;
     let mut colours_ptr = output_ptr.add(len / 2) as *mut u32;
     let mut indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/sse2.rs
@@ -8,6 +8,8 @@ use std::arch::asm;
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
 pub unsafe fn shuffle_v1(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     let aligned_len = len - (len % 32);
     let mut colors_ptr = output_ptr.add(len / 2);
     let mut indices_ptr = colors_ptr.add(len / 4);
@@ -89,6 +91,8 @@ pub unsafe fn shuffle_v1(mut input_ptr: *const u8, mut output_ptr: *mut u8, len:
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
 pub unsafe fn shuffle_v1_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     let aligned_len = len - (len % 64);
     let mut colors_ptr = output_ptr.add(len / 2);
     let mut indices_ptr = colors_ptr.add(len / 4);
@@ -176,6 +180,8 @@ pub unsafe fn shuffle_v1_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
 pub unsafe fn shuffle_v2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     let aligned_len = len - (len % 64);
     let mut colors_ptr = output_ptr.add(len / 2);
     let mut indices_ptr = colors_ptr.add(len / 4);
@@ -263,6 +269,8 @@ pub unsafe fn shuffle_v2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len:
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86_64")]
 pub unsafe fn shuffle_v3(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
     let mut colors_ptr = output_ptr.add(len / 2);

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx2.rs
@@ -15,6 +15,7 @@ static INDCOL_PERMUTE_MASK: [u32; 8] = [0, 4, 2, 6, 1, 5, 3, 7u32];
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86_64")]
 pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
     let alpha_ptr = input_ptr;
     let colors_ptr = alpha_ptr.add(len / 2);
     let indices_ptr = colors_ptr.add(len / 4);
@@ -38,6 +39,7 @@ pub unsafe fn avx2_shuffle_with_components(
     mut colors_ptr: *const u8,
     mut indices_ptr: *const u8,
 ) {
+    debug_assert!(len % 16 == 0);
     // Process 8 blocks (128 bytes) at a time
     let aligned_len = len - (len % 128);
     let alpha_ptr_aligned_end = alpha_ptr.add(aligned_len / 2);

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/sse2.rs
@@ -8,6 +8,7 @@ use std::arch::asm;
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
 pub unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
     // Process 4 blocks (64 bytes) at a time
     let alpha_ptr = input_ptr;
     let colors_ptr = input_ptr.add(len / 2);

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx2.rs
@@ -13,7 +13,7 @@ use super::portable32::u32_with_separate_endpoints;
 /// - len must be divisible by 16 (BC3 block size)
 #[target_feature(enable = "avx2")]
 pub unsafe fn u32_avx2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0, "Length must be a multiple of 16");
+    debug_assert!(len % 16 == 0);
 
     // Process 8 blocks (128 bytes) at a time
     let aligned_len = len - (len % 128);

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/portable.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/portable.rs
@@ -65,6 +65,7 @@ pub unsafe fn u32_detransform_with_separate_pointers(
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
 pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
     const BYTES_PER_ITERATION: usize = 32;
     let aligned_len = len - (len % BYTES_PER_ITERATION);
 
@@ -141,8 +142,8 @@ pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len:
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
 pub unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    const BYTES_PER_ITERATION: usize = 32;
     debug_assert!(len % 16 == 0);
+    const BYTES_PER_ITERATION: usize = 32;
     let aligned_len = len - (len % BYTES_PER_ITERATION);
 
     // Set up input pointers for each section

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/sse2.rs
@@ -13,6 +13,8 @@ use crate::split_blocks::unsplit::portable::u32_detransform_with_separate_pointe
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     // Process as many 64-byte blocks as possible
     let current_output_ptr = output_ptr;
 
@@ -61,6 +63,7 @@ pub unsafe fn u64_detransform_sse2_separate_components(
     mut current_output_ptr: *mut u8,
     len: usize,
 ) {
+    debug_assert!(len % 16 == 0);
     const BYTES_PER_ITERATION: usize = 64;
     let aligned_len = len - (len % BYTES_PER_ITERATION);
     if aligned_len > 0 {
@@ -143,6 +146,8 @@ pub unsafe fn u64_detransform_sse2_separate_components(
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 pub unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
     const BYTES_PER_ITERATION: usize = 64;
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % BYTES_PER_ITERATION);


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->
