### PR TITLE
Added: AVX512 Support to Nightly

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,21 +18,24 @@ jobs:
       matrix:
         include:
           # Common Linux Targets
-          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false }
-          - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-cross: false }
-          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-cross: true }
-          - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-cross: true }
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, rust-toolchain: 'stable' }
+          - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-cross: false, rust-toolchain: 'stable' }
+          - { os: ubuntu-latest, target: aarch64-unknown-linux-gnu, use-cross: true, rust-toolchain: 'stable' }
+          - { os: ubuntu-latest, target: armv7-unknown-linux-gnueabihf, use-cross: true, rust-toolchain: 'stable' }
           # Common Windows Targets
-          - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false }
-          - { os: windows-latest, target: i686-pc-windows-msvc, use-cross: false }
+          - { os: windows-latest, target: x86_64-pc-windows-msvc, use-cross: false, rust-toolchain: 'stable' }
+          - { os: windows-latest, target: i686-pc-windows-msvc, use-cross: false, rust-toolchain: 'stable' }
           # - { os: windows-latest, target: aarch64-pc-windows-msvc, use-cross: true }
           # Common Apple Targets
-          - { os: macos-13, target: x86_64-apple-darwin, use-cross: false }
-          - { os: macos-14, target: aarch64-apple-darwin, use-cross: false }
+          - { os: macos-13, target: x86_64-apple-darwin, use-cross: false, rust-toolchain: 'stable' }
+          - { os: macos-14, target: aarch64-apple-darwin, use-cross: false, rust-toolchain: 'stable' }
           # Big Endian (64-bit)
-          - { os: ubuntu-latest, target: powerpc64-unknown-linux-gnu, use-cross: true }
+          - { os: ubuntu-latest, target: powerpc64-unknown-linux-gnu, use-cross: true, rust-toolchain: 'stable' }
           # Big Endian (32-bit)
-          - { os: ubuntu-latest, target: powerpc-unknown-linux-gnu, use-cross: true }
+          - { os: ubuntu-latest, target: powerpc-unknown-linux-gnu, use-cross: true, rust-toolchain: 'stable' }
+          # Nightly features (AVX512)
+          - { os: ubuntu-latest, target: x86_64-unknown-linux-gnu, use-cross: false, features: "nightly", rust-toolchain: 'nightly' }
+          - { os: ubuntu-latest, target: i686-unknown-linux-gnu, use-cross: false, features: "nightly", rust-toolchain: 'nightly' }
 
     runs-on: ${{ matrix.os }}
 
@@ -45,6 +48,8 @@ jobs:
           target: ${{ matrix.target }}
           use-cross: ${{ matrix.use-cross }}
           codecov-token: ${{ secrets.CODECOV_TOKEN }}
+          features: ${{ matrix.features }}
+          rust-toolchain: ${{ matrix.rust-toolchain }}
 
       # Uncomment after first release.
       # - name: Check semver

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "coverage-gutters.coverageFileNames": [
         "cobertura.xml"
     ],
-    "lldb.displayFormat": "hex",
+    "lldb.displayFormat": "auto",
     "lldb.showDisassembly": "auto",
     "lldb.dereferencePointers": true,
     "lldb.consoleMode": "commands",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
     "coverage-gutters.coverageFileNames": [
         "cobertura.xml"
     ],
-    "lldb.displayFormat": "auto",
+    "lldb.displayFormat": "hex",
     "lldb.showDisassembly": "auto",
     "lldb.dereferencePointers": true,
     "lldb.consoleMode": "commands",

--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -15,6 +15,8 @@ std = []
 pgo = []
 # Use CPU features selected at compile time.
 no-runtime-cpu-detection = []
+# Use nightly compiler features
+nightly = []
 
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }

--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -15,7 +15,7 @@ std = []
 pgo = []
 # Use CPU features selected at compile time.
 no-runtime-cpu-detection = []
-# Use nightly compiler features
+# Use nightly compiler features (AVX512)
 nightly = []
 
 [dependencies]

--- a/projects/dxt-lossless-transform-bc1/benches/split_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/split_blocks/avx512.rs
@@ -16,6 +16,16 @@ fn bench_avx512_permute_unroll_2(
     });
 }
 
+fn bench_avx512_permute(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        permute_512(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
 pub(crate) fn run_benchmarks(
     group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
     input: &RawAlloc,
@@ -23,6 +33,10 @@ pub(crate) fn run_benchmarks(
     size: usize,
     important_benches_only: bool,
 ) {
+    group.bench_with_input(BenchmarkId::new("avx512 permute", size), &size, |b, _| {
+        bench_avx512_permute(b, input, output)
+    });
+
     group.bench_with_input(
         BenchmarkId::new("avx512 permute unroll 2", size),
         &size,

--- a/projects/dxt-lossless-transform-bc1/benches/split_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/split_blocks/avx512.rs
@@ -1,0 +1,33 @@
+use criterion::{black_box, BenchmarkId};
+use dxt_lossless_transform_bc1::split_blocks::split::*;
+use safe_allocator_api::RawAlloc;
+
+fn bench_avx512_permute_unroll_2(
+    b: &mut criterion::Bencher,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+) {
+    b.iter(|| unsafe {
+        permute_512_unroll_2(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    important_benches_only: bool,
+) {
+    group.bench_with_input(
+        BenchmarkId::new("avx512 permute unroll 2", size),
+        &size,
+        |b, _| bench_avx512_permute_unroll_2(b, input, output),
+    );
+
+    if !important_benches_only {}
+}

--- a/projects/dxt-lossless-transform-bc1/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/split_blocks/main.rs
@@ -29,8 +29,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let important_benches_only = true; // Set to false to enable extra benches, unrolls, etc.
 
     group.throughput(criterion::Throughput::Bytes(size as u64));
-    //group.warm_up_time(Duration::from_secs(60));
-    group.measurement_time(Duration::from_secs(10));
+    group.warm_up_time(Duration::from_secs(60));
+    group.measurement_time(Duration::from_secs(60));
 
     // Run architecture-specific benchmarks
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]

--- a/projects/dxt-lossless-transform-bc1/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/split_blocks/main.rs
@@ -56,7 +56,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
 
         #[cfg(feature = "nightly")]
-        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+        if is_x86_feature_detected!("avx512f") {
             avx512::run_benchmarks(
                 &mut group,
                 &input,

--- a/projects/dxt-lossless-transform-bc1/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/split_blocks/main.rs
@@ -12,6 +12,10 @@ mod portable64;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod sse2;
 
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod avx512;
+
 pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
     let layout = Layout::from_size_align(num_bytes, 64).unwrap();
     RawAlloc::new(layout).unwrap()
@@ -25,8 +29,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let important_benches_only = true; // Set to false to enable extra benches, unrolls, etc.
 
     group.throughput(criterion::Throughput::Bytes(size as u64));
-    group.warm_up_time(Duration::from_secs(60));
-    group.measurement_time(Duration::from_secs(60));
+    //group.warm_up_time(Duration::from_secs(60));
+    group.measurement_time(Duration::from_secs(10));
 
     // Run architecture-specific benchmarks
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -43,6 +47,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        #[cfg(feature = "nightly")]
+        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-bc1/benches/unsplit_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/unsplit_blocks/avx512.rs
@@ -1,0 +1,27 @@
+use criterion::*;
+use dxt_lossless_transform_bc1::split_blocks::unsplit::avx512::*;
+use safe_allocator_api::RawAlloc;
+
+fn bench_permute_512_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        permute_512_detransform_unroll_2(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    _important_benches_only: bool,
+) {
+    group.bench_with_input(
+        BenchmarkId::new("avx512 permute unroll 2", size),
+        &size,
+        |b, _| bench_permute_512_unroll_2(b, input, output),
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/benches/unsplit_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/unsplit_blocks/main.rs
@@ -12,6 +12,10 @@ mod portable64;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod sse2;
 
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod avx512;
+
 pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
     let layout = Layout::from_size_align(num_bytes, 64).unwrap();
     RawAlloc::new(layout).unwrap()
@@ -43,6 +47,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-bc1/benches/unsplit_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/unsplit_blocks/main.rs
@@ -56,7 +56,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
 
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+        if cfg!(target_feature = "avx512f") {
             avx512::run_benchmarks(
                 &mut group,
                 &input,

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
+#![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 use core::alloc::Layout;
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::split::portable32::u32_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
@@ -1,5 +1,11 @@
 use crate::split_blocks::split::portable32::u32_with_separate_pointers;
-use core::arch::{asm, x86_64::*};
+use core::arch::*;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
 
 // Byte indices for vpermt2d to gather color pairs (dword elements 0, 2, 4, ..., 14 from src1 and src2)
 const PERM_COLORS_BYTES: [i8; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
@@ -19,6 +19,83 @@ const PERM_INDICES_BYTES: [i8; 16] = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)] // no feature for 512
 #[target_feature(enable = "avx512f")]
+pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
+    let aligned_len = len - (len % 128);
+
+    let mut indices_ptr = output_ptr.add(len / 2);
+    if aligned_len > 0 {
+        let aligned_end_input = input_ptr.add(aligned_len);
+
+        // Load permutation patterns using vpmovsxbd (sign-extend bytes to dwords)
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        unsafe {
+            asm!(
+
+                // Align the loop's instruction address to 32 bytes.
+                // This isn't strictly needed, but more modern processors fetch + execute instructions in
+                // 32-byte chunks, as opposed to older ones in 16-byte chunks. Therefore, we can safely-ish
+                // assume a processor with AVX512 will be one of those.
+                ".p2align 5",
+                "2:",
+
+                // Load all 256 bytes first to utilize memory pipeline
+                "vmovdqu64 {zmm2}, [{src_ptr}]",
+                "vmovdqu64 {zmm3}, [{src_ptr} + 64]",
+                "add {src_ptr}, 128",
+
+                // Do all permutations together to utilize shuffle units (vpermt2d)
+                "vmovdqa64 {zmm6}, {zmm2}", // Preserve zmm2 for index permutation
+                "vpermt2d {zmm6}, {perm_colors}, {zmm3}", // colors from zmm2/zmm3
+                "vpermt2d {zmm2}, {perm_indices}, {zmm3}", // indices from zmm2/zmm3
+
+                // Store all results together to utilize store pipeline
+                "vmovdqu64 [{colors_ptr}], {zmm6}",
+                "add {colors_ptr}, 64",
+
+                "vmovdqu64 [{indices_ptr}], {zmm2}",
+                "add {indices_ptr}, 64",
+
+                // Compare against end address and loop if not done
+                "cmp {src_ptr}, {end_ptr}",
+                "jb 2b",
+
+                src_ptr = inout(reg) input_ptr,
+                colors_ptr = inout(reg) output_ptr,
+                indices_ptr = inout(reg) indices_ptr,
+                end_ptr = in(reg) aligned_end_input,
+                perm_colors = in(zmm_reg) perm_colors,
+                perm_indices = in(zmm_reg) perm_indices,
+                zmm2 = out(zmm_reg) _,
+                zmm3 = out(zmm_reg) _,
+                zmm6 = out(zmm_reg) _,
+                options(nostack, preserves_flags)
+            );
+        }
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            output_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[allow(unused_assignments)] // no feature for 512
+#[target_feature(enable = "avx512f")]
 pub unsafe fn permute_512_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     let aligned_len = len - (len % 256);
@@ -114,6 +191,7 @@ mod tests {
     type PermuteFn = unsafe fn(*const u8, *mut u8, usize);
 
     #[rstest]
+    #[case(permute_512, "avx512 permute")]
     #[case(permute_512_unroll_2, "avx512 permute unroll 2")]
     fn test_avx512_aligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
         if !is_x86_feature_detected!("avx512f") {
@@ -153,6 +231,7 @@ mod tests {
     }
 
     #[rstest]
+    #[case(permute_512, "avx512 permute")]
     #[case(permute_512_unroll_2, "avx512 permute unroll 2")]
     fn test_avx512_unaligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
         if !is_x86_feature_detected!("avx512f") {

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
@@ -19,7 +19,6 @@ const PERM_INDICES_BYTES: [i8; 16] = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)] // no feature for 512
 #[target_feature(enable = "avx512f")]
-#[target_feature(enable = "avx512vl")]
 pub unsafe fn permute_512_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     let aligned_len = len - (len % 256);

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
@@ -1,0 +1,177 @@
+use crate::split_blocks::split::portable32::u32_with_separate_pointers;
+use core::arch::{asm, x86_64::*};
+
+// Byte indices for vpermt2d to gather color pairs (dword elements 0, 2, 4, ..., 14 from src1 and src2)
+const PERM_COLORS_BYTES: [i8; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+
+// Byte indices for vpermt2d to gather index dwords (dword elements 1, 3, 5, ..., 15 from src1 and src2)
+const PERM_INDICES_BYTES: [i8; 16] = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31];
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[allow(unused_assignments)] // no feature for 512
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vl")]
+pub unsafe fn permute_512_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 8 == 0);
+    let aligned_len = len - (len % 256);
+
+    let mut indices_ptr = output_ptr.add(len / 2);
+    if aligned_len > 0 {
+        let aligned_end_input = input_ptr.add(aligned_len);
+
+        // Load permutation patterns using vpmovsxbd (sign-extend bytes to dwords)
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        unsafe {
+            asm!(
+
+                // Align the loop's instruction address to 32 bytes.
+                // This isn't strictly needed, but more modern processors fetch + execute instructions in
+                // 32-byte chunks, as opposed to older ones in 16-byte chunks. Therefore, we can safely-ish
+                // assume a processor with AVX512 will be one of those.
+                ".p2align 5",
+                "2:",
+
+                // Load all 256 bytes first to utilize memory pipeline
+                "vmovdqu64 {zmm2}, [{src_ptr}]",
+                "vmovdqu64 {zmm3}, [{src_ptr} + 64]",
+                "vmovdqu64 {zmm4}, [{src_ptr} + 128]",
+                "vmovdqu64 {zmm5}, [{src_ptr} + 192]",
+                "add {src_ptr}, 256",
+
+                // Do all permutations together to utilize shuffle units (vpermt2d)
+                "vmovdqa64 {zmm6}, {zmm2}", // Preserve zmm2 for index permutation
+                "vpermt2d {zmm6}, {perm_colors}, {zmm3}", // colors from zmm2/zmm3
+                "vpermt2d {zmm2}, {perm_indices}, {zmm3}", // indices from zmm2/zmm3
+
+                "vmovdqa64 {zmm3}, {zmm4}", // Preserve zmm4 for index permutation, reuse zmm3
+                "vpermt2d {zmm3}, {perm_colors}, {zmm5}", // colors from zmm4/zmm5
+                "vpermt2d {zmm4}, {perm_indices}, {zmm5}", // indices from zmm4/zmm5
+
+                // Store all results together to utilize store pipeline
+                "vmovdqu64 [{colors_ptr}], {zmm6}",
+                "vmovdqu64 [{colors_ptr} + 64], {zmm3}",
+                "add {colors_ptr}, 128",
+
+                "vmovdqu64 [{indices_ptr}], {zmm2}",
+                "vmovdqu64 [{indices_ptr} + 64], {zmm4}",
+                "add {indices_ptr}, 128",
+
+                // Compare against end address and loop if not done
+                "cmp {src_ptr}, {end_ptr}",
+                "jb 2b",
+
+                src_ptr = inout(reg) input_ptr,
+                colors_ptr = inout(reg) output_ptr,
+                indices_ptr = inout(reg) indices_ptr,
+                end_ptr = in(reg) aligned_end_input,
+                perm_colors = in(zmm_reg) perm_colors,
+                perm_indices = in(zmm_reg) perm_indices,
+                zmm2 = out(zmm_reg) _,
+                zmm3 = out(zmm_reg) _,
+                zmm4 = out(zmm_reg) _,
+                zmm5 = out(zmm_reg) _,
+                zmm6 = out(zmm_reg) _,
+                options(nostack, preserves_flags)
+            );
+        }
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            output_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split_blocks::split::tests::{
+        assert_implementation_matches_reference, generate_bc1_test_data,
+        transform_with_reference_implementation,
+    };
+    use crate::testutils::allocate_align_64;
+    use core::ptr::copy_nonoverlapping;
+    use rstest::rstest;
+
+    type PermuteFn = unsafe fn(*const u8, *mut u8, usize);
+
+    #[rstest]
+    #[case(permute_512_unroll_2, "avx512 permute unroll 2")]
+    fn test_avx512_aligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
+        for num_blocks in 1..=512 {
+            let mut input = allocate_align_64(num_blocks * 8);
+            let mut output_expected = allocate_align_64(input.len());
+            let mut output_test = allocate_align_64(input.len());
+
+            unsafe {
+                copy_nonoverlapping(
+                    generate_bc1_test_data(num_blocks).as_ptr(),
+                    input.as_mut_ptr(),
+                    input.len(),
+                );
+            }
+
+            transform_with_reference_implementation(
+                input.as_slice(),
+                output_expected.as_mut_slice(),
+            );
+
+            output_test.as_mut_slice().fill(0);
+            unsafe {
+                permute_fn(input.as_ptr(), output_test.as_mut_ptr(), input.len());
+            }
+
+            assert_implementation_matches_reference(
+                output_expected.as_slice(),
+                output_test.as_slice(),
+                &format!("{impl_name} (aligned)"),
+                num_blocks,
+            );
+        }
+    }
+
+    #[rstest]
+    #[case(permute_512_unroll_2, "avx512 permute unroll 2")]
+    fn test_avx512_unaligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
+        for num_blocks in 1..=512 {
+            let input = generate_bc1_test_data(num_blocks);
+
+            let mut input_unaligned = vec![0u8; input.len() + 1];
+            input_unaligned[1..].copy_from_slice(input.as_slice());
+
+            let mut output_expected = vec![0u8; input.len()];
+            let mut output_test = vec![0u8; input.len() + 1];
+
+            transform_with_reference_implementation(input.as_slice(), &mut output_expected);
+
+            output_test.as_mut_slice().fill(0);
+            unsafe {
+                permute_fn(
+                    input_unaligned.as_ptr().add(1),
+                    output_test.as_mut_ptr().add(1),
+                    input.len(),
+                );
+            }
+
+            assert_implementation_matches_reference(
+                output_expected.as_slice(),
+                &output_test[1..],
+                &format!("{impl_name} (unaligned)"),
+                num_blocks,
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/avx512.rs
@@ -116,6 +116,10 @@ mod tests {
     #[rstest]
     #[case(permute_512_unroll_2, "avx512 permute unroll 2")]
     fn test_avx512_aligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512f") {
+            return;
+        }
+
         for num_blocks in 1..=512 {
             let mut input = allocate_align_64(num_blocks * 8);
             let mut output_expected = allocate_align_64(input.len());
@@ -151,6 +155,10 @@ mod tests {
     #[rstest]
     #[case(permute_512_unroll_2, "avx512 permute unroll 2")]
     fn test_avx512_unaligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512f") {
+            return;
+        }
+
         for num_blocks in 1..=512 {
             let input = generate_bc1_test_data(num_blocks);
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
@@ -31,7 +31,7 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
     {
         // Runtime feature detection
         #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+        if std::is_x86_feature_detected!("avx512f") {
             permute_512_unroll_2(input_ptr, output_ptr, len);
             return;
         }
@@ -50,7 +50,7 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+        if cfg!(target_feature = "avx512f") {
             permute_512_unroll_2(input_ptr, output_ptr, len);
             return;
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
@@ -32,7 +32,7 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
         // Runtime feature detection
         #[cfg(feature = "nightly")]
         if std::is_x86_feature_detected!("avx512f") {
-            permute_512_unroll_2(input_ptr, output_ptr, len);
+            permute_512(input_ptr, output_ptr, len);
             return;
         }
 
@@ -51,7 +51,7 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
     {
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") {
-            permute_512_unroll_2(input_ptr, output_ptr, len);
+            permute_512(input_ptr, output_ptr, len);
             return;
         }
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/mod.rs
@@ -30,6 +30,12 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         // Runtime feature detection
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+            permute_512_unroll_2(input_ptr, output_ptr, len);
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             shuffle_permute_unroll_2(input_ptr, output_ptr, len);
             return;
@@ -39,16 +45,16 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
             shufps_unroll_4(input_ptr, output_ptr, len);
             return;
         }
-
-        #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
-            permute_512_unroll_2(input_ptr, output_ptr, len);
-            return;
-        }
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+            permute_512_unroll_2(input_ptr, output_ptr, len);
+            return;
+        }
+
         if cfg!(target_feature = "avx2") {
             shuffle_permute_unroll_2(input_ptr, output_ptr, len);
             return;
@@ -56,12 +62,6 @@ unsafe fn split_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 
         if cfg!(target_feature = "sse2") {
             shufps_unroll_4(input_ptr, output_ptr, len);
-            return;
-        }
-
-        #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
-            permute_512_unroll_2(input_ptr, output_ptr, len);
             return;
         }
     }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/split/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/split/sse2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::split::portable32::u32_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx2.rs
@@ -1,5 +1,5 @@
 use super::u32_detransform_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
@@ -13,7 +13,6 @@ use core::arch::x86::*;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
-#[target_feature(enable = "avx512vl")]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn permute_512_detransform_unroll_2(
     input_ptr: *const u8,
@@ -35,7 +34,6 @@ pub unsafe fn permute_512_detransform_unroll_2(
 /// - colors_ptr must be valid for reads of len/2 bytes
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
-#[target_feature(enable = "avx512vl")]
 #[target_feature(enable = "avx512f")]
 pub unsafe fn permute_512_detransform_unroll_2_with_components(
     mut output_ptr: *mut u8,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
@@ -132,7 +132,11 @@ mod tests {
 
     #[rstest]
     #[case(permute_512_detransform_unroll_2, "avx512_permute_unroll_2")]
-    fn test_avx2_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+    fn test_avx512_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        if !cfg!(target_feature = "avx512f") {
+            return;
+        }
+
         for num_blocks in 1..=512 {
             let original = generate_bc1_test_data(num_blocks);
             let mut transformed = allocate_align_64(original.len());
@@ -162,7 +166,11 @@ mod tests {
 
     #[rstest]
     #[case(permute_512_detransform_unroll_2, "avx512_permute_unroll_2")]
-    fn test_avx2_unaligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+    fn test_avx512_unaligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        if !cfg!(target_feature = "avx512f") {
+            return;
+        }
+
         for num_blocks in 1..=512 {
             let original = generate_bc1_test_data(num_blocks);
 

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
@@ -1,0 +1,195 @@
+use super::u32_detransform_with_separate_pointers;
+use core::arch::{asm, x86_64::*};
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[allow(unused_assignments)]
+#[cfg(feature = "nightly")]
+#[target_feature(enable = "avx512vl")]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn permute_512_detransform_unroll_2(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 8 == 0);
+    // Process as many 128-byte blocks as possible
+    let indices_ptr = input_ptr.add(len / 2);
+    let colors_ptr = input_ptr;
+
+    permute_512_detransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
+}
+
+/// # Safety
+///
+/// - output_ptr must be valid for writes of len bytes
+/// - indices_ptr must be valid for reads of len/2 bytes
+/// - colors_ptr must be valid for reads of len/2 bytes
+#[allow(unused_assignments)]
+#[cfg(feature = "nightly")]
+#[target_feature(enable = "avx512vl")]
+#[target_feature(enable = "avx512f")]
+pub unsafe fn permute_512_detransform_unroll_2_with_components(
+    mut output_ptr: *mut u8,
+    len: usize,
+    mut indices_ptr: *const u8,
+    mut colors_ptr: *const u8,
+) {
+    debug_assert!(len % 8 == 0, "len must be divisible by 8");
+    let aligned_len = len - (len % 256);
+    let colors_aligned_end = colors_ptr.add(aligned_len / 2);
+
+    if aligned_len > 0 {
+        // Define permutation constants for vpermt2d
+        // For gathering low dwords (0,16,1,17,etc.)
+        const PERM_LOW_BYTES: [i8; 16] = [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23];
+        // For gathering high dwords (8,24,9,25,etc.)
+        const PERM_HIGH_BYTES: [i8; 16] =
+            [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31];
+
+        // Load permutation patterns using vpmovsxbd (sign-extend bytes to dwords)
+        let perm_low = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_LOW_BYTES.as_ptr() as *const _));
+        let perm_high = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_HIGH_BYTES.as_ptr() as *const _));
+
+        unsafe {
+            asm!(
+                // Align the loop's instruction address to 32 bytes
+                ".p2align 5",
+                "2:",
+
+                // Load colors and indices
+                "vmovdqu64 {zmm4}, [{colors_ptr}]",             // First colors block
+                "vmovdqu64 {zmm5}, [{colors_ptr} + 64]",        // Second colors block
+                "add {colors_ptr}, 128",
+                "vmovdqu64 {zmm3}, [{indices_ptr}]",            // First indices block
+                "vmovdqu64 {zmm2}, [{indices_ptr} + 64]",       // Second indices block
+                "add {indices_ptr}, 128",
+
+                // Apply permutations
+                "vmovdqa64 {zmm6}, {zmm4}",                     // Copy colors for first permutation
+                "vpermt2d {zmm6}, {perm_low}, {zmm3}",          // Permute with low pattern - using zmm3 (first indices block)
+                "vpermt2d {zmm4}, {perm_high}, {zmm3}",         // Permute with high pattern - using zmm3 (first indices block)
+
+                "vmovdqa64 {zmm3}, {zmm5}",                     // Copy colors for second permutation - reusing zmm3
+                "vpermt2d {zmm3}, {perm_low}, {zmm2}",          // Permute with low pattern - using zmm2 (second indices block)
+                "vpermt2d {zmm5}, {perm_high}, {zmm2}",         // Permute with high pattern - using zmm2 (second indices block)
+
+                // Store results
+                "vmovdqu64 [{dst_ptr}], {zmm6}",                // Store first low part
+                "vmovdqu64 [{dst_ptr} + 64], {zmm4}",           // Store first high part
+                "vmovdqu64 [{dst_ptr} + 128], {zmm3}",          // Store second low part
+                "vmovdqu64 [{dst_ptr} + 192], {zmm5}",          // Store second high part
+
+                // Update pointer and loop.
+                "add {dst_ptr}, 256",
+                "cmp {colors_ptr}, {end}",
+                "jb 2b",
+
+                colors_ptr = inout(reg) colors_ptr,
+                indices_ptr = inout(reg) indices_ptr,
+                dst_ptr = inout(reg) output_ptr,
+                end = in(reg) colors_aligned_end,
+                perm_low = in(zmm_reg) perm_low,
+                perm_high = in(zmm_reg) perm_high,
+                zmm2 = out(zmm_reg) _,
+                zmm3 = out(zmm_reg) _,
+                zmm4 = out(zmm_reg) _,
+                zmm5 = out(zmm_reg) _,
+                zmm6 = out(zmm_reg) _,
+                options(nostack)
+            );
+        }
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_detransform_with_separate_pointers(
+            colors_ptr as *const u32,
+            indices_ptr as *const u32,
+            output_ptr,
+            remaining,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split_blocks::split::tests::generate_bc1_test_data;
+    use crate::split_blocks::split::u32;
+    use crate::split_blocks::unsplit::tests::assert_implementation_matches_reference;
+    use crate::testutils::allocate_align_64;
+    use rstest::rstest;
+
+    type DetransformFn = unsafe fn(*const u8, *mut u8, usize);
+
+    #[rstest]
+    #[case(permute_512_detransform_unroll_2, "avx512_permute_unroll_2")]
+    fn test_avx2_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        for num_blocks in 1..=512 {
+            let original = generate_bc1_test_data(num_blocks);
+            let mut transformed = allocate_align_64(original.len());
+            let mut reconstructed = allocate_align_64(original.len());
+
+            unsafe {
+                // Transform using standard implementation
+                u32(original.as_ptr(), transformed.as_mut_ptr(), original.len());
+
+                // Reconstruct using the implementation being tested
+                reconstructed.as_mut_slice().fill(0);
+                detransform_fn(
+                    transformed.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    transformed.len(),
+                );
+            }
+
+            assert_implementation_matches_reference(
+                original.as_slice(),
+                reconstructed.as_slice(),
+                &format!("{impl_name} (aligned)"),
+                num_blocks,
+            );
+        }
+    }
+
+    #[rstest]
+    #[case(permute_512_detransform_unroll_2, "avx512_permute_unroll_2")]
+    fn test_avx2_unaligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        for num_blocks in 1..=512 {
+            let original = generate_bc1_test_data(num_blocks);
+
+            // Transform using standard implementation
+            let mut transformed = vec![0u8; original.len()];
+            unsafe {
+                u32(original.as_ptr(), transformed.as_mut_ptr(), original.len());
+            }
+
+            // Add 1 extra byte at the beginning to create misaligned buffers
+            let mut transformed_unaligned = vec![0u8; transformed.len() + 1];
+            transformed_unaligned[1..].copy_from_slice(&transformed);
+
+            let mut reconstructed = vec![0u8; original.len() + 1];
+
+            unsafe {
+                // Reconstruct using the implementation being tested with unaligned pointers
+                reconstructed.as_mut_slice().fill(0);
+                detransform_fn(
+                    transformed_unaligned.as_ptr().add(1),
+                    reconstructed.as_mut_ptr().add(1),
+                    transformed.len(),
+                );
+            }
+
+            assert_implementation_matches_reference(
+                original.as_slice(),
+                &reconstructed[1..],
+                &format!("{impl_name} (unaligned)"),
+                num_blocks,
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/avx512.rs
@@ -1,5 +1,11 @@
 use super::u32_detransform_with_separate_pointers;
-use core::arch::{asm, x86_64::*};
+use core::arch::asm;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
@@ -21,7 +21,7 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+        if std::is_x86_feature_detected!("avx512f") {
             avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
@@ -40,7 +40,7 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+        if cfg!(target_feature = "avx512f") {
             avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
@@ -95,7 +95,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+        if std::is_x86_feature_detected!("avx512f") {
             avx512::permute_512_detransform_unroll_2_with_components(
                 output_ptr,
                 len,
@@ -129,7 +129,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+        if cfg!(target_feature = "avx512f") {
             avx512::permute_512_detransform_unroll_2_with_components(
                 output_ptr,
                 len,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
@@ -20,6 +20,12 @@ pub use avx512::*;
 unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+            avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             avx2::permd_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
@@ -29,16 +35,16 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
             sse2::unpck_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
-
-        #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
-            avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
-            return;
-        }
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+            avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
+            return;
+        }
+
         if cfg!(target_feature = "avx2") {
             avx2::permd_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
@@ -46,12 +52,6 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
         if cfg!(target_feature = "sse2") {
             sse2::unpck_detransform_unroll_2(input_ptr, output_ptr, len);
-            return;
-        }
-
-        #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
-            avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
     }
@@ -94,6 +94,17 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
 ) {
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+            avx512::permute_512_detransform_unroll_2_with_components(
+                output_ptr,
+                len,
+                indices_ptr as *const u8,
+                colors_ptr as *const u8,
+            );
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             avx2::permd_detransform_unroll_2_with_components(
                 output_ptr,
@@ -113,7 +124,10 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
             );
             return;
         }
+    }
 
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
             avx512::permute_512_detransform_unroll_2_with_components(
@@ -124,10 +138,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
             );
             return;
         }
-    }
 
-    #[cfg(feature = "no-runtime-cpu-detection")]
-    {
         if cfg!(target_feature = "avx2") {
             avx2::permd_detransform_unroll_2_with_components(
                 output_ptr,
@@ -140,17 +151,6 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
 
         if cfg!(target_feature = "sse2") {
             sse2::unpck_detransform_unroll_2_with_components(
-                output_ptr,
-                len,
-                indices_ptr as *const u8,
-                colors_ptr as *const u8,
-            );
-            return;
-        }
-
-        #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
-            avx512::permute_512_detransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/mod.rs
@@ -31,7 +31,7 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
         }
 
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
             avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }

--- a/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/split_blocks/unsplit/sse2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::unsplit::portable32::u32_detransform_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -15,7 +15,7 @@ std = []
 pgo = []
 # Use CPU features selected at compile time.
 no-runtime-cpu-detection = []
-# Use nightly compiler features
+# Use nightly compiler features (AVX512)
 nightly = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -28,6 +28,9 @@ safe-allocator-api = "0.3.0"
 pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 
 # Benchmark Stuff
+[lib]
+bench = false
+
 [[bench]]
 name = "split_blocks"
 path = "benches/split_blocks/main.rs"

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -15,6 +15,8 @@ std = []
 pgo = []
 # Use CPU features selected at compile time.
 no-runtime-cpu-detection = []
+# Use nightly compiler features
+nightly = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/projects/dxt-lossless-transform-bc2/benches/split_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/split_blocks/avx512.rs
@@ -1,0 +1,27 @@
+use criterion::{black_box, BenchmarkId};
+use dxt_lossless_transform_bc2::split_blocks::split::permute_512;
+use safe_allocator_api::RawAlloc;
+
+fn bench_permute(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        permute_512(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    important_benches_only: bool,
+) {
+    group.bench_with_input(BenchmarkId::new("avx512 permute", size), &size, |b, _| {
+        bench_permute(b, input, output)
+    });
+
+    if !important_benches_only {}
+}

--- a/projects/dxt-lossless-transform-bc2/benches/split_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/split_blocks/avx512.rs
@@ -1,10 +1,20 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::split_blocks::split::permute_512;
+use dxt_lossless_transform_bc2::split_blocks::split::{permute_512, permute_512_v2};
 use safe_allocator_api::RawAlloc;
 
 fn bench_permute(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
         permute_512(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+fn bench_permute_v2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        permute_512_v2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -19,9 +29,15 @@ pub(crate) fn run_benchmarks(
     size: usize,
     important_benches_only: bool,
 ) {
-    group.bench_with_input(BenchmarkId::new("avx512 permute", size), &size, |b, _| {
-        bench_permute(b, input, output)
-    });
+    group.bench_with_input(
+        BenchmarkId::new("avx512 permute v2", size),
+        &size,
+        |b, _| bench_permute_v2(b, input, output),
+    );
 
-    if !important_benches_only {}
+    if !important_benches_only {
+        group.bench_with_input(BenchmarkId::new("avx512 permute", size), &size, |b, _| {
+            bench_permute(b, input, output)
+        });
+    }
 }

--- a/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
@@ -55,7 +55,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         }
 
         #[cfg(feature = "nightly")]
-        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+        if is_x86_feature_detected!("avx512f") {
             avx512::run_benchmarks(
                 &mut group,
                 &input,

--- a/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
@@ -54,6 +54,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             );
         }
 
+        #[cfg(feature = "nightly")]
         if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
             avx512::run_benchmarks(
                 &mut group,

--- a/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
@@ -28,8 +28,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let important_benches_only = true; // Set to false to enable extra benches, unrolls, etc.
 
     group.throughput(criterion::Throughput::Bytes(size as u64));
-    //group.warm_up_time(Duration::from_secs(10));
-    group.measurement_time(Duration::from_secs(30));
+    group.warm_up_time(Duration::from_secs(60));
+    group.measurement_time(Duration::from_secs(60));
 
     // Run architecture-specific benchmarks
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]

--- a/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/split_blocks/main.rs
@@ -7,6 +7,9 @@ use pprof::criterion::{Output, PProfProfiler};
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod avx2;
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod avx512;
 mod portable32;
 mod portable64;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -25,8 +28,8 @@ fn criterion_benchmark(c: &mut Criterion) {
     let important_benches_only = true; // Set to false to enable extra benches, unrolls, etc.
 
     group.throughput(criterion::Throughput::Bytes(size as u64));
-    group.warm_up_time(Duration::from_secs(60));
-    group.measurement_time(Duration::from_secs(60));
+    //group.warm_up_time(Duration::from_secs(10));
+    group.measurement_time(Duration::from_secs(30));
 
     // Run architecture-specific benchmarks
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -43,6 +46,16 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        if is_x86_feature_detected!("avx512f") && is_x86_feature_detected!("avx512vl") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-bc2/benches/unsplit_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/unsplit_blocks/avx512.rs
@@ -1,0 +1,27 @@
+use criterion::{black_box, BenchmarkId};
+use dxt_lossless_transform_bc2::split_blocks::unsplit::avx512::avx512_shuffle;
+use safe_allocator_api::RawAlloc;
+
+fn bench_shuffle(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_shuffle(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    important_benches_only: bool,
+) {
+    group.bench_with_input(BenchmarkId::new("avx512 shuffle", size), &size, |b, _| {
+        bench_shuffle(b, input, output)
+    });
+
+    if !important_benches_only {}
+}

--- a/projects/dxt-lossless-transform-bc2/benches/unsplit_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/unsplit_blocks/main.rs
@@ -7,8 +7,12 @@ use pprof::criterion::{Output, PProfProfiler};
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod avx2;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[cfg(feature = "nightly")]
+mod avx512;
 mod portable32;
 mod portable64;
+
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod sse2;
 
@@ -43,6 +47,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        #[cfg(feature = "nightly")]
+        if is_x86_feature_detected!("avx512f") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc2/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
+#![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod split_blocks;
 

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::split::portable32::u32_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx2.rs
@@ -8,7 +8,7 @@ use core::arch::x86_64::*;
 use core::arch::x86::*;
 
 #[allow(clippy::unusual_byte_groupings)]
-static PERMUTE_MASK: [u32; 8] = [0, 4, 1, 5, 2, 6, 3, 7];
+const PERMUTE_MASK: [u32; 8] = [0, 4, 1, 5, 2, 6, 3, 7];
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
@@ -14,7 +14,6 @@ const PERM_ALPHA_BYTES: [i8; 8] = [0, 2, 4, 6, 8, 10, 12, 14]; // For vpermt2q t
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
-#[target_feature(enable = "avx512vl")]
 #[allow(unused_assignments)]
 pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
@@ -108,7 +107,6 @@ pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
-#[target_feature(enable = "avx512vl")]
 #[allow(unused_assignments)]
 pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
@@ -189,7 +187,6 @@ pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut 
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
-#[target_feature(enable = "avx512vl")]
 #[allow(unused_assignments)]
 pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
@@ -286,7 +283,6 @@ pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *m
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
-#[target_feature(enable = "avx512vl")]
 #[allow(unused_assignments)]
 pub unsafe fn permute_512_v2(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
@@ -408,7 +404,7 @@ mod tests {
     #[case(permute_512_v2_intrinsics, "avx512_permute_intrinsics_v2")]
     #[case(permute_512_v2, "avx512_permute_asm_v2")]
     fn test_avx512_aligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
-        if !std::is_x86_feature_detected!("avx512f") && !std::is_x86_feature_detected!("avx512vl") {
+        if !std::is_x86_feature_detected!("avx512f") {
             return;
         }
 
@@ -451,7 +447,7 @@ mod tests {
     #[case(permute_512_v2_intrinsics, "avx512_permute_intrinsics_v2")]
     #[case(permute_512_v2, "avx512_permute_asm_v2")]
     fn test_avx512_unaligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
-        if !std::is_x86_feature_detected!("avx512f") && !std::is_x86_feature_detected!("avx512vl") {
+        if !std::is_x86_feature_detected!("avx512f") {
             return;
         }
 

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
@@ -8,8 +8,6 @@ use core::arch::x86_64::*;
 use core::arch::x86::*;
 
 const PERM_ALPHA_BYTES: [i8; 8] = [0, 2, 4, 6, 8, 10, 12, 14]; // For vpermt2q to gather alpha values
-const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
-const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
 
 /// # Safety
 ///
@@ -18,7 +16,6 @@ const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vperm
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512vl")]
 #[allow(unused_assignments)]
-#[no_mangle]
 pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
@@ -35,6 +32,9 @@ pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len
 
     if aligned_len > 0 {
         let mut aligned_end = input_ptr.add(aligned_len);
+
+        const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
+        const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
 
         // Load permutation patterns
         let perm_alpha =
@@ -110,7 +110,6 @@ pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512vl")]
 #[allow(unused_assignments)]
-#[no_mangle]
 pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
@@ -130,6 +129,8 @@ pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut 
         let aligned_end = input_ptr.add(aligned_len);
 
         // Constant data for permutation masks
+        const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
+        const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
 
         // Load permutation patterns
         let perm_alpha =
@@ -183,6 +184,211 @@ pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut 
     }
 }
 
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vl")]
+#[allow(unused_assignments)]
+pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut aligned_len = len - (len % 256);
+    let mut alpha_ptr = output_ptr;
+
+    // Note(sewer): We need to subtract 256 (full loop) otherwise we may write over the
+    // end of the buffer.
+    aligned_len = aligned_len.saturating_sub(256);
+
+    let mut colors_ptr = alpha_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let aligned_end = input_ptr.add(aligned_len);
+
+        // Constant data for permutation masks
+        const PERM_COLORS_BYTES: [i8; 16] = [
+            0, 4, 8, 12, 2, 6, 10, 14, // + 16 below
+            16, 20, 24, 28, 18, 22, 26, 30,
+        ]; // For vpermt2d to gather color values
+        const PERM_INDICES_BYTES: [i8; 16] = [
+            1, 5, 9, 13, 3, 7, 11, 15, // +16 below
+            17, 21, 25, 29, 19, 23, 27, 31,
+        ]; // For vpermt2d to gather index values
+
+        // Load permutation patterns
+        let perm_alpha =
+            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadu_epi8(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadu_epi8(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        while input_ptr < aligned_end {
+            // Load 256 bytes (16 blocks)
+            let blocks_0 = _mm512_loadu_si512(input_ptr as *const __m512i);
+            let blocks_1 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+            let blocks_2 = _mm512_loadu_si512(input_ptr.add(128) as *const __m512i);
+            let blocks_3 = _mm512_loadu_si512(input_ptr.add(192) as *const __m512i);
+
+            // Update input pointer
+            input_ptr = input_ptr.add(256);
+
+            // Filter out the alphas only using vpermt2q
+            let alphas_0 = _mm512_permutex2var_epi64(blocks_0, perm_alpha, blocks_1);
+            let alphas_1 = _mm512_permutex2var_epi64(blocks_2, perm_alpha, blocks_3);
+
+            // Lift out colours and indices only
+            let colours_indices_only_b0 = _mm512_unpackhi_epi64(blocks_0, blocks_1);
+            let colours_indices_only_b1 = _mm512_unpackhi_epi64(blocks_2, blocks_3);
+
+            // Permute to separate colors and indices
+            let colours_only = _mm512_permutex2var_epi32(
+                colours_indices_only_b0,
+                perm_colors,
+                colours_indices_only_b1,
+            ); // colours
+            let indices_only = _mm512_permutex2var_epi32(
+                colours_indices_only_b0,
+                perm_indices,
+                colours_indices_only_b1,
+            ); // indices
+
+            // Store results
+            _mm512_storeu_si512(alpha_ptr as *mut __m512i, alphas_0); // alphas 0
+            _mm512_storeu_si512(alpha_ptr.add(64) as *mut __m512i, alphas_1); // alphas 1
+            _mm512_storeu_si512(colors_ptr as *mut __m512i, colours_only); // colours
+            _mm512_storeu_si512(indices_ptr as *mut __m512i, indices_only); // indices
+
+            // Update pointers
+            alpha_ptr = alpha_ptr.add(128);
+            colors_ptr = colors_ptr.add(64);
+            indices_ptr = indices_ptr.add(64);
+        }
+    }
+
+    // Process any remaining elements
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            alpha_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vl")]
+#[allow(unused_assignments)]
+pub unsafe fn permute_512_v2(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut aligned_len = len - (len % 256);
+    let mut alpha_ptr = output_ptr;
+
+    // Note(sewer): We need to subtract 256 (full loop) otherwise we may write over the
+    // end of the buffer.
+    aligned_len = aligned_len.saturating_sub(256);
+
+    let mut colors_ptr = alpha_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let aligned_end = input_ptr.add(aligned_len);
+
+        // Constant data for permutation masks
+        const PERM_COLORS_BYTES: [i8; 16] = [
+            0, 4, 8, 12, 2, 6, 10, 14, // + 16 below
+            16, 20, 24, 28, 18, 22, 26, 30,
+        ]; // For vpermt2d to gather color values
+        const PERM_INDICES_BYTES: [i8; 16] = [
+            1, 5, 9, 13, 3, 7, 11, 15, // +16 below
+            17, 21, 25, 29, 19, 23, 27, 31,
+        ]; // For vpermt2d to gather index values
+
+        // Load permutation patterns
+        let perm_alpha =
+            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadu_epi8(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadu_epi8(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        asm!(
+            ".p2align 5",
+            "3:",
+
+            // Load 256 bytes (16 blocks)
+            "vmovdqu64 {zmm3}, [{input_ptr}]",
+            "vmovdqu64 {zmm4}, [{input_ptr} + 64]",
+            "vmovdqu64 {zmm5}, [{input_ptr} + 128]",
+            "vmovdqu64 {zmm6}, [{input_ptr} + 192]",
+            "add {input_ptr}, 256",
+
+            // Unpack high quadwords and permute
+            "vpunpckhqdq {zmm7}, {zmm3}, {zmm4}",
+            "vpermt2q {zmm3}, {perm_alpha}, {zmm4}",
+            "vpunpckhqdq {zmm4}, {zmm5}, {zmm6}",
+            "vpermt2q {zmm5}, {perm_alpha}, {zmm6}",
+
+            // Permute to separate colors and indices
+            "vmovdqa64 {zmm6}, {zmm7}",
+            "vpermt2d {zmm6}, {perm_colors}, {zmm4}",
+            "vpermt2d {zmm7}, {perm_indices}, {zmm4}",
+
+            // Store results
+            "vmovdqu64 [{alpha_ptr}], {zmm3}",
+            "vmovdqu64 [{alpha_ptr} + 64], {zmm5}",
+            "add {alpha_ptr}, 128",
+            "vmovdqu64 [{colors_ptr}], {zmm6}",
+            "vmovdqu64 [{indices_ptr}], {zmm7}",
+
+            // Update pointers
+            "add {colors_ptr}, 64",
+            "add {indices_ptr}, 64",
+
+            // Loop until done
+            "cmp {input_ptr}, {aligned_end}",
+            "jb 3b",
+
+            input_ptr = inout(reg) input_ptr,
+            alpha_ptr = inout(reg) alpha_ptr,
+            colors_ptr = inout(reg) colors_ptr,
+            indices_ptr = inout(reg) indices_ptr,
+            aligned_end = in(reg) aligned_end,
+            perm_alpha = in(zmm_reg) perm_alpha,
+            perm_colors = in(zmm_reg) perm_colors,
+            perm_indices = in(zmm_reg) perm_indices,
+            zmm3 = out(zmm_reg) _,
+            zmm4 = out(zmm_reg) _,
+            zmm5 = out(zmm_reg) _,
+            zmm6 = out(zmm_reg) _,
+            zmm7 = out(zmm_reg) _,
+            options(nostack, preserves_flags)
+        );
+    }
+
+    // Process any remaining elements
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            alpha_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -199,6 +405,8 @@ mod tests {
     #[rstest]
     #[case(permute_512, "avx512_permute")]
     #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
+    #[case(permute_512_v2_intrinsics, "avx512_permute_intrinsics_v2")]
+    #[case(permute_512_v2, "avx512_permute_asm_v2")]
     fn test_avx512_aligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
         if !std::is_x86_feature_detected!("avx512f") && !std::is_x86_feature_detected!("avx512vl") {
             return;
@@ -240,6 +448,8 @@ mod tests {
     #[rstest]
     #[case(permute_512, "avx512_permute")]
     #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
+    #[case(permute_512_v2_intrinsics, "avx512_permute_intrinsics_v2")]
+    #[case(permute_512_v2, "avx512_permute_asm_v2")]
     fn test_avx512_unaligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
         if !std::is_x86_feature_detected!("avx512f") && !std::is_x86_feature_detected!("avx512vl") {
             return;

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
@@ -1,0 +1,278 @@
+use crate::split_blocks::split::portable32::u32_with_separate_pointers;
+use std::arch::asm;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+
+const PERM_ALPHA_BYTES: [i8; 8] = [0, 2, 4, 6, 8, 10, 12, 14]; // For vpermt2q to gather alpha values
+const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
+const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vl")]
+#[allow(unused_assignments)]
+#[no_mangle]
+pub unsafe fn permute_512(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut aligned_len = len - (len % 128);
+
+    // Note(sewer): We need to subtract 32 (half register) as to not write beyond the end of the
+    // buffer. We write 64 bytes with vmovdqu64, so the final indices_ptr write goes 32 bytes beyond
+    // the limit. We need to guard against this. However, because the indices also represent 4 / 16
+    // of the blocks, we need to multiply the amount we subtract by 4 to account for split buffers.
+    aligned_len = aligned_len.saturating_sub(32 * 4);
+
+    let mut colors_ptr = output_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let mut aligned_end = input_ptr.add(aligned_len);
+
+        // Load permutation patterns
+        let perm_alpha =
+            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        asm!(
+            ".p2align 5",
+            "2:",
+
+            // Load 128 bytes (eight blocks)
+            "vmovdqu64 {zmm4}, [{input_ptr}]",      // Load first 4 blocks
+            "vmovdqu64 {zmm5}, [{input_ptr} + 64]", // Load next 4 blocks
+            "vmovdqa64 {zmm3}, {zmm4}",             // Copy first 4 blocks to zmm3
+            "vpermt2q {zmm3}, {perm_alpha}, {zmm5}",// Filter out the alphas from zmm3 (zmm4) + zmm5
+            "add {input_ptr}, 128",
+
+            // Permute to separate colors and indices
+            "vmovdqa64 {zmm6}, {zmm4}",
+            "vpermt2d {zmm6}, {perm_colors}, {zmm5}",  // Gather colors from zmm4 + zmm5
+            "vpermt2d {zmm4}, {perm_indices}, {zmm5}", // Gather indices from zmm4 + zmm5
+
+            // Store results
+            "vmovdqu64 [{alpha_ptr}], {zmm3}",
+            "vmovdqu64 [{colors_ptr}], {zmm6}",
+            "vmovdqu64 [{indices_ptr}], {zmm4}",
+
+            // Update pointers
+            "add {alpha_ptr}, 64",
+            "add {colors_ptr}, 32",
+            "add {indices_ptr}, 32",
+
+            // Loop until done
+            "cmp {input_ptr}, {aligned_end}",
+            "jb 2b",
+
+            input_ptr = inout(reg) input_ptr,
+            alpha_ptr = inout(reg) output_ptr,
+            colors_ptr = inout(reg) colors_ptr,
+            indices_ptr = inout(reg) indices_ptr,
+            aligned_end = inout(reg) aligned_end,
+            perm_alpha = in(zmm_reg) perm_alpha,
+            perm_colors = in(zmm_reg) perm_colors,
+            perm_indices = in(zmm_reg) perm_indices,
+            zmm3 = out(zmm_reg) _,
+            zmm4 = out(zmm_reg) _,
+            zmm5 = out(zmm_reg) _,
+            zmm6 = out(zmm_reg) _,
+            options(nostack, preserves_flags)
+        );
+    }
+
+    // Process any remaining elements
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            output_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512vl")]
+#[allow(unused_assignments)]
+#[no_mangle]
+pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut aligned_len = len - (len % 128);
+    let mut alpha_ptr = output_ptr;
+
+    // Note(sewer): We need to subtract 32 (half register) as to not write beyond the end of the
+    // buffer. We write 64 bytes with vmovdqu64, so the final indices_ptr write goes 32 bytes beyond
+    // the limit. We need to guard against this. However, because the indices also represent 4 / 16
+    // of the blocks, we need to multiply the amount we subtract by 4 to account for split buffers.
+    aligned_len = aligned_len.saturating_sub(32 * 4);
+
+    let mut colors_ptr = alpha_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let aligned_end = input_ptr.add(aligned_len);
+
+        // Constant data for permutation masks
+
+        // Load permutation patterns
+        let perm_alpha =
+            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        while input_ptr < aligned_end {
+            // Load 128 bytes (eight blocks)
+            let zmm4 = _mm512_loadu_si512(input_ptr as *const __m512i);
+            let zmm5 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+
+            // Copy first 4 blocks to zmm3
+            let mut zmm3 = zmm4;
+
+            // Filter out the alphas using vpermt2q
+            zmm3 = _mm512_permutex2var_epi64(zmm3, perm_alpha, zmm5);
+
+            // Update input pointer
+            input_ptr = input_ptr.add(128);
+
+            // Permute to separate colors and indices
+            let mut zmm6 = zmm4;
+            zmm6 = _mm512_permutex2var_epi32(zmm6, perm_colors, zmm5); // colours
+            let zmm4_indices = _mm512_permutex2var_epi32(zmm4, perm_indices, zmm5); // indices
+
+            // Store results
+            _mm512_storeu_si512(alpha_ptr as *mut __m512i, zmm3); // alphas
+            _mm512_storeu_si512(colors_ptr as *mut __m512i, zmm6); // colours
+            _mm512_storeu_si512(indices_ptr as *mut __m512i, zmm4_indices); // indices
+
+            // Update pointers
+            alpha_ptr = alpha_ptr.add(64);
+            colors_ptr = colors_ptr.add(32);
+            indices_ptr = indices_ptr.add(32);
+        }
+    }
+
+    // Process any remaining elements
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            alpha_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split_blocks::split::tests::{
+        assert_implementation_matches_reference, generate_bc2_test_data,
+        transform_with_reference_implementation,
+    };
+    use crate::testutils::allocate_align_64;
+    use core::ptr::copy_nonoverlapping;
+    use rstest::rstest;
+
+    type PermuteFn = unsafe fn(*const u8, *mut u8, usize);
+
+    #[rstest]
+    #[case(permute_512, "avx512_permute")]
+    #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
+    fn test_avx512_aligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
+        if !std::is_x86_feature_detected!("avx512f") && !std::is_x86_feature_detected!("avx512vl") {
+            return;
+        }
+
+        for num_blocks in 1..=512 {
+            let mut input = allocate_align_64(num_blocks * 16);
+            let mut output_expected = allocate_align_64(input.len());
+            let mut output_test = allocate_align_64(input.len());
+
+            // Fill the input with test data
+            unsafe {
+                copy_nonoverlapping(
+                    generate_bc2_test_data(num_blocks).as_ptr(),
+                    input.as_mut_ptr(),
+                    input.len(),
+                );
+            }
+
+            transform_with_reference_implementation(
+                input.as_slice(),
+                output_expected.as_mut_slice(),
+            );
+
+            output_test.as_mut_slice().fill(0);
+            unsafe {
+                permute_fn(input.as_ptr(), output_test.as_mut_ptr(), input.len());
+            }
+
+            assert_implementation_matches_reference(
+                output_expected.as_slice(),
+                output_test.as_slice(),
+                &format!("{impl_name} (aligned)"),
+                num_blocks,
+            );
+        }
+    }
+
+    #[rstest]
+    #[case(permute_512, "avx512_permute")]
+    #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
+    fn test_avx512_unaligned(#[case] permute_fn: PermuteFn, #[case] impl_name: &str) {
+        if !std::is_x86_feature_detected!("avx512f") && !std::is_x86_feature_detected!("avx512vl") {
+            return;
+        }
+
+        for num_blocks in 1..=512 {
+            let input = generate_bc2_test_data(num_blocks);
+
+            // Add 1 extra byte at the beginning to create misaligned buffers
+            let mut input_unaligned = vec![0u8; input.len() + 1];
+            input_unaligned[1..].copy_from_slice(input.as_slice());
+
+            let mut output_expected = vec![0u8; input.len()];
+            let mut output_test = vec![0u8; input.len() + 1];
+
+            transform_with_reference_implementation(input.as_slice(), &mut output_expected);
+
+            output_test.as_mut_slice().fill(0);
+            unsafe {
+                // Use pointers offset by 1 byte to create unaligned access
+                permute_fn(
+                    input_unaligned.as_ptr().add(1),
+                    output_test.as_mut_ptr().add(1),
+                    input.len(),
+                );
+            }
+
+            assert_implementation_matches_reference(
+                output_expected.as_slice(),
+                &output_test[1..],
+                &format!("{impl_name} (unaligned)"),
+                num_blocks,
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
@@ -191,12 +191,8 @@ pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut 
 pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
-    let mut aligned_len = len - (len % 256);
+    let aligned_len = len - (len % 256);
     let mut alpha_ptr = output_ptr;
-
-    // Note(sewer): We need to subtract 256 (full loop) otherwise we may write over the
-    // end of the buffer.
-    aligned_len = aligned_len.saturating_sub(256);
 
     let mut colors_ptr = alpha_ptr.add(len / 2);
     let mut indices_ptr = colors_ptr.add(len / 4);
@@ -287,12 +283,8 @@ pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *m
 pub unsafe fn permute_512_v2(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
-    let mut aligned_len = len - (len % 256);
+    let aligned_len = len - (len % 256);
     let mut alpha_ptr = output_ptr;
-
-    // Note(sewer): We need to subtract 256 (full loop) otherwise we may write over the
-    // end of the buffer.
-    aligned_len = aligned_len.saturating_sub(256);
 
     let mut colors_ptr = alpha_ptr.add(len / 2);
     let mut indices_ptr = colors_ptr.add(len / 4);

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/avx512.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::split::portable32::u32_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
@@ -29,6 +29,12 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         // Runtime feature detection
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+            avx512::permute_512(input_ptr, output_ptr, len);
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             avx2::shuffle(input_ptr, output_ptr, len);
             return;
@@ -45,16 +51,16 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
             sse2::shuffle_v2(input_ptr, output_ptr, len);
             return;
         }
-
-        #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
-            avx512::permute_512(input_ptr, output_ptr, len);
-            return;
-        }
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+            avx512::permute_512(input_ptr, output_ptr, len);
+            return;
+        }
+
         if cfg!(target_feature = "avx2") {
             avx2::shuffle(input_ptr, output_ptr, len);
             return;
@@ -69,12 +75,6 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
         #[cfg(target_arch = "x86")]
         if cfg!(target_feature = "sse2") {
             sse2::shuffle_v2(input_ptr, output_ptr, len);
-            return;
-        }
-
-        #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
-            avx512::permute_512(input_ptr, output_ptr, len);
             return;
         }
     }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
@@ -25,7 +25,7 @@ pub use avx512::*;
 #[inline(always)]
 unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     // Note(sewer): The AVX512 implementation is disabled because a bunch of CPUs throttle on it,
-    // leading to it being slower.
+    // leading to it being slower.,
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         // Runtime feature detection
@@ -46,13 +46,11 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
             return;
         }
 
-        /*
         #[cfg(feature = "nightly")]
         if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
             avx512::permute_512(input_ptr, output_ptr, len);
             return;
         }
-        */
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
@@ -74,13 +72,11 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
             return;
         }
 
-        /*
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
             avx512::permute_512(input_ptr, output_ptr, len);
             return;
         }
-        */
     }
 
     // Fallback to portable implementation

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
@@ -30,7 +30,7 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
     {
         // Runtime feature detection
         #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+        if std::is_x86_feature_detected!("avx512f") {
             avx512::permute_512(input_ptr, output_ptr, len);
             return;
         }
@@ -56,7 +56,7 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+        if cfg!(target_feature = "avx512f") {
             avx512::permute_512(input_ptr, output_ptr, len);
             return;
         }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/mod.rs
@@ -13,9 +13,19 @@ pub mod avx2;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub use avx2::*;
 
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx512;
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub use avx512::*;
+
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
 unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    // Note(sewer): The AVX512 implementation is disabled because a bunch of CPUs throttle on it,
+    // leading to it being slower.
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         // Runtime feature detection
@@ -35,6 +45,14 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
             sse2::shuffle_v2(input_ptr, output_ptr, len);
             return;
         }
+
+        /*
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") && std::is_x86_feature_detected!("avx512vl") {
+            avx512::permute_512(input_ptr, output_ptr, len);
+            return;
+        }
+        */
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
@@ -55,6 +73,14 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
             sse2::shuffle_v2(input_ptr, output_ptr, len);
             return;
         }
+
+        /*
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512vl") {
+            avx512::permute_512(input_ptr, output_ptr, len);
+            return;
+        }
+        */
     }
 
     // Fallback to portable implementation

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
@@ -3,6 +3,7 @@
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
+#[no_mangle]
 pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/portable32.rs
@@ -3,7 +3,6 @@
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-#[no_mangle]
 pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/split/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/split/sse2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::split::portable32::u32_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::unsplit::portable32::u32_detransform_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 #[allow(clippy::unusual_byte_groupings)]
 static ALPHA_PERMUTE_MASK: [u32; 8] = [0, 1, 4, 5, 2, 3, 6, 7u32];

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
@@ -349,7 +349,11 @@ mod tests {
     #[rstest]
     #[case::avx512_shuffle(avx512_shuffle, "avx512_shuffle")]
     #[case::avx512_shuffle_intrinsics(avx512_shuffle_intrinsics, "avx512_shuffle_intrinsics")]
-    fn test_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+    fn test_avx512_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512f") {
+            return;
+        }
+
         // Test with different block counts to ensure they all work correctly
         for block_count in 1..=512 {
             // Generate test data
@@ -383,6 +387,10 @@ mod tests {
     #[case::avx512_shuffle(avx512_shuffle, "avx512_shuffle")]
     #[case::avx512_shuffle_intrinsics(avx512_shuffle_intrinsics, "avx512_shuffle_intrinsics")]
     fn test_avx512_unaligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512f") {
+            return;
+        }
+
         // Test with different block counts to ensure they all work correctly
         for block_count in 1..=512 {
             // Generate test data

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
@@ -6,6 +6,7 @@ use core::arch::x86_64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 
+#[cfg(target_arch = "x86_64")]
 use core::arch::*;
 
 /// # Safety
@@ -20,7 +21,11 @@ pub unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     let colors_ptr = alpha_ptr.add(len / 2);
     let indices_ptr = colors_ptr.add(len / 4);
 
+    #[cfg(target_arch = "x86_64")]
     avx512_shuffle_with_components(output_ptr, len, alpha_ptr, colors_ptr, indices_ptr);
+
+    #[cfg(target_arch = "x86")]
+    avx512_shuffle_with_components_intrinsics(output_ptr, len, alpha_ptr, colors_ptr, indices_ptr);
 }
 
 /// # Safety
@@ -182,6 +187,7 @@ pub unsafe fn avx512_shuffle_with_components_intrinsics(
 #[target_feature(enable = "avx512f")]
 #[allow(clippy::zero_prefixed_literal)]
 #[allow(clippy::identity_op)]
+#[cfg(target_arch = "x86_64")]
 pub unsafe fn avx512_shuffle_with_components(
     mut output_ptr: *mut u8,
     len: usize,

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
@@ -6,6 +6,8 @@ use core::arch::x86_64::*;
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;
 
+use core::arch::*;
+
 /// # Safety
 ///
 /// - input_ptr must be valid for reads of len bytes
@@ -23,6 +25,21 @@ pub unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
 /// # Safety
 ///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[allow(unused_assignments)]
+pub unsafe fn avx512_shuffle_intrinsics(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+    let alpha_ptr = input_ptr;
+    let colors_ptr = alpha_ptr.add(len / 2);
+    let indices_ptr = colors_ptr.add(len / 4);
+
+    avx512_shuffle_with_components_intrinsics(output_ptr, len, alpha_ptr, colors_ptr, indices_ptr);
+}
+
+/// # Safety
+///
 /// - output_ptr must be valid for writes of len bytes
 /// - alpha_ptr must be valid for reads of len / 2 bytes
 /// - colors_ptr must be valid for reads of len / 4 bytes
@@ -31,7 +48,7 @@ pub unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 #[allow(unused_assignments)]
 #[allow(clippy::zero_prefixed_literal)]
 #[allow(clippy::identity_op)]
-pub unsafe fn avx512_shuffle_with_components(
+pub unsafe fn avx512_shuffle_with_components_intrinsics(
     mut output_ptr: *mut u8,
     len: usize,
     mut alpha_ptr: *const u8,
@@ -46,7 +63,7 @@ pub unsafe fn avx512_shuffle_with_components(
 
     if aligned_len > 0 {
         // Mask for mixing output_0 (lower half of alpha & `color+index` splits)
-        let perm_block_mask_low = _mm512_setr_epi64(
+        let perm_block_low = _mm512_setr_epi64(
             0,  // alpha 8 bytes
             8,  // colors + indices 8 bytes
             1,  // alpha 8 bytes
@@ -57,7 +74,7 @@ pub unsafe fn avx512_shuffle_with_components(
             11, // colors + indices 8 bytes
         );
         // Mask for mixing output_1 (upper half of alpha & `color+index` splits)
-        let perm_block_mask_high = _mm512_setr_epi64(
+        let perm_block_high = _mm512_setr_epi64(
             4,  // alpha 8 bytes
             12, // colors + indices 8 bytes
             5,  // alpha 8 bytes
@@ -69,7 +86,7 @@ pub unsafe fn avx512_shuffle_with_components(
         );
         // Mask for mixing colors and indices (lower half)
         // rust specifies the args for this call in reverse order, e15 == e0. this is a stdlib blunder
-        let perm_color_index_mask_low = _mm512_setr_epi32(
+        let perm_color_index_low = _mm512_setr_epi32(
             00 + 00, // colors 4 bytes,
             00 + 16, // indices 4 bytes,
             01 + 00, // colors 4 bytes,
@@ -88,7 +105,7 @@ pub unsafe fn avx512_shuffle_with_components(
             07 + 16, // indices 4 bytes,
         );
         // Mask for mixing colors and indices (upper half)
-        let perm_color_index_mask_high = _mm512_setr_epi32(
+        let perm_color_index_high = _mm512_setr_epi32(
             08 + 00, // colors 4 bytes,
             08 + 16, // indices 4 bytes,
             09 + 00, // colors 4 bytes,
@@ -119,20 +136,15 @@ pub unsafe fn avx512_shuffle_with_components(
             indices_ptr = indices_ptr.add(64);
 
             // re-mix lower & upper colour+index halves
-            let colors_indices_0 =
-                _mm512_permutex2var_epi32(colors, perm_color_index_mask_low, indices);
+            let colors_indices_0 = _mm512_permutex2var_epi32(colors, perm_color_index_low, indices);
             let colors_indices_1 =
-                _mm512_permutex2var_epi32(colors, perm_color_index_mask_high, indices);
+                _mm512_permutex2var_epi32(colors, perm_color_index_high, indices);
 
             // re-mix alphas and colour+index halves
-            let output_0 =
-                _mm512_permutex2var_epi64(alpha_0, perm_block_mask_low, colors_indices_0);
-            let output_1 =
-                _mm512_permutex2var_epi64(alpha_0, perm_block_mask_high, colors_indices_0);
-            let output_2 =
-                _mm512_permutex2var_epi64(alpha_1, perm_block_mask_low, colors_indices_1);
-            let output_3 =
-                _mm512_permutex2var_epi64(alpha_1, perm_block_mask_high, colors_indices_1);
+            let output_0 = _mm512_permutex2var_epi64(alpha_0, perm_block_low, colors_indices_0);
+            let output_1 = _mm512_permutex2var_epi64(alpha_0, perm_block_high, colors_indices_0);
+            let output_2 = _mm512_permutex2var_epi64(alpha_1, perm_block_low, colors_indices_1);
+            let output_3 = _mm512_permutex2var_epi64(alpha_1, perm_block_high, colors_indices_1);
 
             // Write results
             _mm512_storeu_si512(output_ptr as *mut __m512i, output_0);
@@ -159,6 +171,164 @@ pub unsafe fn avx512_shuffle_with_components(
     }
 }
 
+/// # Safety
+///
+/// - output_ptr must be valid for writes of len bytes
+/// - alpha_ptr must be valid for reads of len / 2 bytes
+/// - colors_ptr must be valid for reads of len / 4 bytes
+/// - indices_ptr must be valid for reads of len / 4 bytes
+#[allow(unused_assignments)]
+#[cfg(feature = "nightly")]
+#[target_feature(enable = "avx512f")]
+#[allow(clippy::zero_prefixed_literal)]
+#[allow(clippy::identity_op)]
+pub unsafe fn avx512_shuffle_with_components(
+    mut output_ptr: *mut u8,
+    len: usize,
+    mut alpha_ptr: *const u8,
+    mut colors_ptr: *const u8,
+    mut indices_ptr: *const u8,
+) {
+    debug_assert!(len % 16 == 0);
+    // Process 16 blocks (256 bytes) at a time
+    let aligned_len = len - (len % 256);
+    let alpha_ptr_aligned_end = alpha_ptr.add(aligned_len / 2);
+
+    if aligned_len > 0 {
+        // Mask for mixing output_0 (lower half of alpha & `color+index` splits)
+        let perm_block_low = _mm512_setr_epi64(
+            0,  // alpha 8 bytes
+            8,  // colors + indices 8 bytes
+            1,  // alpha 8 bytes
+            9,  // colors + indices 8 bytes
+            2,  // alpha 8 bytes
+            10, // colors + indices 8 bytes
+            3,  // alpha 8 bytes
+            11, // colors + indices 8 bytes
+        );
+        // Mask for mixing output_1 (upper half of alpha & `color+index` splits)
+        let perm_block_high = _mm512_setr_epi64(
+            4,  // alpha 8 bytes
+            12, // colors + indices 8 bytes
+            5,  // alpha 8 bytes
+            13, // colors + indices 8 bytes
+            6,  // alpha 8 bytes
+            14, // colors + indices 8 bytes
+            7,  // alpha 8 bytes
+            15, // colors + indices 8 bytes
+        );
+        // Mask for mixing colors and indices (lower half)
+        // rust specifies the args for this call in reverse order, e15 == e0. this is a stdlib blunder
+        let perm_color_index_low = _mm512_setr_epi32(
+            00 + 00, // colors 4 bytes,
+            00 + 16, // indices 4 bytes,
+            01 + 00, // colors 4 bytes,
+            01 + 16, // indices 4 bytes,
+            02 + 00, // colors 4 bytes,
+            02 + 16, // indices 4 bytes,
+            03 + 00, // colors 4 bytes,
+            03 + 16, // indices 4 bytes,
+            04 + 00, // colors 4 bytes,
+            04 + 16, // indices 4 bytes,
+            05 + 00, // colors 4 bytes,
+            05 + 16, // indices 4 bytes,
+            06 + 00, // colors 4 bytes,
+            06 + 16, // indices 4 bytes,
+            07 + 00, // colors 4 bytes,
+            07 + 16, // indices 4 bytes,
+        );
+        // Mask for mixing colors and indices (upper half)
+        let perm_color_index_high = _mm512_setr_epi32(
+            08 + 00, // colors 4 bytes,
+            08 + 16, // indices 4 bytes,
+            09 + 00, // colors 4 bytes,
+            09 + 16, // indices 4 bytes,
+            10 + 00, // colors 4 bytes,
+            10 + 16, // indices 4 bytes,
+            11 + 00, // colors 4 bytes,
+            11 + 16, // indices 4 bytes,
+            12 + 00, // colors 4 bytes,
+            12 + 16, // indices 4 bytes,
+            13 + 00, // colors 4 bytes,
+            13 + 16, // indices 4 bytes,
+            14 + 00, // colors 4 bytes,
+            14 + 16, // indices 4 bytes,
+            15 + 00, // colors 4 bytes,
+            15 + 16, // indices 4 bytes,
+        );
+
+        unsafe {
+            asm!(
+                // Align the loop's instruction address to 16 bytes
+                ".p2align 4",
+                "2:",  // Loop label
+
+                // Load alpha, colors, and indices
+                "vmovdqu64 {zmm6}, [{colors_ptr}]",        // Load colors
+                "vmovdqu64 {zmm7}, [{indices_ptr}]",       // Load indices
+                "vmovdqu64 {zmm4}, [{alpha_ptr}]",         // Load first alpha block
+                "vmovdqu64 {zmm5}, [{alpha_ptr} + 64]",    // Load second alpha block
+                "add {alpha_ptr}, 128",                   // Increment alpha pointer
+                "add {colors_ptr}, 64",                    // Increment colors pointer
+                "add {indices_ptr}, 64",                   // Increment indices pointer
+
+                // Re-mix colors and indices
+                "vmovdqa64 {zmm8}, {zmm6}",                // Copy colors for permutation
+                "vpermt2d {zmm8}, {perm_color_index_low}, {zmm7}",    // Permute with low pattern
+                "vpermt2d {zmm6}, {perm_color_index_high}, {zmm7}",   // Permute with high pattern
+
+                // Re-mix alphas and color+index halves
+                "vmovdqa64 {zmm7}, {zmm4}",                // Copy alpha for permutation
+                "vpermt2q {zmm7}, {perm_block_low}, {zmm8}", // Permute with low pattern (output_0)
+                "vpermt2q {zmm4}, {perm_block_high}, {zmm8}", // Permute with high pattern (output_1)
+
+                "vmovdqa64 {zmm8}, {zmm5}",                // Copy alpha for second permutation
+                "vpermt2q {zmm8}, {perm_block_low}, {zmm6}", // Permute with low pattern (output_2)
+                "vpermt2q {zmm5}, {perm_block_high}, {zmm6}", // Permute with high pattern (output_3)
+
+                // Store results
+                "vmovdqu64 [{dst_ptr}], {zmm7}",           // Store first block (output_0)
+                "vmovdqu64 [{dst_ptr} + 64], {zmm4}",      // Store second block (output_1)
+                "vmovdqu64 [{dst_ptr} + 128], {zmm8}",     // Store third block (output_2)
+                "vmovdqu64 [{dst_ptr} + 192], {zmm5}",     // Store fourth block (output_3)
+
+                // Update pointer and loop
+                "add {dst_ptr}, 256",                      // Increment destination pointer
+                "cmp {alpha_ptr}, {end}",                  // Compare with end pointer
+                "jb 2b",                                   // Jump back if not at end
+
+                alpha_ptr = inout(reg) alpha_ptr,
+                colors_ptr = inout(reg) colors_ptr,
+                indices_ptr = inout(reg) indices_ptr,
+                dst_ptr = inout(reg) output_ptr,
+                end = in(reg) alpha_ptr_aligned_end,
+                perm_color_index_low = in(zmm_reg) perm_color_index_low,
+                perm_color_index_high = in(zmm_reg) perm_color_index_high,
+                perm_block_low = in(zmm_reg) perm_block_low,
+                perm_block_high = in(zmm_reg) perm_block_high,
+                zmm4 = out(zmm_reg) _,
+                zmm5 = out(zmm_reg) _,
+                zmm6 = out(zmm_reg) _,
+                zmm7 = out(zmm_reg) _,
+                zmm8 = out(zmm_reg) _,
+                options(nostack)
+            );
+        }
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        avx512_shuffle_with_components_intrinsics(
+            output_ptr,
+            remaining,
+            alpha_ptr,
+            colors_ptr,
+            indices_ptr,
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -172,6 +342,7 @@ mod tests {
 
     #[rstest]
     #[case::avx512_shuffle(avx512_shuffle, "avx512_shuffle")]
+    #[case::avx512_shuffle_intrinsics(avx512_shuffle_intrinsics, "avx512_shuffle_intrinsics")]
     fn test_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
         // Test with different block counts to ensure they all work correctly
         for block_count in 1..=512 {
@@ -204,6 +375,7 @@ mod tests {
 
     #[rstest]
     #[case::avx512_shuffle(avx512_shuffle, "avx512_shuffle")]
+    #[case::avx512_shuffle_intrinsics(avx512_shuffle_intrinsics, "avx512_shuffle_intrinsics")]
     fn test_avx512_unaligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
         // Test with different block counts to ensure they all work correctly
         for block_count in 1..=512 {

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/avx512.rs
@@ -61,7 +61,7 @@ pub unsafe fn avx512_shuffle_with_components_intrinsics(
     mut indices_ptr: *const u8,
 ) {
     debug_assert!(len % 16 == 0);
-    // Process 8 blocks (128 bytes) at a time
+    // Process 16 blocks (256 bytes) at a time
     let aligned_len = len - (len % 256);
     let alpha_ptr_aligned_end = alpha_ptr.add(aligned_len / 2);
     // End pointer for the loop based on aligned length

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -7,6 +7,14 @@ pub mod sse2;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx2;
 
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx512;
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub use avx512::*;
+
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
 unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
@@ -21,6 +29,11 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
             sse2::shuffle(input_ptr, output_ptr, len);
             return;
         }
+
+        if std::is_x86_feature_detected!("avx512f") {
+            avx512::avx512_shuffle(input_ptr, output_ptr, len);
+            return;
+        }
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
@@ -32,6 +45,11 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
 
         if cfg!(target_feature = "sse2") {
             sse2::shuffle(input_ptr, output_ptr, len);
+            return;
+        }
+
+        if cfg!(target_feature = "avx512f") {
+            avx512::avx512_shuffle(input_ptr, output_ptr, len);
             return;
         }
     }

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -21,6 +21,8 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
+        #[cfg(target_arch = "x86_64")]
+        // disabled due to non-guaranteed performance on 32-bit
         if std::is_x86_feature_detected!("avx512f") {
             avx512::avx512_shuffle(input_ptr, output_ptr, len);
             return;
@@ -40,6 +42,8 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
+        #[cfg(target_arch = "x86_64")]
+        // disabled due to non-guaranteed performance on 32-bit
         if cfg!(target_feature = "avx512f") {
             avx512::avx512_shuffle(input_ptr, output_ptr, len);
             return;
@@ -96,6 +100,8 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
+        #[cfg(target_arch = "x86_64")]
+        // disabled due to non-guaranteed performance on 32-bit
         if std::is_x86_feature_detected!("avx512f") {
             avx512::avx512_shuffle_with_components_intrinsics(
                 output_ptr,
@@ -133,6 +139,8 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
+        #[cfg(target_arch = "x86_64")]
+        // disabled due to non-guaranteed performance on 32-bit
         if cfg!(target_feature = "avx512f") {
             avx512::avx512_shuffle_with_components_intrinsics(
                 output_ptr,

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -30,6 +30,7 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
             return;
         }
 
+        #[cfg(feature = "nightly")]
         if std::is_x86_feature_detected!("avx512f") {
             avx512::avx512_shuffle(input_ptr, output_ptr, len);
             return;
@@ -48,6 +49,7 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
             return;
         }
 
+        #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") {
             avx512::avx512_shuffle(input_ptr, output_ptr, len);
             return;

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -97,7 +97,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     {
         #[cfg(feature = "nightly")]
         if std::is_x86_feature_detected!("avx512f") {
-            avx512::avx512_shuffle_with_components(
+            avx512::avx512_shuffle_with_components_intrinsics(
                 output_ptr,
                 len,
                 alphas_ptr as *const u8,
@@ -134,7 +134,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     {
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") {
-            avx512::avx512_shuffle_with_components(
+            avx512::avx512_shuffle_with_components_intrinsics(
                 output_ptr,
                 len,
                 alphas_ptr as *const u8,

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/mod.rs
@@ -20,6 +20,12 @@ pub use avx512::*;
 unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") {
+            avx512::avx512_shuffle(input_ptr, output_ptr, len);
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             avx2::avx2_shuffle(input_ptr, output_ptr, len);
             return;
@@ -29,16 +35,16 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
             sse2::shuffle(input_ptr, output_ptr, len);
             return;
         }
-
-        #[cfg(feature = "nightly")]
-        if std::is_x86_feature_detected!("avx512f") {
-            avx512::avx512_shuffle(input_ptr, output_ptr, len);
-            return;
-        }
     }
 
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") {
+            avx512::avx512_shuffle(input_ptr, output_ptr, len);
+            return;
+        }
+
         if cfg!(target_feature = "avx2") {
             avx2::avx2_shuffle(input_ptr, output_ptr, len);
             return;
@@ -46,12 +52,6 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
 
         if cfg!(target_feature = "sse2") {
             sse2::shuffle(input_ptr, output_ptr, len);
-            return;
-        }
-
-        #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") {
-            avx512::avx512_shuffle(input_ptr, output_ptr, len);
             return;
         }
     }
@@ -95,6 +95,18 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
 ) {
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512f") {
+            avx512::avx512_shuffle_with_components(
+                output_ptr,
+                len,
+                alphas_ptr as *const u8,
+                colors_ptr as *const u8,
+                indices_ptr as *const u8,
+            );
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             avx2::avx2_shuffle_with_components(
                 output_ptr,
@@ -120,6 +132,18 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
 
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") {
+            avx512::avx512_shuffle_with_components(
+                output_ptr,
+                len,
+                alphas_ptr as *const u8,
+                colors_ptr as *const u8,
+                indices_ptr as *const u8,
+            );
+            return;
+        }
+
         if cfg!(target_feature = "avx2") {
             avx2::avx2_shuffle_with_components(
                 output_ptr,

--- a/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/split_blocks/unsplit/sse2.rs
@@ -1,5 +1,5 @@
 use crate::split_blocks::unsplit::portable32::u32_detransform_with_separate_pointers;
-use std::arch::asm;
+use core::arch::asm;
 
 /// # Safety
 ///

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -15,6 +15,8 @@ std = []
 pgo = []
 # Use CPU features selected at compile time.
 no-runtime-cpu-detection = []
+# Use nightly compiler features (AVX512)
+nightly = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/projects/dxt-lossless-transform-bc3/benches/split_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/split_blocks/avx512.rs
@@ -1,0 +1,27 @@
+use criterion::{black_box, BenchmarkId};
+use dxt_lossless_transform_bc3::split_blocks::split::avx512_vbmi;
+use safe_allocator_api::RawAlloc;
+
+fn bench_avx512_vbmi(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_vbmi(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    important_benches_only: bool,
+) {
+    group.bench_with_input(BenchmarkId::new("avx512 vbmi", size), &size, |b, _| {
+        bench_avx512_vbmi(b, input, output)
+    });
+
+    if !important_benches_only {}
+}

--- a/projects/dxt-lossless-transform-bc3/benches/split_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/split_blocks/main.rs
@@ -7,6 +7,9 @@ use pprof::criterion::{Output, PProfProfiler};
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod avx2;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[cfg(feature = "nightly")]
+mod avx512;
 mod portable32;
 mod portable64;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -43,6 +46,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        #[cfg(feature = "nightly")]
+        if is_x86_feature_detected!("avx512vbmi") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-bc3/benches/unsplit_blocks/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/unsplit_blocks/avx512.rs
@@ -1,0 +1,61 @@
+use criterion::{black_box, BenchmarkId};
+use dxt_lossless_transform_bc3::split_blocks::unsplit::{
+    avx512_detransform, avx512_detransform_32_vbmi, avx512_detransform_32_vl,
+};
+use safe_allocator_api::RawAlloc;
+
+fn bench_avx512_32_vbmi(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_detransform_32_vbmi(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+fn bench_avx512_32_vl(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_detransform_32_vl(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+fn bench_avx512_64(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_detransform(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    important_benches_only: bool,
+) {
+    group.bench_with_input(
+        BenchmarkId::new("avx512 32bit vbmi", size),
+        &size,
+        |b, _| bench_avx512_32_vbmi(b, input, output),
+    );
+
+    if is_x86_feature_detected!("avx512vl") {
+        group.bench_with_input(BenchmarkId::new("avx512 32bit vl", size), &size, |b, _| {
+            bench_avx512_32_vl(b, input, output)
+        });
+    }
+
+    group.bench_with_input(BenchmarkId::new("avx512 64bit", size), &size, |b, _| {
+        bench_avx512_64(b, input, output)
+    });
+
+    if !important_benches_only {}
+}

--- a/projects/dxt-lossless-transform-bc3/benches/unsplit_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/unsplit_blocks/main.rs
@@ -7,6 +7,8 @@ use pprof::criterion::{Output, PProfProfiler};
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod avx2;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod avx512;
 mod portable32;
 mod portable64;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -43,6 +45,16 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        if is_x86_feature_detected!("avx512vbmi") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc3/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
+#![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod split_blocks;
 

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx2.rs
@@ -1,8 +1,8 @@
 #[cfg(target_arch = "x86")]
-use std::arch::x86::*;
+use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
-use std::arch::x86_64::*;
-use std::arch::*;
+use core::arch::x86_64::*;
+use core::arch::*;
 
 use super::portable32::u32_with_separate_endpoints;
 

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx512.rs
@@ -1,0 +1,220 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use super::portable32::u32_with_separate_endpoints;
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 16 (BC3 block size)
+#[target_feature(enable = "avx512vbmi")]
+#[allow(clippy::identity_op)]
+#[allow(clippy::erasing_op)]
+pub unsafe fn avx512_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    // Process 8 blocks (128 bytes) at a time
+    let mut aligned_len = len - (len % 128);
+    // 16 / 2 == block size / alpha_bytes size
+    // 128 == loop length
+    aligned_len = aligned_len.saturating_sub(16 / 2 * 128); // 1024
+    let remaining_len = len - aligned_len;
+
+    // Setup pointers for alpha components
+    let mut alpha_byte_out_ptr = output_ptr;
+    let mut alpha_bit_out_ptr = output_ptr.add(len / 16 * 2);
+    let mut color_out_ptr = output_ptr.add(len / 16 * 8);
+    let mut index_out_ptr = output_ptr.add(len / 16 * 12);
+
+    let mut current_input_ptr = input_ptr;
+    let input_aligned_end_ptr = input_ptr.add(aligned_len);
+
+    // Permute to lift out the alpha bytes from the read blocks.
+    #[rustfmt::skip]
+    let alpha_bytes_permute_mask: __m512i = _mm512_set_epi8(
+        0, 0, 0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        1 + (16 * 3),
+        0 + (16 * 3), // block 3
+        1 + (16 * 2),
+        0 + (16 * 2), // block 2
+        1 + (16 * 1),
+        0 + (16 * 1), // block 1
+        1 + (16 * 0),
+        0 + (16 * 0), // block 0
+    );
+
+    #[rustfmt::skip]
+    let alpha_bits_permute_mask: __m512i = _mm512_set_epi8(
+        0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        7 + (16 * 3),
+        6 + (16 * 3),
+        5 + (16 * 3),
+        4 + (16 * 3),
+        3 + (16 * 3),
+        2 + (16 * 3), // block 3
+        7 + (16 * 2),
+        6 + (16 * 2),
+        5 + (16 * 2),
+        4 + (16 * 2),
+        3 + (16 * 2),
+        2 + (16 * 2), // block 2
+        7 + (16 * 1),
+        6 + (16 * 1),
+        5 + (16 * 1),
+        4 + (16 * 1),
+        3 + (16 * 1),
+        2 + (16 * 1), // block 1
+        7 + (16 * 0),
+        6 + (16 * 0),
+        5 + (16 * 0),
+        4 + (16 * 0),
+        3 + (16 * 0),
+        2 + (16 * 0), // block 0
+    );
+
+    #[rustfmt::skip]
+    let color_bytes_permute_mask: __m512i = _mm512_set_epi8(
+        0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        11 + (16 * 3),
+        10 + (16 * 3),
+        9 + (16 * 3),
+        8 + (16 * 3), // block 3
+        11 + (16 * 2),
+        10 + (16 * 2),
+        9 + (16 * 2),
+        8 + (16 * 2), // block 2
+        11 + (16 * 1),
+        10 + (16 * 1),
+        9 + (16 * 1),
+        8 + (16 * 1), // block 1
+        11 + (16 * 0),
+        10 + (16 * 0),
+        9 + (16 * 0),
+        8 + (16 * 0), // block 0
+    );
+
+    #[rustfmt::skip]
+    let index_bytes_permute_mask: __m512i = _mm512_set_epi8(
+        0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+        15 + (16 * 3),
+        14 + (16 * 3),
+        13 + (16 * 3),
+        12 + (16 * 3), // block 3
+        15 + (16 * 2),
+        14 + (16 * 2),
+        13 + (16 * 2),
+        12 + (16 * 2), // block 2
+        15 + (16 * 1),
+        14 + (16 * 1),
+        13 + (16 * 1),
+        12 + (16 * 1), // block 1
+        15 + (16 * 0),
+        14 + (16 * 0),
+        13 + (16 * 0),
+        12 + (16 * 0), // block 0
+    );
+
+    while current_input_ptr < input_aligned_end_ptr {
+        // Read 8 blocks (128 bytes)
+        let block_0 = _mm512_loadu_si512(current_input_ptr as *const __m512i);
+        let block_1 = _mm512_loadu_si512(current_input_ptr.add(64) as *const __m512i);
+        current_input_ptr = current_input_ptr.add(128); // Move forward 8 blocks
+
+        let alpha_bytes_0 = _mm512_permutexvar_epi8(alpha_bytes_permute_mask, block_0);
+        let alpha_bits_0 = _mm512_permutexvar_epi8(alpha_bits_permute_mask, block_0);
+        let color_bytes_0 = _mm512_permutexvar_epi8(color_bytes_permute_mask, block_0);
+        let index_bytes_0 = _mm512_permutexvar_epi8(index_bytes_permute_mask, block_0);
+
+        let alpha_bytes_1 = _mm512_permutexvar_epi8(alpha_bytes_permute_mask, block_1);
+        let alpha_bits_1 = _mm512_permutexvar_epi8(alpha_bits_permute_mask, block_1);
+        let color_bytes_1 = _mm512_permutexvar_epi8(color_bytes_permute_mask, block_1);
+        let index_bytes_1 = _mm512_permutexvar_epi8(index_bytes_permute_mask, block_1);
+
+        _mm512_storeu_si512(alpha_byte_out_ptr as *mut __m512i, alpha_bytes_0);
+        _mm512_storeu_si512(alpha_bit_out_ptr as *mut __m512i, alpha_bits_0);
+        _mm512_storeu_si512(color_out_ptr as *mut __m512i, color_bytes_0);
+        _mm512_storeu_si512(index_out_ptr as *mut __m512i, index_bytes_0);
+
+        _mm512_storeu_si512(alpha_byte_out_ptr.add(8) as *mut __m512i, alpha_bytes_1);
+        _mm512_storeu_si512(alpha_bit_out_ptr.add(24) as *mut __m512i, alpha_bits_1);
+        _mm512_storeu_si512(color_out_ptr.add(16) as *mut __m512i, color_bytes_1);
+        _mm512_storeu_si512(index_out_ptr.add(16) as *mut __m512i, index_bytes_1);
+
+        // Update pointers
+        alpha_byte_out_ptr = alpha_byte_out_ptr.add(16);
+        alpha_bit_out_ptr = alpha_bit_out_ptr.add(48);
+        color_out_ptr = color_out_ptr.add(32);
+        index_out_ptr = index_out_ptr.add(32);
+    }
+
+    // Process any remaining blocks (less than 8)
+    if remaining_len > 0 {
+        let alpha_byte_end_ptr = output_ptr.add(len / 16 * 2);
+        u32_with_separate_endpoints(
+            current_input_ptr,              // Start of remaining input data
+            alpha_byte_out_ptr as *mut u16, // Start of remaining alpha byte output
+            alpha_bit_out_ptr as *mut u16,  // Start of alpha bits
+            color_out_ptr as *mut u32,      // Start of remaining color output
+            index_out_ptr as *mut u32,      // Start of remaining index output
+            alpha_byte_end_ptr as *mut u16, // End of alpha byte section
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split_blocks::split::tests::{
+        assert_implementation_matches_reference, generate_bc3_test_data,
+        transform_with_reference_implementation,
+    };
+    use crate::testutils::allocate_align_64;
+    use rstest::rstest;
+
+    #[rstest]
+    fn test_avx512_aligned() {
+        for num_blocks in 1..=512 {
+            let input = generate_bc3_test_data(num_blocks);
+            let mut output_expected = vec![0u8; input.len()];
+            transform_with_reference_implementation(input.as_slice(), &mut output_expected);
+
+            let mut output_test = allocate_align_64(input.len());
+            output_test.as_mut_slice().fill(0);
+            unsafe {
+                avx512_vbmi(input.as_ptr(), output_test.as_mut_ptr(), input.len());
+            }
+
+            assert_implementation_matches_reference(
+                output_expected.as_slice(),
+                output_test.as_slice(),
+                "avx512",
+                num_blocks,
+            );
+        }
+    }
+
+    #[rstest]
+    fn test_avx512_unaligned() {
+        for num_blocks in 1..=512 {
+            let input = generate_bc3_test_data(num_blocks);
+            let mut output_expected = vec![0u8; input.len() + 1];
+            transform_with_reference_implementation(input.as_slice(), &mut output_expected[1..]);
+
+            let mut output_test = vec![0u8; input.len() + 1];
+            output_test.as_mut_slice().fill(0);
+            unsafe {
+                avx512_vbmi(input.as_ptr(), output_test.as_mut_ptr().add(1), input.len());
+            }
+
+            assert_implementation_matches_reference(
+                &output_expected[1..],
+                &output_test[1..],
+                "avx512",
+                num_blocks,
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx512.rs
@@ -13,6 +13,7 @@ use super::portable32::u32_with_separate_endpoints;
 #[target_feature(enable = "avx512vbmi")]
 #[allow(clippy::identity_op)]
 #[allow(clippy::erasing_op)]
+#[no_mangle]
 pub unsafe fn avx512_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
@@ -232,6 +233,10 @@ mod tests {
 
     #[rstest]
     fn test_avx512_aligned() {
+        if !is_x86_feature_detected!("avx512vbmi") {
+            return;
+        }
+
         for num_blocks in 1..=512 {
             let input = generate_bc3_test_data(num_blocks);
             let mut output_expected = vec![0u8; input.len()];
@@ -254,6 +259,10 @@ mod tests {
 
     #[rstest]
     fn test_avx512_unaligned() {
+        if !is_x86_feature_detected!("avx512vbmi") {
+            return;
+        }
+
         for num_blocks in 1..=512 {
             let input = generate_bc3_test_data(num_blocks);
             let mut output_expected = vec![0u8; input.len() + 1];

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/split/avx512.rs
@@ -14,6 +14,8 @@ use super::portable32::u32_with_separate_endpoints;
 #[allow(clippy::identity_op)]
 #[allow(clippy::erasing_op)]
 pub unsafe fn avx512_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    // Note: Leaving as intrinsics because the compiler generated form for ancient CPU
+    // produces OK code.
     debug_assert!(len % 16 == 0);
 
     // Process 8 blocks (128 bytes) at a time

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/avx512.rs
@@ -1,0 +1,895 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use crate::split_blocks::unsplit::portable::u32_detransform_with_separate_pointers;
+
+/// # Safety
+///
+/// - Same safety requirements as the scalar version:
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512vbmi")]
+pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    // Non-64bit has an optimized path, and vl + non-vl variant
+    #[cfg(not(target_arch = "x86_64"))]
+    avx512_detransform_32(input_ptr, output_ptr, len);
+
+    #[cfg(target_arch = "x86_64")]
+    {
+        debug_assert!(len % 16 == 0);
+        // Process as many 64-byte blocks as possible
+        let current_output_ptr = output_ptr;
+
+        // Set up input pointers for each section
+        let alpha_byte_in_ptr = input_ptr;
+        let alpha_bit_in_ptr = input_ptr.add(len / 16 * 2);
+        let color_byte_in_ptr = input_ptr.add(len / 16 * 8);
+        let index_byte_in_ptr = input_ptr.add(len / 16 * 12);
+
+        avx512_detransform_separate_components(
+            alpha_byte_in_ptr,
+            alpha_bit_in_ptr,
+            color_byte_in_ptr,
+            index_byte_in_ptr,
+            current_output_ptr,
+            len,
+        );
+    }
+}
+
+/// # Safety
+///
+/// - Same safety requirements as the scalar version:
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512vbmi")]
+pub unsafe fn avx512_detransform_32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    #[cfg(target_feature = "avx512vl")]
+    let is_vl_supported = true;
+
+    #[cfg(not(target_feature = "avx512vl"))]
+    let is_vl_supported = is_x86_feature_detected!("avx512vl");
+
+    if is_vl_supported {
+        avx512_detransform_32_vl(input_ptr, output_ptr, len);
+    } else {
+        avx512_detransform_32_vbmi(input_ptr, output_ptr, len);
+    }
+}
+
+/// # Safety
+///
+/// - Same safety requirements as the scalar version:
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512vbmi")]
+#[target_feature(enable = "avx512vl")]
+pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    // Process as many 64-byte blocks as possible
+    let current_output_ptr = output_ptr;
+
+    // Set up input pointers for each section
+    let alpha_byte_in_ptr = input_ptr;
+    let alpha_bit_in_ptr = input_ptr.add(len / 16 * 2);
+    let color_byte_in_ptr = input_ptr.add(len / 16 * 8);
+    let index_byte_in_ptr = input_ptr.add(len / 16 * 12);
+
+    avx512_detransform_separate_components_32_vl(
+        alpha_byte_in_ptr,
+        alpha_bit_in_ptr,
+        color_byte_in_ptr,
+        index_byte_in_ptr,
+        current_output_ptr,
+        len,
+    );
+}
+
+/// # Safety
+///
+/// - Same safety requirements as the scalar version:
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512vbmi")]
+pub unsafe fn avx512_detransform_32_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    // Process as many 64-byte blocks as possible
+    let current_output_ptr = output_ptr;
+
+    // Set up input pointers for each section
+    let alpha_byte_in_ptr = input_ptr;
+    let alpha_bit_in_ptr = input_ptr.add(len / 16 * 2);
+    let color_byte_in_ptr = input_ptr.add(len / 16 * 8);
+    let index_byte_in_ptr = input_ptr.add(len / 16 * 12);
+
+    avx512_detransform_separate_components_32(
+        alpha_byte_in_ptr,
+        alpha_bit_in_ptr,
+        color_byte_in_ptr,
+        index_byte_in_ptr,
+        current_output_ptr,
+        len,
+    );
+}
+
+/// Detransforms BC3 block data from separated components using AVX512 instructions.
+///
+/// # Arguments
+///
+/// * `alpha_byte_in_ptr` - Pointer to the input buffer containing alpha endpoint pairs (2 bytes per block).
+/// * `alpha_bit_in_ptr` - Pointer to the input buffer containing packed alpha indices (6 bytes per block).
+/// * `color_byte_in_ptr` - Pointer to the input buffer containing color endpoint pairs (packed RGB565, 4 bytes per block) and unused padding (4 bytes per block). Loaded as `__m128i`.
+/// * `index_byte_in_ptr` - Pointer to the input buffer containing color indices (4 bytes per block) and unused padding (4 bytes per block). Loaded as `__m128i`.
+/// * `current_output_ptr` - Pointer to the output buffer where the reconstructed BC3 blocks (16 bytes per block) will be written.
+/// * `len` - The total number of bytes to write to the output buffer. Must be a multiple of 16.
+///
+/// # Safety
+///
+/// - All input pointers must be valid for reads corresponding to `len` bytes of output.
+///   - `alpha_byte_in_ptr` needs `len / 16 * 2` readable bytes.
+///   - `alpha_bit_in_ptr` needs `len / 16 * 6` readable bytes.
+///   - `color_byte_in_ptr` needs `len / 16 * 8` readable bytes.
+///   - `index_byte_in_ptr` needs `len / 16 * 8` readable bytes.
+/// - `current_output_ptr` must be valid for writes for `len` bytes.
+/// - `len` must be a multiple of 16 (the size of a BC3 block).
+/// - Pointers do not need to be aligned; unaligned loads/reads are used.
+#[allow(clippy::erasing_op)]
+#[allow(clippy::identity_op)]
+#[target_feature(enable = "avx512vbmi")]
+pub unsafe fn avx512_detransform_separate_components(
+    mut alpha_byte_in_ptr: *const u8,
+    mut alpha_bit_in_ptr: *const u8,
+    mut color_byte_in_ptr: *const u8,
+    mut index_byte_in_ptr: *const u8,
+    mut current_output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 16 == 0);
+    const BYTES_PER_ITERATION: usize = 512;
+    // We drop some alpha bits, which may lead to an overrun so we should technically subtract,
+    // however it's impossible to get a read over the buffer here, as the colours and indices follow
+    // right after; so we can just work with aligned len just fine.
+    let aligned_len = len - (len % BYTES_PER_ITERATION);
+    let alpha_byte_end_ptr = alpha_byte_in_ptr.add(aligned_len / 16 * 2);
+
+    // Add the alpha bits to the alpha bytes register
+    #[rustfmt::skip]
+    let blocks_0_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        23+64,22+64, 21+64,20+64,19+64,18+64, // alpha bits 3
+        7,6, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        17+64,16+64,15+64,14+64,13+64,12+64, // alpha bits 2
+        5,4, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        11+64,10+64,9+64,8+64,7+64,6+64, // alpha bits 1
+        3,2, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        5+64,4+64,3+64,2+64,1+64,0+64, // alpha bits 0
+        1,0 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_1_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        47+64,46+64, 45+64,44+64,43+64,42+64, // alpha bits 3
+        15,14, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        41+64,40+64,39+64,38+64,37+64,36+64, // alpha bits 2
+        13,12, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        35+64,34+64,33+64,32+64,31+64,30+64, // alpha bits 1
+        11,10, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        29+64,28+64,27+64,26+64,25+64,24+64, // alpha bits 0
+        9,8 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_2_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        23+64,22+64, 21+64,20+64,19+64,18+64, // alpha bits 3
+        23,22, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        17+64,16+64,15+64,14+64,13+64,12+64, // alpha bits 2
+        21,20, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        11+64,10+64,9+64,8+64,7+64,6+64, // alpha bits 1
+        19,18, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        5+64,4+64,3+64,2+64,1+64,0+64, // alpha bits 0
+        17,16 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_3_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        47+64,46+64, 45+64,44+64,43+64,42+64, // alpha bits 3
+        31,30, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        41+64,40+64,39+64,38+64,37+64,36+64, // alpha bits 2
+        29,28, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        35+64,34+64,33+64,32+64,31+64,30+64, // alpha bits 1
+        27,26, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        29+64,28+64,27+64,26+64,25+64,24+64, // alpha bits 0
+        25,24 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_4_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        23+64,22+64, 21+64,20+64,19+64,18+64, // alpha bits 3
+        39,38, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        17+64,16+64,15+64,14+64,13+64,12+64, // alpha bits 2
+        37,36, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        11+64,10+64,9+64,8+64,7+64,6+64, // alpha bits 1
+        35,34, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        5+64,4+64,3+64,2+64,1+64,0+64, // alpha bits 0
+        33,32 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_5_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        47+64,46+64, 45+64,44+64,43+64,42+64, // alpha bits 3
+        47,46, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        41+64,40+64,39+64,38+64,37+64,36+64, // alpha bits 2
+        45,44, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        35+64,34+64,33+64,32+64,31+64,30+64, // alpha bits 1
+        43,42, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        29+64,28+64,27+64,26+64,25+64,24+64, // alpha bits 0
+        41,40 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_6_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        23+64,22+64, 21+64,20+64,19+64,18+64, // alpha bits 3
+        55,54, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        17+64,16+64,15+64,14+64,13+64,12+64, // alpha bits 2
+        53,52, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        11+64,10+64,9+64,8+64,7+64,6+64, // alpha bits 1
+        51,50, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        5+64,4+64,3+64,2+64,1+64,0+64, // alpha bits 0
+        49,48 // alpha bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_7_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        47+64,46+64, 45+64,44+64,43+64,42+64, // alpha bits 3
+        63,62, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        41+64,40+64,39+64,38+64,37+64,36+64, // alpha bits 2
+        61,60, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        35+64,34+64,33+64,32+64,31+64,30+64, // alpha bits 1
+        59,58, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        29+64,28+64,27+64,26+64,25+64,24+64, // alpha bits 0
+        57,56 // alpha bytes 0
+    );
+
+    // Add the colours to the alpha bytes+alpha bits register
+    #[rustfmt::skip]
+    let blocks_0_perm_colours: __m512i = _mm512_set_epi8(
+        0,0,0,0,
+        15+64,14+64,13+64,12+64, // colours 3
+        55,54, 53,52,51,50, 49,48, // existing bytes 3
+        0,0,0,0,
+        11+64,10+64,9+64,8+64, // colours 2
+        39,38,37,36,35,34, 33,32, // existing bytes 2
+        0,0,0,0,
+        7+64,6+64,5+64,4+64, // colours 1
+        23,22,21,20,19,18, 17,16, // existing bytes 1
+        0,0, 0,0,
+        3+64,2+64,1+64,0+64, // colours 0
+        7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_1_perm_colours: __m512i = _mm512_set_epi8(
+        0,0,0,0,
+        31+64,30+64,29+64,28+64, // colours 3
+        55,54, 53,52,51,50, 49,48, // existing bytes 3
+        0,0,0,0,
+        27+64,26+64,25+64,24+64, // colours 2
+        39,38,37,36,35,34, 33,32, // existing bytes 2
+        0,0,0,0,
+        23+64,22+64,21+64,20+64, // colours 1
+        23,22,21,20,19,18, 17,16, // existing bytes 1
+        0,0, 0,0,
+        19+64,18+64,17+64,16+64, // colours 0
+        7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_2_perm_colours: __m512i = _mm512_set_epi8(
+        0,0,0,0,
+        47+64,46+64,45+64,44+64, // colours 3
+        55,54, 53,52,51,50, 49,48, // existing bytes 3
+        0,0,0,0,
+        43+64,42+64,41+64,40+64, // colours 2
+        39,38,37,36,35,34, 33,32, // existing bytes 2
+        0,0,0,0,
+        39+64,38+64,37+64,36+64, // colours 1
+        23,22,21,20,19,18, 17,16, // existing bytes 1
+        0,0, 0,0,
+        35+64,34+64,33+64,32+64, // colours 0
+        7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_3_perm_colours: __m512i = _mm512_set_epi8(
+        0,0,0,0,
+        63+64,62+64,61+64,60+64, // colours 3
+        55,54, 53,52,51,50, 49,48, // existing bytes 3
+        0,0,0,0,
+        59+64,58+64,57+64,56+64, // colours 2
+        39,38,37,36,35,34, 33,32, // existing bytes 2
+        0,0,0,0,
+        55+64,54+64,53+64,52+64, // colours 1
+        23,22,21,20,19,18, 17,16, // existing bytes 1
+        0,0, 0,0,
+        51+64,50+64,49+64,48+64, // colours 0
+        7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    // Add the indices to the alpha bytes+alpha bits+colours register
+    #[rustfmt::skip]
+    let blocks_0_perm_indices: __m512i = _mm512_set_epi8(
+        15+64,14+64,13+64,12+64, // indices 3
+        59,58,57,56, 55,54, 53,52,51,50, 49,48, // existing bytes 3
+        11+64,10+64,9+64,8+64, // indices 2
+        43,42,41,40, 39,38,37,36,35,34, 33,32, // existing bytes 2
+        7+64,6+64,5+64,4+64, // indices 1
+        27,26,25,24, 23,22,21,20,19,18, 17,16, // existing bytes 1
+        3+64,2+64,1+64,0+64, // indices 0
+        11,10, 9,8, 7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_1_perm_indices: __m512i = _mm512_set_epi8(
+        31+64,30+64,29+64,28+64, // indices 3
+        59,58,57,56, 55,54, 53,52,51,50, 49,48, // existing bytes 3
+        27+64,26+64,25+64,24+64, // indices 2
+        43,42,41,40, 39,38,37,36,35,34, 33,32, // existing bytes 2
+        23+64,22+64,21+64,20+64, // indices 1
+        27,26,25,24, 23,22,21,20,19,18, 17,16, // existing bytes 1
+        19+64,18+64,17+64,16+64, // indices 0
+        11,10, 9,8, 7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_2_perm_indices: __m512i = _mm512_set_epi8(
+        47+64,46+64,45+64,44+64, // indices 3
+        59,58,57,56, 55,54, 53,52,51,50, 49,48, // existing bytes 3
+        43+64,42+64,41+64,40+64, // indices 2
+        43,42,41,40, 39,38,37,36,35,34, 33,32, // existing bytes 2
+        39+64,38+64,37+64,36+64, // indices 1
+        27,26,25,24, 23,22,21,20,19,18, 17,16, // existing bytes 1
+        35+64,34+64,33+64,32+64, // indices 0
+        11,10, 9,8, 7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    #[rustfmt::skip]
+    let blocks_3_perm_indices: __m512i = _mm512_set_epi8(
+        63+64,62+64,61+64,60+64, // indices 3
+        59,58,57,56, 55,54, 53,52,51,50, 49,48, // existing bytes 3
+        59+64,58+64,57+64,56+64, // indices 2
+        43,42,41,40, 39,38,37,36,35,34, 33,32, // existing bytes 2
+        55+64,54+64,53+64,52+64, // indices 1
+        27,26,25,24, 23,22,21,20,19,18, 17,16, // existing bytes 1
+        51+64,50+64,49+64,48+64, // indices 0
+        11,10, 9,8, 7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    while alpha_byte_in_ptr < alpha_byte_end_ptr {
+        // Okay, so we can read 64 bytes of alpha bytes (2 byte) at a time.
+        // This means 32-blocks read in single read. (1x)
+        //
+        // For colours and indices, this is 4 bytes at a time.
+        // So 16-blocks per read. (2x)
+        //
+        // For alpha bits (6 bytes), the math does not divide evenly (64 / 6) == ~10.6.
+        // So we have to round this down to 8 blocks. (4x)
+        // 8 blocks * 48 bits == 384 bits total. 48 bytes per read.
+        //
+        // What does this mean? To maximize throughput, we read 4x of alpha bits (largest item),
+        // then blend with other registers to reproduce the original blocks.
+
+        // Read in the individual components.
+        // In AVX512 we got 32 registers, we're going to cook with them all!
+
+        // [4]  9 input registers <- from memory (4 always active)
+        // [16] 8+4+4 permutation registers <- from memory (16 always active)
+        // [4]  8 output registers <- to memory (4 always active)
+        // So around 33 registers used total, but only 24 registers 'active' at any given point.
+        // Therefore this fits in the 32 reg limit nicely for AVX512 on x86-64.
+
+        // The alpha bytes for 32 blocks
+        let alpha_bytes_0 = _mm512_loadu_si512(alpha_byte_in_ptr as *const __m512i); // 32 blocks, 8 regs
+        alpha_byte_in_ptr = alpha_byte_in_ptr.add(64);
+
+        // The colors and indices for 32 blocks (16 blocks per read)
+        let colors_0 = _mm512_loadu_si512(color_byte_in_ptr as *const __m512i); // 16 blocks, 4 regs
+        let colors_1 = _mm512_loadu_si512(color_byte_in_ptr.add(64) as *const __m512i); // 16 blocks, 4 regs
+        color_byte_in_ptr = color_byte_in_ptr.add(128);
+
+        let indices_0 = _mm512_loadu_si512(index_byte_in_ptr as *const __m512i); // 16 blocks, 4 regs
+        let indices_1 = _mm512_loadu_si512(index_byte_in_ptr.add(64) as *const __m512i); // 16 blocks, 4 regs
+        index_byte_in_ptr = index_byte_in_ptr.add(128);
+
+        // The alpha bits for 32 blocks (8 blocks per read)
+        let alpha_bit_0 = _mm512_loadu_si512(alpha_bit_in_ptr as *const __m512i); // 8 blocks, 2 regs
+        let alpha_bit_1 = _mm512_loadu_si512(alpha_bit_in_ptr.add(48) as *const __m512i); // 8 blocks, 2 regs
+        let alpha_bit_2 = _mm512_loadu_si512(alpha_bit_in_ptr.add(96) as *const __m512i); // 8 blocks, 2 regs
+        let alpha_bit_3 = _mm512_loadu_si512(alpha_bit_in_ptr.add(144) as *const __m512i); // 8 blocks, 2 regs
+        alpha_bit_in_ptr = alpha_bit_in_ptr.add(192);
+
+        // 9 regs used, let's use another 8
+        // and another few for the permutations
+
+        // Now let's reassemble the 32 blocks
+        // 64 / 16 == 4 blocks per register, so 8 registers of blocks needed because we got 32 blocks
+        let mut blocks_0 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_0_perm_alphabits, alpha_bit_0);
+        blocks_0 = _mm512_permutex2var_epi8(blocks_0, blocks_0_perm_colours, colors_0);
+        blocks_0 = _mm512_permutex2var_epi8(blocks_0, blocks_0_perm_indices, indices_0);
+
+        let mut blocks_1 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_1_perm_alphabits, alpha_bit_0);
+        blocks_1 = _mm512_permutex2var_epi8(blocks_1, blocks_1_perm_colours, colors_0);
+        blocks_1 = _mm512_permutex2var_epi8(blocks_1, blocks_1_perm_indices, indices_0);
+
+        let mut blocks_2 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_2_perm_alphabits, alpha_bit_1);
+        blocks_2 = _mm512_permutex2var_epi8(blocks_2, blocks_2_perm_colours, colors_0);
+        blocks_2 = _mm512_permutex2var_epi8(blocks_2, blocks_2_perm_indices, indices_0);
+
+        let mut blocks_3 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_3_perm_alphabits, alpha_bit_1);
+        blocks_3 = _mm512_permutex2var_epi8(blocks_3, blocks_3_perm_colours, colors_0);
+        blocks_3 = _mm512_permutex2var_epi8(blocks_3, blocks_3_perm_indices, indices_0);
+
+        let mut blocks_4 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_4_perm_alphabits, alpha_bit_2);
+        blocks_4 = _mm512_permutex2var_epi8(blocks_4, blocks_0_perm_colours, colors_1);
+        blocks_4 = _mm512_permutex2var_epi8(blocks_4, blocks_0_perm_indices, indices_1);
+
+        let mut blocks_5 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_5_perm_alphabits, alpha_bit_2);
+        blocks_5 = _mm512_permutex2var_epi8(blocks_5, blocks_1_perm_colours, colors_1);
+        blocks_5 = _mm512_permutex2var_epi8(blocks_5, blocks_1_perm_indices, indices_1);
+
+        let mut blocks_6 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_6_perm_alphabits, alpha_bit_3);
+        blocks_6 = _mm512_permutex2var_epi8(blocks_6, blocks_2_perm_colours, colors_1);
+        blocks_6 = _mm512_permutex2var_epi8(blocks_6, blocks_2_perm_indices, indices_1);
+
+        let mut blocks_7 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_7_perm_alphabits, alpha_bit_3);
+        blocks_7 = _mm512_permutex2var_epi8(blocks_7, blocks_3_perm_colours, colors_1);
+        blocks_7 = _mm512_permutex2var_epi8(blocks_7, blocks_3_perm_indices, indices_1);
+
+        // Now compiler will swap out `alpha_bit_1` into register of `alpha_bit_0`, hopefully.
+        _mm512_storeu_si512(current_output_ptr as *mut __m512i, blocks_0);
+        _mm512_storeu_si512(current_output_ptr.add(64) as *mut __m512i, blocks_1);
+        _mm512_storeu_si512(current_output_ptr.add(128) as *mut __m512i, blocks_2);
+        _mm512_storeu_si512(current_output_ptr.add(192) as *mut __m512i, blocks_3);
+        _mm512_storeu_si512(current_output_ptr.add(256) as *mut __m512i, blocks_4);
+        _mm512_storeu_si512(current_output_ptr.add(320) as *mut __m512i, blocks_5);
+        _mm512_storeu_si512(current_output_ptr.add(384) as *mut __m512i, blocks_6);
+        _mm512_storeu_si512(current_output_ptr.add(448) as *mut __m512i, blocks_7);
+
+        // The colors and indices for 8 blocks
+        current_output_ptr = current_output_ptr.add(BYTES_PER_ITERATION);
+    }
+
+    // Convert pointers to the types expected by u32_detransform_with_separate_pointers
+    let alpha_byte_in_ptr_u16 = alpha_byte_in_ptr as *const u16;
+    let alpha_bit_in_ptr_u16 = alpha_bit_in_ptr as *const u16;
+    let color_byte_in_ptr_u32 = color_byte_in_ptr as *const u32;
+    let index_byte_in_ptr_u32 = index_byte_in_ptr as *const u32;
+
+    u32_detransform_with_separate_pointers(
+        alpha_byte_in_ptr_u16,
+        alpha_bit_in_ptr_u16,
+        color_byte_in_ptr_u32,
+        index_byte_in_ptr_u32,
+        current_output_ptr,
+        len - aligned_len,
+    );
+}
+
+/// Detransforms BC3 block data from separated components using AVX512 instructions.
+/// [32-bit optimized variant]
+///
+/// # Arguments
+///
+/// * `alpha_byte_in_ptr` - Pointer to the input buffer containing alpha endpoint pairs (2 bytes per block).
+/// * `alpha_bit_in_ptr` - Pointer to the input buffer containing packed alpha indices (6 bytes per block).
+/// * `color_byte_in_ptr` - Pointer to the input buffer containing color endpoint pairs (packed RGB565, 4 bytes per block) and unused padding (4 bytes per block). Loaded as `__m128i`.
+/// * `index_byte_in_ptr` - Pointer to the input buffer containing color indices (4 bytes per block) and unused padding (4 bytes per block). Loaded as `__m128i`.
+/// * `current_output_ptr` - Pointer to the output buffer where the reconstructed BC3 blocks (16 bytes per block) will be written.
+/// * `len` - The total number of bytes to write to the output buffer. Must be a multiple of 16.
+///
+/// # Safety
+///
+/// - All input pointers must be valid for reads corresponding to `len` bytes of output.
+///   - `alpha_byte_in_ptr` needs `len / 16 * 2` readable bytes.
+///   - `alpha_bit_in_ptr` needs `len / 16 * 6` readable bytes.
+///   - `color_byte_in_ptr` needs `len / 16 * 8` readable bytes.
+///   - `index_byte_in_ptr` needs `len / 16 * 8` readable bytes.
+/// - `current_output_ptr` must be valid for writes for `len` bytes.
+/// - `len` must be a multiple of 16 (the size of a BC3 block).
+/// - Pointers do not need to be aligned; unaligned loads/reads are used.
+#[allow(clippy::erasing_op)]
+#[allow(clippy::identity_op)]
+#[target_feature(enable = "avx512vbmi")]
+pub unsafe fn avx512_detransform_separate_components_32(
+    mut alpha_byte_in_ptr: *const u8,
+    mut alpha_bit_in_ptr: *const u8,
+    mut color_byte_in_ptr: *const u8,
+    mut index_byte_in_ptr: *const u8,
+    mut current_output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 16 == 0);
+    const BYTES_PER_ITERATION: usize = 64;
+    // We drop some alpha bits, which may lead to an overrun so we should technically subtract,
+    // however it's impossible to get a read over the buffer here, as the colours and indices follow
+    // right after; so we can just work with aligned len just fine.
+    let aligned_len = len - (len % BYTES_PER_ITERATION);
+    let alpha_byte_end_ptr = alpha_byte_in_ptr.add(aligned_len / 16 * 2);
+
+    // Add the alpha bits to the alpha bytes register
+    #[rustfmt::skip]
+    let blocks_0_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        23+64,22+64, 21+64,20+64,19+64,18+64, // alpha bits 3
+        7,6, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        17+64,16+64,15+64,14+64,13+64,12+64, // alpha bits 2
+        5,4, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        11+64,10+64,9+64,8+64,7+64,6+64, // alpha bits 1
+        3,2, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        5+64,4+64,3+64,2+64,1+64,0+64, // alpha bits 0
+        1,0 // alpha bytes 0
+    );
+
+    // Add the colours to the alpha bytes+alpha bits register
+    #[rustfmt::skip]
+    let blocks_0_perm_colours: __m512i = _mm512_set_epi8(
+        0,0,0,0,
+        15+64,14+64,13+64,12+64, // colours 3
+        55,54, 53,52,51,50, 49,48, // existing bytes 3
+        0,0,0,0,
+        11+64,10+64,9+64,8+64, // colours 2
+        39,38,37,36,35,34, 33,32, // existing bytes 2
+        0,0,0,0,
+        7+64,6+64,5+64,4+64, // colours 1
+        23,22,21,20,19,18, 17,16, // existing bytes 1
+        0,0, 0,0,
+        3+64,2+64,1+64,0+64, // colours 0
+        7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    // Add the indices to the alpha bytes+alpha bits+colours register
+    #[rustfmt::skip]
+    let blocks_0_perm_indices: __m512i = _mm512_set_epi8(
+        15+64,14+64,13+64,12+64, // indices 3
+        59,58,57,56, 55,54, 53,52,51,50, 49,48, // existing bytes 3
+        11+64,10+64,9+64,8+64, // indices 2
+        43,42,41,40, 39,38,37,36,35,34, 33,32, // existing bytes 2
+        7+64,6+64,5+64,4+64, // indices 1
+        27,26,25,24, 23,22,21,20,19,18, 17,16, // existing bytes 1
+        3+64,2+64,1+64,0+64, // indices 0
+        11,10, 9,8, 7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    while alpha_byte_in_ptr < alpha_byte_end_ptr {
+        // This is a variant of the 64-bit version that minimizes register usage for x86.
+        // Same code as above, but no unroll.
+        // Each zmm register stores 4 blocks.
+
+        // The alpha bytes, (4 blocks * 2 bytes == 8 bytes)
+        let alpha_bytes_0 = _mm512_loadu_si512(alpha_byte_in_ptr as *const __m512i); // 32 blocks, 8 regs
+        alpha_byte_in_ptr = alpha_byte_in_ptr.add(8);
+
+        // The colors and indices (4 blocks * 4 bytes == 16 bytes)
+        let colors_0 = _mm512_loadu_si512(color_byte_in_ptr as *const __m512i); // 16 blocks, 4 regs
+        color_byte_in_ptr = color_byte_in_ptr.add(16);
+
+        let indices_0 = _mm512_loadu_si512(index_byte_in_ptr as *const __m512i); // 16 blocks, 4 regs
+        index_byte_in_ptr = index_byte_in_ptr.add(16);
+
+        // The alpha bits (4 blocks * 6 bytes == 24 bytes)
+        let alpha_bit_0 = _mm512_loadu_si512(alpha_bit_in_ptr as *const __m512i); // 8 blocks, 2 regs
+        alpha_bit_in_ptr = alpha_bit_in_ptr.add(24);
+
+        // 9 regs used, let's use another 8
+        // and another few for the permutations
+
+        // Now let's reassemble the 32 blocks
+        // 64 / 16 == 4 blocks per register, so 8 registers of blocks needed because we got 32 blocks
+        let mut blocks_0 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_0_perm_alphabits, alpha_bit_0);
+        blocks_0 = _mm512_permutex2var_epi8(blocks_0, blocks_0_perm_colours, colors_0);
+        blocks_0 = _mm512_permutex2var_epi8(blocks_0, blocks_0_perm_indices, indices_0);
+
+        // Now compiler will swap out `alpha_bit_1` into register of `alpha_bit_0`, hopefully.
+        _mm512_storeu_si512(current_output_ptr as *mut __m512i, blocks_0);
+
+        // The colors and indices for 8 blocks
+        current_output_ptr = current_output_ptr.add(BYTES_PER_ITERATION);
+    }
+
+    // Convert pointers to the types expected by u32_detransform_with_separate_pointers
+    let alpha_byte_in_ptr_u16 = alpha_byte_in_ptr as *const u16;
+    let alpha_bit_in_ptr_u16 = alpha_bit_in_ptr as *const u16;
+    let color_byte_in_ptr_u32 = color_byte_in_ptr as *const u32;
+    let index_byte_in_ptr_u32 = index_byte_in_ptr as *const u32;
+
+    u32_detransform_with_separate_pointers(
+        alpha_byte_in_ptr_u16,
+        alpha_bit_in_ptr_u16,
+        color_byte_in_ptr_u32,
+        index_byte_in_ptr_u32,
+        current_output_ptr,
+        len - aligned_len,
+    );
+}
+
+/// Detransforms BC3 block data from separated components using AVX512 instructions.
+/// [32-bit optimized variant]
+///
+/// # Arguments
+///
+/// * `alpha_byte_in_ptr` - Pointer to the input buffer containing alpha endpoint pairs (2 bytes per block).
+/// * `alpha_bit_in_ptr` - Pointer to the input buffer containing packed alpha indices (6 bytes per block).
+/// * `color_byte_in_ptr` - Pointer to the input buffer containing color endpoint pairs (packed RGB565, 4 bytes per block) and unused padding (4 bytes per block). Loaded as `__m128i`.
+/// * `index_byte_in_ptr` - Pointer to the input buffer containing color indices (4 bytes per block) and unused padding (4 bytes per block). Loaded as `__m128i`.
+/// * `current_output_ptr` - Pointer to the output buffer where the reconstructed BC3 blocks (16 bytes per block) will be written.
+/// * `len` - The total number of bytes to write to the output buffer. Must be a multiple of 16.
+///
+/// # Safety
+///
+/// - All input pointers must be valid for reads corresponding to `len` bytes of output.
+///   - `alpha_byte_in_ptr` needs `len / 16 * 2` readable bytes.
+///   - `alpha_bit_in_ptr` needs `len / 16 * 6` readable bytes.
+///   - `color_byte_in_ptr` needs `len / 16 * 8` readable bytes.
+///   - `index_byte_in_ptr` needs `len / 16 * 8` readable bytes.
+/// - `current_output_ptr` must be valid for writes for `len` bytes.
+/// - `len` must be a multiple of 16 (the size of a BC3 block).
+/// - Pointers do not need to be aligned; unaligned loads/reads are used.
+#[allow(clippy::erasing_op)]
+#[allow(clippy::identity_op)]
+#[target_feature(enable = "avx512vbmi")]
+#[target_feature(enable = "avx512vl")]
+pub unsafe fn avx512_detransform_separate_components_32_vl(
+    mut alpha_byte_in_ptr: *const u8,
+    mut alpha_bit_in_ptr: *const u8,
+    mut color_byte_in_ptr: *const u8,
+    mut index_byte_in_ptr: *const u8,
+    mut current_output_ptr: *mut u8,
+    len: usize,
+) {
+    debug_assert!(len % 16 == 0);
+    const BYTES_PER_ITERATION: usize = 64;
+    // We drop some alpha bits, which may lead to an overrun so we should technically subtract,
+    // however it's impossible to get a read over the buffer here, as the colours and indices follow
+    // right after; so we can just work with aligned len just fine.
+    let aligned_len = len - (len % BYTES_PER_ITERATION);
+    let alpha_byte_end_ptr = alpha_byte_in_ptr.add(aligned_len / 16 * 2);
+
+    // Add the alpha bits to the alpha bytes register
+    #[rustfmt::skip]
+    let blocks_0_perm_alphabits: __m512i = _mm512_set_epi8(
+        0,0,0,0,0,0,0,0,
+        23+64,22+64, 21+64,20+64,19+64,18+64, // alpha bits 3
+        7,6, // alpha bytes 3
+        0,0,0,0,0,0,0,0,
+        17+64,16+64,15+64,14+64,13+64,12+64, // alpha bits 2
+        5,4, // alpha bytes 2
+        0,0,0,0,0,0,0,0,
+        11+64,10+64,9+64,8+64,7+64,6+64, // alpha bits 1
+        3,2, // alpha bytes 1
+        0,0, 0,0,0,0,0,0,
+        5+64,4+64,3+64,2+64,1+64,0+64, // alpha bits 0
+        1,0 // alpha bytes 0
+    );
+
+    // Add the colours to the alpha bytes+alpha bits register
+    #[rustfmt::skip]
+    let blocks_0_perm_colours: __m512i = _mm512_set_epi8(
+        0,0,0,0,
+        15+64,14+64,13+64,12+64, // colours 3
+        55,54, 53,52,51,50, 49,48, // existing bytes 3
+        0,0,0,0,
+        11+64,10+64,9+64,8+64, // colours 2
+        39,38,37,36,35,34, 33,32, // existing bytes 2
+        0,0,0,0,
+        7+64,6+64,5+64,4+64, // colours 1
+        23,22,21,20,19,18, 17,16, // existing bytes 1
+        0,0, 0,0,
+        3+64,2+64,1+64,0+64, // colours 0
+        7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    // Add the indices to the alpha bytes+alpha bits+colours register
+    #[rustfmt::skip]
+    let blocks_0_perm_indices: __m512i = _mm512_set_epi8(
+        15+64,14+64,13+64,12+64, // indices 3
+        59,58,57,56, 55,54, 53,52,51,50, 49,48, // existing bytes 3
+        11+64,10+64,9+64,8+64, // indices 2
+        43,42,41,40, 39,38,37,36,35,34, 33,32, // existing bytes 2
+        7+64,6+64,5+64,4+64, // indices 1
+        27,26,25,24, 23,22,21,20,19,18, 17,16, // existing bytes 1
+        3+64,2+64,1+64,0+64, // indices 0
+        11,10, 9,8, 7,6,5,4,3,2,1,0 // existing bytes 0
+    );
+
+    while alpha_byte_in_ptr < alpha_byte_end_ptr {
+        // This is a variant of the 64-bit version that minimizes register usage for x86.
+        // Same code as above, but no unroll.
+        // Each zmm register stores 4 blocks.
+
+        // The alpha bytes, (4 blocks * 2 bytes == 8 bytes)
+        let alpha_bytes_0 =
+            _mm512_castsi128_si512(_mm_loadu_si128(alpha_byte_in_ptr as *const __m128i)); // 32 blocks, 8 regs
+        alpha_byte_in_ptr = alpha_byte_in_ptr.add(8);
+
+        // The colors and indices (4 blocks * 4 bytes == 16 bytes)
+        let colors_0 = _mm512_castsi128_si512(_mm_loadu_si128(color_byte_in_ptr as *const __m128i)); // 16 blocks, 4 regs
+        color_byte_in_ptr = color_byte_in_ptr.add(16);
+
+        let indices_0 =
+            _mm512_castsi128_si512(_mm_loadu_si128(index_byte_in_ptr as *const __m128i)); // 16 blocks, 4 regs
+        index_byte_in_ptr = index_byte_in_ptr.add(16);
+
+        // The alpha bits (4 blocks * 6 bytes == 24 bytes)
+        let alpha_bit_0 =
+            _mm512_castsi256_si512(_mm256_loadu_si256(alpha_bit_in_ptr as *const __m256i)); // 8 blocks, 2 regs
+        alpha_bit_in_ptr = alpha_bit_in_ptr.add(24);
+
+        // 9 regs used, let's use another 8
+        // and another few for the permutations
+
+        // Now let's reassemble the 32 blocks
+        // 64 / 16 == 4 blocks per register, so 8 registers of blocks needed because we got 32 blocks
+        let mut blocks_0 =
+            _mm512_permutex2var_epi8(alpha_bytes_0, blocks_0_perm_alphabits, alpha_bit_0);
+        blocks_0 = _mm512_permutex2var_epi8(blocks_0, blocks_0_perm_colours, colors_0);
+        blocks_0 = _mm512_permutex2var_epi8(blocks_0, blocks_0_perm_indices, indices_0);
+
+        // Now compiler will swap out `alpha_bit_1` into register of `alpha_bit_0`, hopefully.
+        _mm512_storeu_si512(current_output_ptr as *mut __m512i, blocks_0);
+
+        // The colors and indices for 8 blocks
+        current_output_ptr = current_output_ptr.add(BYTES_PER_ITERATION);
+    }
+
+    // Convert pointers to the types expected by u32_detransform_with_separate_pointers
+    let alpha_byte_in_ptr_u16 = alpha_byte_in_ptr as *const u16;
+    let alpha_bit_in_ptr_u16 = alpha_bit_in_ptr as *const u16;
+    let color_byte_in_ptr_u32 = color_byte_in_ptr as *const u32;
+    let index_byte_in_ptr_u32 = index_byte_in_ptr as *const u32;
+
+    u32_detransform_with_separate_pointers(
+        alpha_byte_in_ptr_u16,
+        alpha_bit_in_ptr_u16,
+        color_byte_in_ptr_u32,
+        index_byte_in_ptr_u32,
+        current_output_ptr,
+        len - aligned_len,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::split_blocks::split::tests::generate_bc3_test_data;
+    use crate::split_blocks::split::u32;
+    use crate::split_blocks::unsplit::tests::assert_implementation_matches_reference;
+    use crate::testutils::allocate_align_64;
+    use rstest::rstest;
+
+    type DetransformFn = unsafe fn(*const u8, *mut u8, usize);
+
+    #[rstest]
+    #[case(avx512_detransform, "avx512")]
+    #[case(avx512_detransform_32_vl, "avx512_32_vl")]
+    #[case(avx512_detransform_32_vbmi, "avx512_32_vbmi")]
+    fn test_avx512_aligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512vbmi") || !is_x86_feature_detected!("avx512vl") {
+            return;
+        }
+
+        for num_blocks in 1..=512 {
+            let original = generate_bc3_test_data(num_blocks);
+            let mut transformed = allocate_align_64(original.len());
+            let mut reconstructed = allocate_align_64(original.len());
+
+            unsafe {
+                // Transform using standard implementation
+                u32(original.as_ptr(), transformed.as_mut_ptr(), original.len());
+
+                // Reconstruct using the implementation being tested
+                reconstructed.as_mut_slice().fill(0);
+                detransform_fn(
+                    transformed.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    transformed.len(),
+                );
+            }
+
+            assert_implementation_matches_reference(
+                original.as_slice(),
+                reconstructed.as_slice(),
+                &format!("{impl_name} (aligned)"),
+                num_blocks,
+            );
+        }
+    }
+
+    #[rstest]
+    #[case(avx512_detransform, "avx512")]
+    #[case(avx512_detransform_32_vbmi, "avx512_32_vbmi")]
+    #[case(avx512_detransform_32_vl, "avx512_32_vl")]
+    fn test_avx512_unaligned(#[case] detransform_fn: DetransformFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512vbmi") || !is_x86_feature_detected!("avx512vl") {
+            return;
+        }
+
+        for num_blocks in 1..=512 {
+            let original = generate_bc3_test_data(num_blocks);
+
+            // Transform using standard implementation
+            let mut transformed = vec![0u8; original.len()];
+            unsafe {
+                u32(original.as_ptr(), transformed.as_mut_ptr(), original.len());
+            }
+
+            // Add 1 extra byte at the beginning to create misaligned buffers
+            let mut transformed_unaligned = vec![0u8; transformed.len() + 1];
+            transformed_unaligned[1..].copy_from_slice(&transformed);
+
+            let mut reconstructed = vec![0u8; original.len() + 1];
+
+            unsafe {
+                // Reconstruct using the implementation being tested with unaligned pointers
+                reconstructed.as_mut_slice().fill(0);
+                detransform_fn(
+                    transformed_unaligned.as_ptr().add(1),
+                    reconstructed.as_mut_ptr().add(1),
+                    transformed.len(),
+                );
+            }
+
+            assert_implementation_matches_reference(
+                original.as_slice(),
+                &reconstructed[1..],
+                &format!("{impl_name} (unaligned)"),
+                num_blocks,
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/avx512.rs
@@ -610,18 +610,21 @@ pub unsafe fn avx512_detransform_separate_components_32(
         // Each zmm register stores 4 blocks.
 
         // The alpha bytes, (4 blocks * 2 bytes == 8 bytes)
-        let alpha_bytes_0 = _mm512_loadu_si512(alpha_byte_in_ptr as *const __m512i); // 32 blocks, 8 regs
+        let alpha_bytes_0 =
+            _mm512_castsi128_si512(_mm_loadu_si128(alpha_byte_in_ptr as *const __m128i)); // 32 blocks, 8 regs
         alpha_byte_in_ptr = alpha_byte_in_ptr.add(8);
 
         // The colors and indices (4 blocks * 4 bytes == 16 bytes)
-        let colors_0 = _mm512_loadu_si512(color_byte_in_ptr as *const __m512i); // 16 blocks, 4 regs
+        let colors_0 = _mm512_castsi128_si512(_mm_loadu_si128(color_byte_in_ptr as *const __m128i)); // 16 blocks, 4 regs
         color_byte_in_ptr = color_byte_in_ptr.add(16);
 
-        let indices_0 = _mm512_loadu_si512(index_byte_in_ptr as *const __m512i); // 16 blocks, 4 regs
+        let indices_0 =
+            _mm512_castsi128_si512(_mm_loadu_si128(index_byte_in_ptr as *const __m128i)); // 16 blocks, 4 regs
         index_byte_in_ptr = index_byte_in_ptr.add(16);
 
         // The alpha bits (4 blocks * 6 bytes == 24 bytes)
-        let alpha_bit_0 = _mm512_loadu_si512(alpha_bit_in_ptr as *const __m512i); // 8 blocks, 2 regs
+        let alpha_bit_0 =
+            _mm512_castsi256_si512(_mm256_loadu_si256(alpha_bit_in_ptr as *const __m256i)); // 8 blocks, 2 regs
         alpha_bit_in_ptr = alpha_bit_in_ptr.add(24);
 
         // 9 regs used, let's use another 8

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
@@ -83,6 +83,40 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     output_ptr: *mut u8,
     len: usize,
 ) {
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    {
+        #[cfg(feature = "nightly")]
+        #[cfg(target_arch = "x86_64")]
+        if std::is_x86_feature_detected!("avx512vbmi") {
+            avx512::avx512_detransform_separate_components(
+                alpha_byte_ptr,
+                alpha_bit_ptr,
+                color_byte_ptr,
+                index_byte_ptr,
+                output_ptr,
+                len,
+            );
+            return;
+        }
+    }
+
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
+        #[cfg(target_arch = "x86_64")]
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512vbmi") {
+            avx512::avx512_detransform_separate_components(
+                alpha_byte_ptr,
+                alpha_bit_ptr,
+                color_byte_ptr,
+                index_byte_ptr,
+                output_ptr,
+                len,
+            );
+            return;
+        }
+    }
+
     // SSE2 is required by x86-64, so no check needed
     // On i686, this is slower, so skipped.
     #[cfg(target_arch = "x86_64")]

--- a/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/split_blocks/unsplit/mod.rs
@@ -7,9 +7,11 @@ pub mod sse2;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub use sse2::*;
 
+#[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx512;
 
+#[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub use avx512::*;
 

--- a/projects/dxt-lossless-transform-common/Cargo.toml
+++ b/projects/dxt-lossless-transform-common/Cargo.toml
@@ -15,6 +15,8 @@ std = []
 pgo = []
 # Use CPU features selected at compile time.
 no-runtime-cpu-detection = []
+# Use nightly compiler features (AVX512)
+nightly = []
 
 [dev-dependencies]
 rstest = "0.25.0"

--- a/projects/dxt-lossless-transform-common/benches/split_color565_endpoints/avx512.rs
+++ b/projects/dxt-lossless-transform-common/benches/split_color565_endpoints/avx512.rs
@@ -1,0 +1,44 @@
+#![allow(dead_code)]
+#![allow(unused_variables)]
+use criterion::{black_box, BenchmarkId};
+use dxt_lossless_transform_common::transforms::split_565_color_endpoints::{
+    avx512_impl, avx512_impl_unroll2,
+};
+use safe_allocator_api::RawAlloc;
+
+fn bench_avx512_unroll2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_impl_unroll2(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+
+fn bench_avx512(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
+    b.iter(|| unsafe {
+        avx512_impl(
+            black_box(input.as_ptr()),
+            black_box(output.as_mut_ptr()),
+            black_box(input.len()),
+        )
+    });
+}
+pub(crate) fn run_benchmarks(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+    input: &RawAlloc,
+    output: &mut RawAlloc,
+    size: usize,
+    important_benches_only: bool,
+) {
+    group.bench_with_input(BenchmarkId::new("avx512", size), &size, |b, _| {
+        bench_avx512(b, input, output)
+    });
+
+    group.bench_with_input(BenchmarkId::new("avx512 unroll2", size), &size, |b, _| {
+        bench_avx512_unroll2(b, input, output)
+    });
+
+    if !important_benches_only {}
+}

--- a/projects/dxt-lossless-transform-common/benches/split_color565_endpoints/main.rs
+++ b/projects/dxt-lossless-transform-common/benches/split_color565_endpoints/main.rs
@@ -7,6 +7,9 @@ use pprof::criterion::{Output, PProfProfiler};
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 mod avx2;
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+mod avx512;
 mod portable32;
 mod portable64;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -55,6 +58,17 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         if is_x86_feature_detected!("avx2") {
             avx2::run_benchmarks(
+                &mut group,
+                &input,
+                &mut output,
+                size,
+                important_benches_only,
+            );
+        }
+
+        #[cfg(feature = "nightly")]
+        if is_x86_feature_detected!("avx512vbmi") {
+            avx512::run_benchmarks(
                 &mut group,
                 &input,
                 &mut output,

--- a/projects/dxt-lossless-transform-common/src/lib.rs
+++ b/projects/dxt-lossless-transform-common/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", std::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
+#![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod color_565;
 pub mod color_8888;

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx2.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx2.rs
@@ -56,7 +56,7 @@ pub unsafe fn avx2_shuf_impl_asm(colors: *const u8, colors_out: *mut u8, colors_
             5, 4, 1, 0, 7, 6, 3, 2, // xmm low
         );
 
-        std::arch::asm!(
+        core::arch::asm!(
             // Loop alignment
             ".p2align 4",
 

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx512.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx512.rs
@@ -1,0 +1,288 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+use crate::transforms::split_565_color_endpoints::u32_with_separate_endpoints;
+
+/// Splits the colour endpoints using AVX512VBMI instructions
+///
+/// # Arguments
+///
+/// * `colors` - Pointer to the input array of colors
+/// * `colors_out` - Pointer to the output array of colors
+/// * `colors_len_bytes` - Number of bytes in the input array.
+///
+/// # Safety
+///
+/// - `colors` must be valid for reads of `colors_len_bytes` bytes
+/// - `colors_out` must be valid for writes of `colors_len_bytes` bytes
+/// - `colors_len_bytes` must be a multiple of 4
+/// - Pointers should be 32-byte aligned for best performance
+/// - CPU must support AVX512VBMI instructions
+#[target_feature(enable = "avx512vbmi")]
+#[allow(clippy::identity_op)]
+pub unsafe fn avx512_impl_unroll2(colors: *const u8, colors_out: *mut u8, colors_len_bytes: usize) {
+    debug_assert!(
+        colors_len_bytes >= 4 && colors_len_bytes % 4 == 0,
+        "colors_len_bytes must be at least 4 and a multiple of 4"
+    );
+
+    const BYTES_PER_ITERATION: usize = 256;
+
+    // Setup pointers for processing
+    let mut input_ptr = colors;
+    let mut output_low = colors_out;
+    let mut output_high = colors_out.add(colors_len_bytes / 2);
+
+    // Calculate end pointer for our main loop (process 64 bytes at a time)
+    let aligned_len = colors_len_bytes - (colors_len_bytes % BYTES_PER_ITERATION);
+    let aligned_end_ptr = colors.add(aligned_len);
+
+    // Input data:
+    // [00 01], (80 81), [02 03], (82 83), [04 05], (84 85), [06 07], (86 87)
+    // [08 09], (88 89), [0A 0B], (8A 8B), [0C 0D], (8C 8D), [0E 0F], (8E 8F)
+    // [10 11], (90 91), [12 13], (92 93), [14 15], (94 95), [16 17], (96 97)
+    // [18 19], (98 99), [1A 1B], (9A 9B), [1C 1D], (9C 9D), [1E 1F], (9E 9F)
+
+    // Desired format (big endian):
+    // [00 01], [02 03], [04 05], [06 07], (80 81), (82 83), (84 85), (86 87)
+    // [08 09], [0A 0B], [0C 0D], [0E 0F], (88 89), (8A 8B), (8C 8D), (8E 8F)
+    // [10 11], [12 13], [14 15], [16 17], (90 91), (92 93), (94 95), (96 97)
+    // [18 19], [1A 1B], [1C 1D], [1E 1F], (98 99), (9A 9B), (9C 9D), (9E 9F)
+    #[rustfmt::skip]
+    let shuffle_mask_color0 = _mm512_set_epi8(
+        125,124,121,120,117,116,113,112,
+        109,108,105,104,101,100,97,96,
+        93,92,89,88,85,84,81,80,
+        77,76,73,72,69,68,65,64, // variable 1
+        61,60,57,56,53,52,49,48,
+        45,44,41,40,37,36,33,32,
+        29,28,25,24,21,20,17,16,
+        13,12,9,8,5,4,1,0, // variable 2
+    );
+
+    #[rustfmt::skip]
+    let shuffle_mask_color1 = _mm512_set_epi8(
+        127,126,123,122,119,118,115,114,
+        111,110,107,106,103,102,99,98,
+        95,94,91,90,87,86,83,82,
+        79,78,75,74,71,70,67,66, // variable 1
+        63,62,59,58,55,54,51,50,
+        47,46,43,42,39,38,35,34,
+        31,30,27,26,23,22,19,18,
+        15,14,11,10,7,6,3,2, // variable 2
+    );
+
+    // Note(sewer): Don't forget the damned little endian!! Flip the order!!
+    while input_ptr < aligned_end_ptr {
+        // Load 64 bytes (2 blocks of 64 bytes each)
+        let chunk1 = _mm512_loadu_si512(input_ptr as *const __m512i);
+        let chunk2 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+        let chunk3 = _mm512_loadu_si512(input_ptr.add(128) as *const __m512i);
+        let chunk4 = _mm512_loadu_si512(input_ptr.add(192) as *const __m512i);
+        input_ptr = input_ptr.add(BYTES_PER_ITERATION); // 256
+
+        // Store results
+        let color0_rearranged_0 = _mm512_permutex2var_epi8(chunk1, shuffle_mask_color0, chunk2);
+        let color1_rearranged_0 = _mm512_permutex2var_epi8(chunk1, shuffle_mask_color1, chunk2);
+        let color2_rearranged_1 = _mm512_permutex2var_epi8(chunk3, shuffle_mask_color0, chunk4);
+        let color3_rearranged_1 = _mm512_permutex2var_epi8(chunk3, shuffle_mask_color1, chunk4);
+
+        _mm512_storeu_si512(output_low as *mut __m512i, color0_rearranged_0);
+        _mm512_storeu_si512(output_low.add(64) as *mut __m512i, color2_rearranged_1);
+        output_low = output_low.add(128);
+
+        _mm512_storeu_si512(output_high as *mut __m512i, color1_rearranged_0);
+        _mm512_storeu_si512(output_high.add(64) as *mut __m512i, color3_rearranged_1);
+        output_high = output_high.add(128);
+    }
+
+    // Handle remaining elements
+    let end_ptr = colors.add(colors_len_bytes);
+    u32_with_separate_endpoints(
+        end_ptr as *const u32,
+        input_ptr as *const u32,
+        output_low as *mut u16,
+        output_high as *mut u16,
+    );
+}
+
+/// Splits the colour endpoints using AVX512VBMI instructions
+///
+/// # Arguments
+///
+/// * `colors` - Pointer to the input array of colors
+/// * `colors_out` - Pointer to the output array of colors
+/// * `colors_len_bytes` - Number of bytes in the input array.
+///
+/// # Safety
+///
+/// - `colors` must be valid for reads of `colors_len_bytes` bytes
+/// - `colors_out` must be valid for writes of `colors_len_bytes` bytes
+/// - `colors_len_bytes` must be a multiple of 4
+/// - Pointers should be 32-byte aligned for best performance
+/// - CPU must support AVX512VBMI instructions
+#[target_feature(enable = "avx512vbmi")]
+#[allow(clippy::identity_op)]
+pub unsafe fn avx512_impl(colors: *const u8, colors_out: *mut u8, colors_len_bytes: usize) {
+    debug_assert!(
+        colors_len_bytes >= 4 && colors_len_bytes % 4 == 0,
+        "colors_len_bytes must be at least 4 and a multiple of 4"
+    );
+
+    const BYTES_PER_ITERATION: usize = 128;
+
+    // Setup pointers for processing
+    let mut input_ptr = colors;
+    let mut output_low = colors_out;
+    let mut output_high = colors_out.add(colors_len_bytes / 2);
+
+    // Calculate end pointer for our main loop (process 64 bytes at a time)
+    let aligned_len = colors_len_bytes - (colors_len_bytes % BYTES_PER_ITERATION);
+    let aligned_end_ptr = colors.add(aligned_len);
+
+    // Input data:
+    // [00 01], (80 81), [02 03], (82 83), [04 05], (84 85), [06 07], (86 87)
+    // [08 09], (88 89), [0A 0B], (8A 8B), [0C 0D], (8C 8D), [0E 0F], (8E 8F)
+    // [10 11], (90 91), [12 13], (92 93), [14 15], (94 95), [16 17], (96 97)
+    // [18 19], (98 99), [1A 1B], (9A 9B), [1C 1D], (9C 9D), [1E 1F], (9E 9F)
+
+    // Desired format (big endian):
+    // [00 01], [02 03], [04 05], [06 07], (80 81), (82 83), (84 85), (86 87)
+    // [08 09], [0A 0B], [0C 0D], [0E 0F], (88 89), (8A 8B), (8C 8D), (8E 8F)
+    // [10 11], [12 13], [14 15], [16 17], (90 91), (92 93), (94 95), (96 97)
+    // [18 19], [1A 1B], [1C 1D], [1E 1F], (98 99), (9A 9B), (9C 9D), (9E 9F)
+    #[rustfmt::skip]
+    let shuffle_mask_color0 = _mm512_set_epi8(
+        125,124,121,120,117,116,113,112,
+        109,108,105,104,101,100,97,96,
+        93,92,89,88,85,84,81,80,
+        77,76,73,72,69,68,65,64, // variable 1
+        61,60,57,56,53,52,49,48,
+        45,44,41,40,37,36,33,32,
+        29,28,25,24,21,20,17,16,
+        13,12,9,8,5,4,1,0, // variable 2
+    );
+
+    #[rustfmt::skip]
+    let shuffle_mask_color1 = _mm512_set_epi8(
+        127,126,123,122,119,118,115,114,
+        111,110,107,106,103,102,99,98,
+        95,94,91,90,87,86,83,82,
+        79,78,75,74,71,70,67,66, // variable 1
+        63,62,59,58,55,54,51,50,
+        47,46,43,42,39,38,35,34,
+        31,30,27,26,23,22,19,18,
+        15,14,11,10,7,6,3,2, // variable 2
+    );
+
+    // Note(sewer): Don't forget the damned little endian!! Flip the order!!
+    while input_ptr < aligned_end_ptr {
+        // Load 64 bytes (2 blocks of 64 bytes each)
+        let chunk1 = _mm512_loadu_si512(input_ptr as *const __m512i);
+        let chunk2 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+        input_ptr = input_ptr.add(BYTES_PER_ITERATION); // 256
+
+        // Store results
+        let color0_rearranged_0 = _mm512_permutex2var_epi8(chunk1, shuffle_mask_color0, chunk2);
+        let color1_rearranged_0 = _mm512_permutex2var_epi8(chunk1, shuffle_mask_color1, chunk2);
+
+        _mm512_storeu_si512(output_low as *mut __m512i, color0_rearranged_0);
+        _mm512_storeu_si512(output_high as *mut __m512i, color1_rearranged_0);
+        output_low = output_low.add(64);
+        output_high = output_high.add(64);
+    }
+
+    // Handle remaining elements
+    let end_ptr = colors.add(colors_len_bytes);
+    u32_with_separate_endpoints(
+        end_ptr as *const u32,
+        input_ptr as *const u32,
+        output_low as *mut u16,
+        output_high as *mut u16,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transforms::split_565_color_endpoints::tests::{
+        assert_implementation_matches_reference, generate_test_data,
+        transform_with_reference_implementation,
+    };
+    use rstest::rstest;
+
+    // Define the function pointer type
+    type TransformFn = unsafe fn(*const u8, *mut u8, usize);
+
+    #[rstest]
+    #[case(avx512_impl, "avx512_impl")]
+    #[case(avx512_impl_unroll2, "avx512_impl unroll2")]
+    fn test_avx512_aligned(#[case] implementation: TransformFn, #[case] impl_name: &str) {
+        for num_pairs in 1..=512 {
+            let input = generate_test_data(num_pairs);
+            let mut output_expected = vec![0u8; input.len()];
+            let mut output_test = vec![0u8; input.len()];
+
+            // Generate reference output
+            transform_with_reference_implementation(input.as_slice(), &mut output_expected);
+
+            // Clear the output buffer
+            output_test.fill(0);
+
+            // Run the implementation
+            unsafe {
+                implementation(input.as_ptr(), output_test.as_mut_ptr(), input.len());
+            }
+
+            // Compare results
+            assert_implementation_matches_reference(
+                &output_expected,
+                &output_test,
+                &format!("{impl_name} (aligned)"),
+                num_pairs,
+            );
+        }
+    }
+
+    #[rstest]
+    #[case(avx512_impl, "avx512_impl")]
+    #[case(avx512_impl_unroll2, "avx512_impl unroll2")]
+    fn test_avx512_unaligned(#[case] implementation: TransformFn, #[case] impl_name: &str) {
+        for num_pairs in 1..=512 {
+            let input = generate_test_data(num_pairs);
+
+            // Add 1 extra byte at the beginning to create misaligned buffers
+            let mut input_unaligned = vec![0u8; input.len() + 1];
+            input_unaligned[1..].copy_from_slice(input.as_slice());
+
+            let mut output_expected = vec![0u8; input.len()];
+            let mut output_test = vec![0u8; input.len() + 1];
+
+            // Generate reference output
+            transform_with_reference_implementation(input.as_slice(), &mut output_expected);
+
+            // Clear the output buffer
+            output_test.fill(0);
+
+            // Run the implementation
+            unsafe {
+                // Use pointers offset by 1 byte to create unaligned access
+                implementation(
+                    input_unaligned.as_ptr().add(1),
+                    output_test.as_mut_ptr().add(1),
+                    input.len(),
+                );
+            }
+
+            // Compare results
+            assert_implementation_matches_reference(
+                &output_expected,
+                &output_test[1..],
+                &format!("{impl_name} (unaligned)"),
+                num_pairs,
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx512.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx512.rs
@@ -220,6 +220,10 @@ mod tests {
     #[case(avx512_impl, "avx512_impl")]
     #[case(avx512_impl_unroll2, "avx512_impl unroll2")]
     fn test_avx512_aligned(#[case] implementation: TransformFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512vbmi") {
+            return;
+        }
+
         for num_pairs in 1..=512 {
             let input = generate_test_data(num_pairs);
             let mut output_expected = vec![0u8; input.len()];
@@ -250,6 +254,10 @@ mod tests {
     #[case(avx512_impl, "avx512_impl")]
     #[case(avx512_impl_unroll2, "avx512_impl unroll2")]
     fn test_avx512_unaligned(#[case] implementation: TransformFn, #[case] impl_name: &str) {
+        if !is_x86_feature_detected!("avx512vbmi") {
+            return;
+        }
+
         for num_pairs in 1..=512 {
             let input = generate_test_data(num_pairs);
 

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/mod.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/mod.rs
@@ -43,6 +43,14 @@ pub mod avx2;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub use avx2::*;
 
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx512;
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub use avx512::*;
+
 use crate::color_565::Color565;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -55,6 +63,12 @@ unsafe fn split_color_endpoints_x86(
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         // Runtime feature detection
+        #[cfg(feature = "nightly")]
+        if std::is_x86_feature_detected!("avx512vbmi") {
+            avx512_impl(colors, colors_out, colors_len_bytes);
+            return;
+        }
+
         if std::is_x86_feature_detected!("avx2") {
             avx2_shuf_impl_asm(colors, colors_out, colors_len_bytes);
             return;
@@ -68,6 +82,12 @@ unsafe fn split_color_endpoints_x86(
 
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512vbmi") {
+            avx512_impl(colors, colors_out, colors_len_bytes);
+            return;
+        }
+
         if cfg!(target_feature = "avx2") {
             avx2_shuf_impl_asm(colors, colors_out, colors_len_bytes);
             return;

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/portable32.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/portable32.rs
@@ -1,5 +1,5 @@
 use crate::color_565::Color565;
-use std::mem::size_of;
+use core::mem::size_of;
 
 /// Splits the colour endpoints using 32-bit operations
 ///

--- a/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/portable64.rs
+++ b/projects/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/portable64.rs
@@ -1,6 +1,6 @@
 use crate::color_565::Color565;
 use crate::transforms::split_565_color_endpoints::portable32::u32_with_separate_endpoints;
-use std::mem::size_of;
+use core::mem::size_of;
 
 /// Splits the colour endpoints using 64-bit operations
 ///


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added AVX-512 optimized implementations for BC1, BC2, BC3, and 565 color endpoint transforms, including split and unsplit operations, enabled via a new "nightly" feature flag.
  - Introduced runtime and compile-time detection to utilize AVX-512 code paths on supported hardware.
  - Expanded benchmarking suites to include AVX-512 performance tests for all relevant transforms.
- **Bug Fixes**
  - Improved test data generation to ensure values remain within expected ranges for more robust validation.
- **Documentation**
  - Enhanced code comments and test coverage for new AVX-512 implementations.
- **Style**
  - Updated import statements to use the `core` crate for assembly and intrinsics, improving compatibility.
- **Chores**
  - Added "nightly" feature flags to project configuration files to control AVX-512 code activation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->