### PR TITLE
Style: Inline parameters into format!

### DIFF
--- a/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
@@ -21,14 +21,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     // Try to load the test file
     let file_data = match fs::read(TEST_FILE_PATH) {
         Ok(data) => {
-            println!("Successfully loaded test file: {}", TEST_FILE_PATH);
+            println!("Successfully loaded test file: {TEST_FILE_PATH}");
             data
         }
         Err(_) => {
-            println!(
-                "Warning: Could not load test file '{}'. Exiting.",
-                TEST_FILE_PATH
-            );
+            println!("Warning: Could not load test file '{TEST_FILE_PATH}'. Exiting.");
             return;
         }
     };

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/mod.rs
@@ -114,8 +114,7 @@ mod tests {
             assert_eq!(
                 transformed.as_slice(),
                 reference.as_slice(),
-                "transform_bc1 produced different results than reference for {} blocks",
-                num_blocks
+                "transform_bc1 produced different results than reference for {num_blocks} blocks"
             );
 
             // Test untransform
@@ -127,8 +126,7 @@ mod tests {
             assert_eq!(
                 reconstructed.as_slice(),
                 input.as_slice(),
-                "untransform_bc1 failed to reconstruct original data for {} blocks",
-                num_blocks
+                "untransform_bc1 failed to reconstruct original data for {num_blocks} blocks"
             );
         }
     }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx2.rs
@@ -445,7 +445,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -483,7 +483,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
@@ -94,11 +94,10 @@ pub mod tests {
     ) {
         assert_eq!(
             output_expected, output_test,
-            "{} implementation produced different results than reference for {} blocks.\n\
+            "{impl_name} implementation produced different results than reference for {num_blocks} blocks.\n\
             First differing block will have predictable values:\n\
             Colors: Sequential 0-3 + (block_num * 4)\n\
-            Indices: Sequential 128-131 + (block_num * 4)",
-            impl_name, num_blocks
+            Indices: Sequential 128-131 + (block_num * 4)"
         );
     }
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/portable32.rs
@@ -298,7 +298,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -335,7 +335,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/portable64.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/portable64.rs
@@ -600,7 +600,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -643,7 +643,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/sse2.rs
@@ -333,7 +333,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -373,7 +373,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
@@ -411,7 +411,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 reconstructed.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -451,7 +451,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 &reconstructed[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
@@ -168,11 +168,10 @@ mod tests {
     ) {
         assert_eq!(
             expected, actual,
-            "{} implementation produced different results than reference for {} blocks.\n\
+            "{impl_name} implementation produced different results than reference for {num_blocks} blocks.\n\
             First differing block will have predictable values:\n\
             Colors: Sequential 0-3 + (block_num * 4)\n\
-            Indices: Sequential 128-131 + (block_num * 4)",
-            impl_name, num_blocks
+            Indices: Sequential 128-131 + (block_num * 4)"
         );
     }
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/portable32.rs
@@ -286,7 +286,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 reconstructed.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -326,7 +326,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 &reconstructed[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
@@ -292,7 +292,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 reconstructed.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -334,7 +334,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 &reconstructed[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/mod.rs
@@ -124,8 +124,7 @@ mod tests {
             assert_eq!(
                 transformed.as_slice(),
                 reference.as_slice(),
-                "transform_bc2 produced different results than reference for {} blocks",
-                num_blocks
+                "transform_bc2 produced different results than reference for {num_blocks} blocks"
             );
 
             // Test untransform
@@ -137,8 +136,7 @@ mod tests {
             assert_eq!(
                 reconstructed.as_slice(),
                 input.as_slice(),
-                "untransform_bc2 failed to reconstruct original data for {} blocks",
-                num_blocks
+                "untransform_bc2 failed to reconstruct original data for {num_blocks} blocks"
             );
         }
     }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
@@ -196,7 +196,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -234,7 +234,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
@@ -105,12 +105,11 @@ pub mod tests {
     ) {
         assert_eq!(
             output_expected, output_test,
-            "{} implementation produced different results than reference for {} blocks.\n\
+            "{impl_name} implementation produced different results than reference for {num_blocks} blocks.\n\
             First differing block will have predictable values:\n\
             Alpha: Sequential 0-7 + (block_num * 8)\n\
             Colors: Sequential 0x80-0x83 + (block_num * 4)\n\
-            Indices: Sequential 0xC0-0xC3 + (block_num * 4)",
-            impl_name, num_blocks
+            Indices: Sequential 0xC0-0xC3 + (block_num * 4)"
         );
     }
 

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
@@ -237,7 +237,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -273,7 +273,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/sse2.rs
@@ -410,7 +410,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 output_test.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -447,7 +447,7 @@ mod tests {
             assert_implementation_matches_reference(
                 output_expected.as_slice(),
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -181,12 +181,11 @@ mod tests {
     ) {
         assert_eq!(
             expected, actual,
-            "{} implementation produced different results than reference for {} blocks.\n\
+            "{impl_name} implementation produced different results than reference for {num_blocks} blocks.\n\
             First differing block will have predictable values:\n\
             Alpha: Sequential 0-7 + (block_num * 8)\n\
             Colors: Sequential 128-131 + (block_num * 4)\n\
-            Indices: Sequential 192-195 + (block_num * 4)",
-            impl_name, num_blocks
+            Indices: Sequential 192-195 + (block_num * 4)"
         );
     }
 

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/mod.rs
@@ -127,8 +127,7 @@ mod tests {
             assert_eq!(
                 transformed.as_slice(),
                 reference.as_slice(),
-                "transform_bc3 produced different results than reference for {} blocks",
-                num_blocks
+                "transform_bc3 produced different results than reference for {num_blocks} blocks"
             );
 
             // Test untransform
@@ -140,8 +139,7 @@ mod tests {
             assert_eq!(
                 reconstructed.as_slice(),
                 input.as_slice(),
-                "untransform_bc3 failed to reconstruct original data for {} blocks",
-                num_blocks
+                "untransform_bc3 failed to reconstruct original data for {num_blocks} blocks"
             );
         }
     }

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/split/mod.rs
@@ -75,13 +75,12 @@ pub mod tests {
     ) {
         assert_eq!(
             expected, actual,
-            "BC3 {} implementation produced different results than reference for {} blocks.\n\
+            "BC3 {impl_name} implementation produced different results than reference for {num_blocks} blocks.\n\
             First differing block will have predictable values:\n\
             Alpha: Sequential 00-31\n\
             Alpha Indices: Sequential 32-127\n\
             Colors: Sequential 128-191\n\
-            Indices: Sequential 192-255",
-            impl_name, num_blocks
+            Indices: Sequential 192-255"
         );
     }
 

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
@@ -148,13 +148,12 @@ mod tests {
     ) {
         assert_eq!(
             expected, actual,
-            "{} implementation produced different results than reference for {} blocks.\n\
+            "{impl_name} implementation produced different results than reference for {num_blocks} blocks.\n\
             First differing block will have predictable values:\n\
             Alpha bytes: Sequential 0-1 + (block_num * 2)\n\
             Alpha bits: Sequential 32-37 + (block_num * 6)\n\
             Colors: Sequential 128-131 + (block_num * 4)\n\
-            Indices: Sequential 192-195 + (block_num * 4)",
-            impl_name, num_blocks
+            Indices: Sequential 192-195 + (block_num * 4)"
         );
     }
 

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/portable.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/portable.rs
@@ -259,7 +259,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 reconstructed.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -298,7 +298,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 &reconstructed[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/sse2.rs
@@ -295,7 +295,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 reconstructed.as_slice(),
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_blocks,
             );
         }
@@ -333,7 +333,7 @@ mod tests {
             assert_implementation_matches_reference(
                 original.as_slice(),
                 &reconstructed[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_blocks,
             );
         }

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
@@ -77,10 +77,7 @@ fn validate_normalize(cmd: ValidateCommand) -> Result<(), TransformError> {
         }
     }
 
-    println!(
-        "Validation complete: {} succeeded, {} failed",
-        success_count, failure_count
-    );
+    println!("Validation complete: {success_count} succeeded, {failure_count} failed");
 
     Ok(())
 }

--- a/projects/dxt-lossless-transform-cli/src/error.rs
+++ b/projects/dxt-lossless-transform-cli/src/error.rs
@@ -26,10 +26,10 @@ impl From<StripPrefixError> for TransformError {
 impl std::fmt::Display for TransformError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TransformError::IoError(e) => write!(f, "{}", e),
-            TransformError::PathError(e) => write!(f, "{}", e),
-            TransformError::MmapError(e) => write!(f, "{}", e),
-            TransformError::UnsupportedFormat(e) => write!(f, "Unsupported DDS format, {}", e),
+            TransformError::IoError(e) => write!(f, "{e}"),
+            TransformError::PathError(e) => write!(f, "{e}"),
+            TransformError::MmapError(e) => write!(f, "{e}"),
+            TransformError::UnsupportedFormat(e) => write!(f, "Unsupported DDS format, {e}"),
             TransformError::InvalidDdsFile => write!(f, "Invalid DDS file"),
             TransformError::IgnoredByFilter => write!(f, "File was skipped by filter"),
         }

--- a/projects/dxt-lossless-transform-cli/src/main.rs
+++ b/projects/dxt-lossless-transform-cli/src/main.rs
@@ -42,8 +42,7 @@ impl FromStr for DdsFilter {
             "bc7" => Ok(DdsFilter::BC7),
             "all" => Ok(DdsFilter::All),
             _ => Err(format!(
-                "Invalid DDS type: {}. Valid types are: bc1, bc2, bc3, bc7, all",
-                s
+                "Invalid DDS type: {s}. Valid types are: bc1, bc2, bc3, bc7, all"
             )),
         }
     }
@@ -106,11 +105,11 @@ fn canonicalize_cli_path(value: &str) -> Result<PathBuf, String> {
 
     // If path doesn't exist, create it
     if !path.exists() {
-        fs::create_dir_all(path).map_err(|e| format!("Failed to create directory: {}", e))?;
+        fs::create_dir_all(path).map_err(|e| format!("Failed to create directory: {e}"))?;
     }
 
     // Now we can canonicalize it
-    fs::canonicalize(path).map_err(|e| format!("Invalid path: {}", e))
+    fs::canonicalize(path).map_err(|e| format!("Invalid path: {e}"))
 }
 
 fn main() -> Result<(), Box<dyn Error>> {
@@ -208,7 +207,7 @@ fn handle_process_entry_error(result: Result<(), TransformError>) {
     if let Err(e) = result {
         match e {
             TransformError::IgnoredByFilter => (),
-            _ => eprintln!("{}", e),
+            _ => eprintln!("{e}"),
         }
     }
 }

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -485,9 +485,7 @@ mod tests {
             assert_eq!(
                 color.raw_value(),
                 original_color.raw_value(),
-                "{:?} - Color at index {} failed to restore.",
-                variant,
-                x
+                "{variant:?} - Color at index {x} failed to restore."
             );
         }
     }
@@ -507,8 +505,7 @@ mod tests {
         assert_ne!(
             transformed.raw_value(),
             original.raw_value(),
-            "{:?} - Color should change after decorrelation",
-            variant
+            "{variant:?} - Color should change after decorrelation"
         );
 
         // Recorrelate
@@ -516,8 +513,7 @@ mod tests {
         assert_eq!(
             transformed.raw_value(),
             original.raw_value(),
-            "{:?} - Color should be restored after recorrelation",
-            variant
+            "{variant:?} - Color should be restored after recorrelation"
         );
     }
 }

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx2.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx2.rs
@@ -365,7 +365,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test,
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_pairs,
             );
         }
@@ -406,7 +406,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_pairs,
             );
         }

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/mod.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/mod.rs
@@ -167,11 +167,10 @@ mod tests {
     ) {
         assert_eq!(
             output_expected, output_test,
-            "{} implementation produced different results than reference for {} color pairs.\n\
+            "{impl_name} implementation produced different results than reference for {num_pairs} color pairs.\n\
             First differing pair will have predictable values:\n\
             Color0: Sequential bytes 0x00,0x01 + (pair_num * 4)\n\
-            Color1: Sequential bytes 0x80,0x81 + (pair_num * 4)",
-            impl_name, num_pairs
+            Color1: Sequential bytes 0x80,0x81 + (pair_num * 4)"
         );
     }
 

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/portable64.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/portable64.rs
@@ -722,7 +722,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test,
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_pairs,
             );
         }
@@ -767,7 +767,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_pairs,
             );
         }

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/sse2.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/sse2.rs
@@ -427,7 +427,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test,
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_pairs,
             );
         }
@@ -469,7 +469,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_pairs,
             );
         }

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/ssse3.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/ssse3.rs
@@ -219,7 +219,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test,
-                &format!("{} (aligned)", impl_name),
+                &format!("{impl_name} (aligned)"),
                 num_pairs,
             );
         }
@@ -259,7 +259,7 @@ mod tests {
             assert_implementation_matches_reference(
                 &output_expected,
                 &output_test[1..],
-                &format!("{} (unaligned)", impl_name),
+                &format!("{impl_name} (unaligned)"),
                 num_pairs,
             );
         }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all user-facing and test output messages to use modern Rust inline string formatting for improved readability and consistency.
- **Tests**
  - Refined assertion and test case messages to adopt the new formatting style, enhancing clarity of error and test output messages.
- **Bug Fixes**
  - None.
- **New Features**
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->