### PR TITLE
Added: BC2 Decoding and Fuzzing Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,8 @@ members = [
 
     # CLI Tool
     "projects/dxt-lossless-transform-cli",
+
+    # Fuzzing
+    "fuzz",
 ]
 resolver = "2"

--- a/README.MD
+++ b/README.MD
@@ -44,6 +44,24 @@ Click on a project to navigate to its description.
 
 They are low level crates; without a stable API.
 
+## Fuzzing
+
+This project contains a fuzzing crate that can be used to test some of the code against other
+implementations.
+
+```text
+# You may need to install nightly compiler first:
+# https://rust-fuzz.github.io/book/cargo-fuzz/setup.html
+# Install cargo-fuzz
+cargo install cargo-fuzz
+
+# Build the fuzz target
+CARGO_PROFILE_RELEASE_LTO=false cargo fuzz build bc1_decode
+
+# Run the fuzz target
+CARGO_PROFILE_RELEASE_LTO=false cargo fuzz run bc1_decode
+```
+
 ## Usage
 
 This crate is not yet released.

--- a/README.MD
+++ b/README.MD
@@ -55,12 +55,11 @@ implementations.
 # Install cargo-fuzz
 cargo install cargo-fuzz
 
-# Build the fuzz target
-CARGO_PROFILE_RELEASE_LTO=false cargo fuzz build bc1_decode
-
 # Run the fuzz target
 CARGO_PROFILE_RELEASE_LTO=false cargo fuzz run bc1_decode
 ```
+
+To find the targets, look at the `fuzz` folder, `Cargo.toml`.
 
 ## Usage
 

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 rgbcx-sys = "1.1.3"
+bcdec_rs = "0.2.0"
 dxt-lossless-transform-bc1 = { path = "../projects/dxt-lossless-transform-bc1" }
 dxt-lossless-transform-bc2 = { path = "../projects/dxt-lossless-transform-bc2" }
 dxt-lossless-transform-common = { path = "../projects/dxt-lossless-transform-common" }
@@ -24,6 +25,13 @@ bench = false
 [[bin]]
 name = "bc2_decode"
 path = "fuzz_targets/bc2_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bc2_decode_color_only"
+path = "fuzz_targets/bc2_decode_color_only.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "dxt-lossless-transform-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
+rgbcx-sys = "1.1.3"
+dxt-lossless-transform-bc1 = { path = "../projects/dxt-lossless-transform-bc1" }
+dxt-lossless-transform-bc2 = { path = "../projects/dxt-lossless-transform-bc2" }
+dxt-lossless-transform-common = { path = "../projects/dxt-lossless-transform-common" }
+
+[[bin]]
+name = "bc1_decode"
+path = "fuzz_targets/bc1_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bc2_decode"
+path = "fuzz_targets/bc2_decode.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/bc1_decode.rs
+++ b/fuzz/fuzz_targets/bc1_decode.rs
@@ -1,0 +1,54 @@
+#![no_main]
+
+// This fuzz test compares our BC1 decoder against rgbcx-sys implementation using the Ideal method.
+// Extra reading: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
+
+use core::mem;
+use dxt_lossless_transform_bc1::util::decode_bc1_block;
+use dxt_lossless_transform_common::color_8888::Color8888;
+use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+use libfuzzer_sys::{arbitrary, fuzz_target};
+use rgbcx_sys::root::rgbcx;
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc1Block {
+    pub bytes: [u8; 8],
+}
+
+// Fuzz test comparing our BC1 decoder against rgbcx-sys implementation
+fuzz_target!(|color: Bc1Block| {
+    // Get a slice to the BC1 block data
+    let bc1_block = &color.bytes;
+
+    // Decode using our implementation
+    let our_decoded = unsafe { decode_bc1_block(bc1_block.as_ptr()) };
+
+    // Decode using rgbcx-sys implementation with Ideal method and convert to Decoded4x4Block
+    let rgbcx_decoded = rgbcx_decode_bc1_to_block(bc1_block);
+
+    // Compare the results directly
+    assert_eq!(our_decoded, rgbcx_decoded, "Decoded blocks don't match");
+});
+
+/// Decode BC1 block using rgbcx-sys with Ideal method and return it as Decoded4x4Block
+fn rgbcx_decode_bc1_to_block(bc1_block: &[u8]) -> Decoded4x4Block {
+    // Create buffer with properly aligned size for direct transmute
+    let mut rgba_buffer = [0u8; 4 * 16]; // 4 bytes per pixel * 16 pixels
+
+    // Decode using rgbcx-sys with Ideal method
+    unsafe {
+        rgbcx::unpack_bc1(
+            bc1_block.as_ptr() as *const ::std::os::raw::c_void,
+            rgba_buffer.as_mut_ptr() as *mut ::std::os::raw::c_void,
+            true, // set_alpha
+            rgbcx::bc1_approx_mode::cBC1Ideal,
+        );
+    }
+
+    // Use unsafe direct copy to Decoded4x4Block through transmute
+    unsafe {
+        // The memory layout is already correct - RGBA byte pattern matches Color8888 layout
+        let pixels: [Color8888; 16] = mem::transmute(rgba_buffer);
+        Decoded4x4Block { pixels }
+    }
+}

--- a/fuzz/fuzz_targets/bc2_decode.rs
+++ b/fuzz/fuzz_targets/bc2_decode.rs
@@ -1,0 +1,53 @@
+#![no_main]
+
+// This fuzz test compares our BC2 decoder against rgbcx-sys implementation using the Ideal method.
+// Extra reading: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
+
+use core::mem;
+use dxt_lossless_transform_bc2::util::decode_bc2_block;
+use dxt_lossless_transform_common::color_8888::Color8888;
+use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+use libfuzzer_sys::{arbitrary, fuzz_target};
+use rgbcx_sys::root::rgbcx;
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc2Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test comparing our BC2 decoder against rgbcx-sys implementation
+fuzz_target!(|block: Bc2Block| {
+    // Get a slice to the BC2 block data
+    let bc2_block = &block.bytes;
+
+    // Decode using our implementation
+    let our_decoded = unsafe { decode_bc2_block(bc2_block.as_ptr()) };
+
+    // Decode using rgbcx-sys implementation with Ideal method and convert to Decoded4x4Block
+    let rgbcx_decoded = rgbcx_decode_bc2_to_block(bc2_block);
+
+    // Compare the results directly
+    assert_eq!(our_decoded, rgbcx_decoded, "Decoded blocks don't match");
+});
+
+/// Decode BC2 block using rgbcx-sys with Ideal method and return it as Decoded4x4Block
+fn rgbcx_decode_bc2_to_block(bc2_block: &[u8]) -> Decoded4x4Block {
+    // Create buffer with properly aligned size for direct transmute
+    let mut rgba_buffer = [0u8; 4 * 16]; // 4 bytes per pixel * 16 pixels
+
+    // Decode using rgbcx-sys with Ideal method
+    unsafe {
+        rgbcx::unpack_bc3(
+            bc2_block.as_ptr() as *const ::std::os::raw::c_void,
+            rgba_buffer.as_mut_ptr() as *mut ::std::os::raw::c_void,
+            rgbcx::bc1_approx_mode::cBC1Ideal,
+        );
+    }
+
+    // Use unsafe direct copy to Decoded4x4Block through transmute
+    unsafe {
+        // The memory layout is already correct - RGBA byte pattern matches Color8888 layout
+        let pixels: [Color8888; 16] = mem::transmute(rgba_buffer);
+        Decoded4x4Block { pixels }
+    }
+}

--- a/fuzz/fuzz_targets/bc2_decode.rs
+++ b/fuzz/fuzz_targets/bc2_decode.rs
@@ -1,12 +1,12 @@
 #![no_main]
 
-// This fuzz test compares our BC2 decoder against rgbcx-sys implementation using the Ideal method.
+// This fuzz test compares our BC2 decoder against rgbcx-sys for colors and bcdec_rs for alpha.
 // Extra reading: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
 
 use core::mem;
 use dxt_lossless_transform_bc2::util::decode_bc2_block;
-use dxt_lossless_transform_common::color_8888::Color8888;
 use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+use dxt_lossless_transform_common::{color_565::Color565, color_8888::Color8888};
 use libfuzzer_sys::{arbitrary, fuzz_target};
 use rgbcx_sys::root::rgbcx;
 
@@ -17,37 +17,60 @@ pub struct Bc2Block {
 
 // Fuzz test comparing our BC2 decoder against rgbcx-sys implementation
 fuzz_target!(|block: Bc2Block| {
+    // Skip if c0 <= c1 as that mode is not supported on all GPUs.
+    let c0_raw: u16 = u16::from_le_bytes([block.bytes[8], block.bytes[9]]);
+    let c1_raw: u16 = u16::from_le_bytes([block.bytes[10], block.bytes[11]]);
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+    if !c0.greater_than(&c1) {
+        return;
+    }
+
     // Get a slice to the BC2 block data
     let bc2_block = &block.bytes;
 
     // Decode using our implementation
     let our_decoded = unsafe { decode_bc2_block(bc2_block.as_ptr()) };
 
-    // Decode using rgbcx-sys implementation with Ideal method and convert to Decoded4x4Block
-    let rgbcx_decoded = rgbcx_decode_bc2_to_block(bc2_block);
+    // Decode using rgbcx-sys for color and bcdec_rs for alpha
+    let hybrid_decoded = hybrid_decode_bc2_to_block(bc2_block);
 
     // Compare the results directly
-    assert_eq!(our_decoded, rgbcx_decoded, "Decoded blocks don't match");
+    assert_eq!(our_decoded, hybrid_decoded, "Decoded blocks don't match");
 });
 
-/// Decode BC2 block using rgbcx-sys with Ideal method and return it as Decoded4x4Block
-fn rgbcx_decode_bc2_to_block(bc2_block: &[u8]) -> Decoded4x4Block {
+/// Decode BC2 block using rgbcx-sys for color (with Ideal method) and bcdec_rs for alpha
+fn hybrid_decode_bc2_to_block(bc2_block: &[u8]) -> Decoded4x4Block {
     // Create buffer with properly aligned size for direct transmute
     let mut rgba_buffer = [0u8; 4 * 16]; // 4 bytes per pixel * 16 pixels
 
-    // Decode using rgbcx-sys with Ideal method
+    // Create a separate buffer for bcdec_rs alpha decoding
+    let mut bcdec_buffer = [0u8; 4 * 16]; // 4 bytes per pixel * 16 pixels
+
+    // Decode using rgbcx-sys for color components with Ideal method
     unsafe {
-        rgbcx::unpack_bc3(
-            bc2_block.as_ptr() as *const ::std::os::raw::c_void,
+        // The BC2 (DXT3) format has the same color block format as BC1 (DXT1)
+        // We'll decode the color part (last 8 bytes) with unpack_bc1
+        rgbcx::unpack_bc1(
+            bc2_block.as_ptr().add(8) as *const ::std::os::raw::c_void,
             rgba_buffer.as_mut_ptr() as *mut ::std::os::raw::c_void,
+            true, // set_alpha
             rgbcx::bc1_approx_mode::cBC1Ideal,
         );
     }
 
+    // Decode the same block with bcdec_rs to get alpha values
+    bcdec_rs::bc2(bc2_block, &mut bcdec_buffer, 4 * 4);
+
     // Use unsafe direct copy to Decoded4x4Block through transmute
     unsafe {
         // The memory layout is already correct - RGBA byte pattern matches Color8888 layout
-        let pixels: [Color8888; 16] = mem::transmute(rgba_buffer);
+        let mut pixels: [Color8888; 16] = mem::transmute(rgba_buffer);
+        let bcdec_pixels: [Color8888; 16] = mem::transmute(bcdec_buffer);
+
+        for x in 0..16 {
+            pixels[x].a = bcdec_pixels[x].a;
+        }
         Decoded4x4Block { pixels }
     }
 }

--- a/fuzz/fuzz_targets/bc2_decode_color_only.rs
+++ b/fuzz/fuzz_targets/bc2_decode_color_only.rs
@@ -1,0 +1,54 @@
+#![no_main]
+
+// This fuzz test compares our BC1 decoder against our BC2 decoder for colors only, ignoring alpha.
+// Extra reading: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
+
+use dxt_lossless_transform_bc1::util::decode_bc1_block;
+use dxt_lossless_transform_bc2::util::decode_bc2_block;
+use dxt_lossless_transform_common::color_565::Color565;
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc2Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test comparing our BC1 decoder against our BC2 decoder implementation (color component only)
+fuzz_target!(|block: Bc2Block| {
+    // Skip if c0 <= c1 as that mode is not supported on all GPUs.
+    let c0_raw: u16 = u16::from_le_bytes([block.bytes[8], block.bytes[9]]);
+    let c1_raw: u16 = u16::from_le_bytes([block.bytes[10], block.bytes[11]]);
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+    if !c0.greater_than(&c1) {
+        return;
+    }
+
+    // Get a slice to the BC2 block data
+    let bc2_block = &block.bytes;
+
+    // Create a BC1 block from the color part of the BC2 block (last 8 bytes)
+    let bc1_block = &bc2_block[8..];
+
+    // Decode using our BC1 implementation
+    let bc1_decoded = unsafe { decode_bc1_block(bc1_block.as_ptr()) };
+
+    // Decode using our BC2 implementation (color only)
+    let bc2_decoded = unsafe { decode_bc2_block(bc2_block.as_ptr()) };
+
+    // Compare the results, ignoring alpha values
+    for x in 0..16 {
+        assert_eq!(
+            bc1_decoded.pixels[x].r, bc2_decoded.pixels[x].r,
+            "Red component mismatch at pixel {x}",
+        );
+        assert_eq!(
+            bc1_decoded.pixels[x].g, bc2_decoded.pixels[x].g,
+            "Green component mismatch at pixel {x}",
+        );
+        assert_eq!(
+            bc1_decoded.pixels[x].b, bc2_decoded.pixels[x].b,
+            "Blue component mismatch at pixel {x}",
+        );
+    }
+});

--- a/projects/dxt-lossless-transform-bc1/src/util/bc1_decode.rs
+++ b/projects/dxt-lossless-transform-bc1/src/util/bc1_decode.rs
@@ -1,6 +1,9 @@
 //! BC1 (DXT1) decoding implementation; based on etcpak
 //! <https://github.com/wolfpld/etcpak> and MSDN
 //! <https://learn.microsoft.com/en-us/windows/win32/direct3d9/opaque-and-1-bit-alpha-textures>
+//!
+//! Uses the 'ideal' rounding/computing method described in the DX9 docs, as opposed to DX10, AMD or Nvidia
+//! method.
 
 use dxt_lossless_transform_common::{
     color_565::Color565, color_8888::Color8888, decoded_4x4_block::Decoded4x4Block,

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -18,6 +18,9 @@ no-runtime-cpu-detection = []
 # Use nightly compiler features (AVX512)
 nightly = []
 
+[dependencies]
+dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]
 criterion = "0.5.1"

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -43,3 +43,8 @@ harness = false
 name = "unsplit_blocks"
 path = "benches/unsplit_blocks/main.rs"
 harness = false
+
+[[bench]]
+name = "block_decode"
+path = "benches/block_decode/main.rs"
+harness = false

--- a/projects/dxt-lossless-transform-bc2/benches/block_decode/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/block_decode/main.rs
@@ -1,0 +1,111 @@
+use core::alloc::Layout;
+use criterion::{criterion_group, criterion_main, Criterion};
+use dxt_lossless_transform_bc2::util::decode_bc2_block;
+use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+use safe_allocator_api::RawAlloc;
+
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
+    let layout = Layout::from_size_align(num_bytes, 64).unwrap();
+    RawAlloc::new(layout).unwrap()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BC2 Decode Blocks (BC2 -> RGBA8888)");
+
+    // Set up the test data - 8MB of BC2 blocks
+    let bc2_size = 8388608; // 8MB
+    let blocks_count = bc2_size / 16; // Each BC2 block is 16 bytes
+
+    // Allocate memory for input BC2 data and output pixels
+    let input = allocate_align_64(bc2_size);
+    let mut output = allocate_align_64(blocks_count * core::mem::size_of::<Decoded4x4Block>());
+
+    // Initialize input with test data (simple pattern for BC2 blocks)
+    unsafe {
+        let input_ptr = input.as_ptr() as *mut u8;
+        // Fill with valid BC2 blocks
+        for block_idx in 0..(bc2_size / 16) {
+            let block_ptr = input_ptr.add(block_idx * 16);
+
+            // Write alpha values (4 bits per pixel = 8 bytes total)
+            for i in 0..8 {
+                *block_ptr.add(i) = ((block_idx * i) % 255) as u8;
+            }
+
+            // Write color endpoints (RGB565 format)
+            *block_ptr.add(8) = 0x40; // First color (R)
+            *block_ptr.add(9) = 0xF8; // First color (G+B)
+            *block_ptr.add(10) = 0x00; // Second color (R)
+            *block_ptr.add(11) = 0xF8; // Second color (G+B)
+
+            // Write color indices (randomized)
+            for i in 12..16 {
+                *block_ptr.add(i) = ((block_idx * i) % 255) as u8;
+            }
+        }
+    }
+
+    let input_ptr = input.as_ptr();
+    let output_blocks = output.as_mut_ptr() as *mut Decoded4x4Block;
+    group.throughput(criterion::Throughput::Bytes(bc2_size as u64));
+
+    // Benchmark the BC2 decoding function with raw pointers
+    group.bench_function("decode_bc2_blocks_raw_ptr", |b| {
+        b.iter(|| {
+            unsafe {
+                // Decode blocks one by one.
+                for block_idx in 0..blocks_count {
+                    let block_ofs = block_idx * 16;
+
+                    // Decode one block at a time using raw pointer-based function
+                    *output_blocks.add(block_idx) = decode_bc2_block(input_ptr.add(block_ofs));
+                }
+            }
+        })
+    });
+
+    // Benchmark the has_identical_pixels method on decoded blocks
+    // Decode all blocks to have data to work with ahead of running bench.
+    unsafe {
+        for block_idx in 0..blocks_count {
+            let block_ofs = block_idx * 16;
+            *output_blocks.add(block_idx) = decode_bc2_block(input_ptr.add(block_ofs));
+        }
+    }
+
+    group.bench_function("has_identical_pixels", |b| {
+        unsafe {
+            // Then benchmark the has_identical_pixels method
+            b.iter(|| {
+                let mut identical_count = 0;
+                for block_idx in 0..blocks_count {
+                    if (*output_blocks.add(block_idx)).has_identical_pixels() {
+                        identical_count += 1;
+                    }
+                }
+                identical_count
+            })
+        }
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/projects/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc2/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod split_blocks;
+pub mod util;
 
 /// The information about the BC2 transform that was just performed.
 /// Each item transformed via [`transform_bc2`] will produce an instance of this struct.

--- a/projects/dxt-lossless-transform-bc2/src/util/bc2_decode.rs
+++ b/projects/dxt-lossless-transform-bc2/src/util/bc2_decode.rs
@@ -1,6 +1,9 @@
 //! BC2 (DXT2/DXT3) decoding implementation; based on etcpak
 //! <https://github.com/wolfpld/etcpak> and MSDN
 //! <https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc2>
+//!
+//! Uses the 'ideal' rounding/computing method described in the DX9 docs, as opposed to DX10, AMD or Nvidia
+//! method.
 
 use core::slice;
 

--- a/projects/dxt-lossless-transform-bc2/src/util/bc2_decode.rs
+++ b/projects/dxt-lossless-transform-bc2/src/util/bc2_decode.rs
@@ -39,9 +39,6 @@ use dxt_lossless_transform_common::{
 /// ```
 #[inline(always)]
 pub unsafe fn decode_bc2_block(src: *const u8) -> Decoded4x4Block {
-    // First 8 bytes contain the explicit alpha values (4 bits per pixel)
-    let alpha_bytes = slice::from_raw_parts(src, 8);
-
     // Last 8 bytes contain the color data (same format as BC1)
     let color_src = src.add(8);
 
@@ -87,6 +84,9 @@ pub unsafe fn decode_bc2_block(src: *const u8) -> Decoded4x4Block {
 
     // Initialize the result block
     let mut result = Decoded4x4Block::new(Color8888::new(0, 0, 0, 0));
+
+    // First 8 bytes contain the explicit alpha values (4 bits per pixel)
+    let alpha_bytes = slice::from_raw_parts(src, 8);
 
     // Decode indices and set pixels with explicit alpha
     let mut index_pos = 0;

--- a/projects/dxt-lossless-transform-bc2/src/util/bc2_decode.rs
+++ b/projects/dxt-lossless-transform-bc2/src/util/bc2_decode.rs
@@ -1,0 +1,132 @@
+//! BC2 (DXT2/DXT3) decoding implementation; based on etcpak
+//! <https://github.com/wolfpld/etcpak> and MSDN
+//! <https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc2>
+
+use core::slice;
+
+use dxt_lossless_transform_common::{
+    color_565::Color565, color_8888::Color8888, decoded_4x4_block::Decoded4x4Block,
+};
+
+/// Decodes a BC2 block into a structured representation of pixels
+///
+/// # Parameters
+///
+/// - `src`: Pointer to the source BC2 block (must point to at least 16 bytes of valid memory)
+///
+/// # Returns
+///
+/// A [`Decoded4x4Block`] containing all 16 decoded pixels with alpha
+///
+/// # Safety
+///
+/// The caller must ensure that `src` points to at least 16 bytes of valid memory.
+///
+/// # Example
+///
+/// ```
+/// use dxt_lossless_transform_bc2::util::decode_bc2_block;
+///
+/// let bc2_block = [0u8; 16]; // Compressed BC2 block
+///
+/// // Decode the BC2 block into a structured representation
+/// unsafe {
+///     let decoded = decode_bc2_block(bc2_block.as_ptr());
+///     
+///     // Access individual pixels
+///     let pixel_at_0_0 = decoded.get_pixel_unchecked(0, 0);
+/// }
+/// ```
+#[inline(always)]
+pub unsafe fn decode_bc2_block(src: *const u8) -> Decoded4x4Block {
+    // First 8 bytes contain the explicit alpha values (4 bits per pixel)
+    let alpha_bytes = slice::from_raw_parts(src, 8);
+
+    // Last 8 bytes contain the color data (same format as BC1)
+    let color_src = src.add(8);
+
+    // Extract color endpoints and index data
+    let c0_raw: u16 = u16::from_le_bytes([*color_src, *color_src.add(1)]);
+    let c1_raw: u16 = u16::from_le_bytes([*color_src.add(2), *color_src.add(3)]);
+    let idx: u32 = u32::from_le_bytes([
+        *color_src.add(4),
+        *color_src.add(5),
+        *color_src.add(6),
+        *color_src.add(7),
+    ]);
+
+    // Create Color565 wrappers
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+
+    // Extract RGB components for the colors
+    let r0 = c0.red();
+    let g0 = c0.green();
+    let b0 = c0.blue();
+
+    let r1 = c1.red();
+    let g1 = c1.green();
+    let b1 = c1.blue();
+
+    // Create color dictionary - no bounds checks needed for fixed-size array
+    // BC2 always uses the 4-color mode (no transparency from color section)
+    let mut dict = [Color8888::new(0, 0, 0, 0); 4];
+    dict[0] = Color8888::new(r0, g0, b0, 255);
+    dict[1] = Color8888::new(r1, g1, b1, 255);
+
+    // Four-color block (BC2 always uses 4-color mode regardless of c0/c1 comparison)
+    let r = ((2 * r0 as u32) + r1 as u32) / 3;
+    let g = ((2 * g0 as u32) + g1 as u32) / 3;
+    let b = ((2 * b0 as u32) + b1 as u32) / 3;
+    dict[2] = Color8888::new(r as u8, g as u8, b as u8, 255);
+
+    let r = (r0 as u32 + 2 * r1 as u32) / 3;
+    let g = (g0 as u32 + 2 * g1 as u32) / 3;
+    let b = (b0 as u32 + 2 * b1 as u32) / 3;
+    dict[3] = Color8888::new(r as u8, g as u8, b as u8, 255);
+
+    // Initialize the result block
+    let mut result = Decoded4x4Block::new(Color8888::new(0, 0, 0, 0));
+
+    // Decode indices and set pixels with explicit alpha
+    let mut index_pos = 0;
+    let mut alpha_bit_pos = 0;
+
+    // Compiler unrolls this!
+    for y in 0..4 {
+        for x in 0..4 {
+            // Get color index and fetch color
+            let pixel_idx = (idx >> index_pos) & 0x3;
+            let mut pixel = *dict.get_unchecked(pixel_idx as usize);
+
+            // Get 4-bit alpha value (0-15)
+            // Branchless approach: multiply shift by (alpha_bit_pos & 0x1) * 4 which gives 0 or 4
+            let shift_amount = (alpha_bit_pos & 0x1) * 4;
+            let alpha_value = (alpha_bytes[alpha_bit_pos >> 1] >> shift_amount) & 0x0F;
+
+            // Scale 4-bit alpha (0-15) to 8-bit (0-255): multiply by 17 (255/15 ≈ 17)
+            pixel.a = alpha_value * 17;
+
+            // Set pixel with color and alpha
+            result.set_pixel_unchecked(x, y, pixel);
+
+            index_pos += 2;
+            alpha_bit_pos += 1;
+        }
+    }
+
+    result
+}
+
+/// Safely wraps the unsafe [`decode_bc2_block`] function for use with slices
+///
+/// # Returns
+///
+/// A decoded block, else [`None`] if the slice is too short.
+#[inline(always)]
+pub fn decode_bc2_block_from_slice(src: &[u8]) -> Option<Decoded4x4Block> {
+    if src.len() < 16 {
+        return None;
+    }
+    unsafe { Some(decode_bc2_block(src.as_ptr())) }
+}

--- a/projects/dxt-lossless-transform-bc2/src/util/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/util/mod.rs
@@ -1,0 +1,4 @@
+//! Utility functions for BC2 manipulation
+
+mod bc2_decode;
+pub use bc2_decode::*;

--- a/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
+++ b/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
@@ -2,7 +2,7 @@ use crate::color_8888::Color8888;
 use core::mem::transmute;
 
 /// Represents a decoded 4x4 block of BC pixels
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Decoded4x4Block {
     /// The 16 pixels in the block (row-major order)
     pub pixels: [Color8888; 16],


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced BC2 (DXT2/DXT3) block decoding utilities, including safe and unsafe decoding functions.
  - Added fuzz testing targets for BC1 and BC2 decoding to ensure consistency and correctness across implementations.
  - Exposed a new utility module for BC2 decoding in the BC2 project.
  - Added benchmarking for BC2 block decoding performance.

- **Documentation**
  - Added a "Fuzzing" section to the README with setup and usage instructions for fuzz testing.
  - Clarified BC1 decoding method details in module documentation.

- **Chores**
  - Updated workspace configuration to include a new fuzzing member.
  - Added `.gitignore` rules to exclude fuzzing artifacts from version control.
  - Added a new dependency on a common crate for BC2 decoding utilities.

- **Bug Fixes**
  - Enabled direct equality comparisons for decoded 4x4 blocks by deriving `PartialEq` and `Eq`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->