### PR TITLE
Added: BC3 Block Decode Support

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ rgbcx-sys = "1.1.3"
 bcdec_rs = "0.2.0"
 dxt-lossless-transform-bc1 = { path = "../projects/dxt-lossless-transform-bc1" }
 dxt-lossless-transform-bc2 = { path = "../projects/dxt-lossless-transform-bc2" }
+dxt-lossless-transform-bc3 = { path = "../projects/dxt-lossless-transform-bc3" }
 dxt-lossless-transform-common = { path = "../projects/dxt-lossless-transform-common" }
 
 [[bin]]
@@ -32,6 +33,13 @@ bench = false
 [[bin]]
 name = "bc2_decode_color_only"
 path = "fuzz_targets/bc2_decode_color_only.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "bc3_decode"
+path = "fuzz_targets/bc3_decode.rs"
 test = false
 doc = false
 bench = false

--- a/fuzz/fuzz_targets/bc2_decode.rs
+++ b/fuzz/fuzz_targets/bc2_decode.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 // This fuzz test compares our BC2 decoder against rgbcx-sys for colors and bcdec_rs for alpha.
-// Extra reading: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
 
 use core::mem;
 use dxt_lossless_transform_bc2::util::decode_bc2_block;

--- a/fuzz/fuzz_targets/bc2_decode_color_only.rs
+++ b/fuzz/fuzz_targets/bc2_decode_color_only.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
 // This fuzz test compares our BC1 decoder against our BC2 decoder for colors only, ignoring alpha.
-// Extra reading: https://fgiesen.wordpress.com/2021/10/04/gpu-bcn-decoding/
 
 use dxt_lossless_transform_bc1::util::decode_bc1_block;
 use dxt_lossless_transform_bc2::util::decode_bc2_block;

--- a/fuzz/fuzz_targets/bc3_decode.rs
+++ b/fuzz/fuzz_targets/bc3_decode.rs
@@ -1,0 +1,62 @@
+#![no_main]
+
+// This fuzz test compares our BC3 decoder against rgbcx-sys.
+// BC3 uses BC1 format for color data and BC4 compression for alpha.
+
+use core::mem;
+use dxt_lossless_transform_bc3::util::decode_bc3_block;
+use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+use dxt_lossless_transform_common::{color_565::Color565, color_8888::Color8888};
+use libfuzzer_sys::{arbitrary, fuzz_target};
+use rgbcx_sys::root::rgbcx;
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc3Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test comparing our BC3 decoder against rgbcx-sys and bcdec_rs implementations
+fuzz_target!(|block: Bc3Block| {
+    // Skip if c0 <= c1 for the color part, as that mode is not supported on all GPUs for BC3
+    // BC3 color data starts at offset 8
+    let c0_raw: u16 = u16::from_le_bytes([block.bytes[8], block.bytes[9]]);
+    let c1_raw: u16 = u16::from_le_bytes([block.bytes[10], block.bytes[11]]);
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+    if !c0.greater_than(&c1) {
+        return;
+    }
+
+    // Get a slice to the BC3 block data
+    let bc3_block = &block.bytes;
+
+    // Decode using our implementation
+    let our_decoded = unsafe { decode_bc3_block(bc3_block.as_ptr()) };
+
+    // Decode using reference implementations
+    let reference_decoded = hybrid_decode_bc3_to_block(bc3_block);
+
+    // Compare the results - we require exact matching with no tolerance for differences
+    assert_eq!(our_decoded, reference_decoded, "Decoded blocks don't match");
+});
+
+/// Decode BC3 block using rgbcx-sys for color (with Ideal method)
+fn hybrid_decode_bc3_to_block(bc3_block: &[u8]) -> Decoded4x4Block {
+    // Create buffer for the rgbcx-sys decoded result
+    let mut rgba_buffer = [0u8; 4 * 16]; // 4 bytes per pixel * 16 pixels
+
+    unsafe {
+        // rgbcx::unpack_bc3 decodes both color and alpha, taking the entire BC3 block
+        // We've already filtered invalid inputs at the start of the fuzz test
+        rgbcx::unpack_bc3(
+            bc3_block.as_ptr() as *const ::std::os::raw::c_void,
+            rgba_buffer.as_mut_ptr() as *mut ::std::os::raw::c_void,
+            rgbcx::bc1_approx_mode::cBC1Ideal,
+        );
+
+        // The memory layout is already correct - RGBA byte pattern matches Color8888 layout
+        // in little endian.
+        let pixels: [Color8888; 16] = mem::transmute(rgba_buffer);
+        Decoded4x4Block { pixels }
+    }
+}

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -19,6 +19,9 @@ no-runtime-cpu-detection = []
 nightly = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
+
 [dev-dependencies]
 criterion = "0.5.1"
 rstest = "0.25.0"

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -40,3 +40,8 @@ harness = false
 name = "unsplit_blocks"
 path = "benches/unsplit_blocks/main.rs"
 harness = false
+
+[[bench]]
+name = "block_decode"
+path = "benches/block_decode/main.rs"
+harness = false

--- a/projects/dxt-lossless-transform-bc3/benches/block_decode/main.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/block_decode/main.rs
@@ -1,0 +1,115 @@
+use core::alloc::Layout;
+use criterion::{criterion_group, criterion_main, Criterion};
+use dxt_lossless_transform_bc3::util::decode_bc3_block;
+use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
+use safe_allocator_api::RawAlloc;
+
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
+    let layout = Layout::from_size_align(num_bytes, 64).unwrap();
+    RawAlloc::new(layout).unwrap()
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BC3 Decode Blocks (BC3 -> RGBA8888)");
+
+    // Set up the test data - 8MB of BC3 blocks
+    let bc3_size = 8388608; // 8MB
+    let blocks_count = bc3_size / 16; // Each BC3 block is 16 bytes
+
+    // Allocate memory for input BC3 data and output pixels
+    let input = allocate_align_64(bc3_size);
+    let mut output = allocate_align_64(blocks_count * core::mem::size_of::<Decoded4x4Block>());
+
+    // Initialize input with test data (simple pattern for BC3 blocks)
+    unsafe {
+        let input_ptr = input.as_ptr() as *mut u8;
+        // Fill with valid BC3 blocks
+        for block_idx in 0..(bc3_size / 16) {
+            let block_ptr = input_ptr.add(block_idx * 16);
+
+            // Write alpha endpoints and indices (BC4 compression for alpha)
+            *block_ptr = 255; // Alpha0 (max alpha)
+            *block_ptr.add(1) = 0; // Alpha1 (min alpha)
+
+            // Fill alpha indices (3 bits per index)
+            for x in 2..8 {
+                *block_ptr.add(x) = ((block_idx * x) % 255) as u8;
+            }
+
+            // Write color endpoints (RGB565 format - same as BC1/BC2)
+            *block_ptr.add(8) = 0x40; // First color (R)
+            *block_ptr.add(9) = 0xF8; // First color (G+B)
+            *block_ptr.add(10) = 0x00; // Second color (R)
+            *block_ptr.add(11) = 0xF8; // Second color (G+B)
+
+            // Write color indices (randomized)
+            for x in 12..16 {
+                *block_ptr.add(x) = ((block_idx * x) % 255) as u8;
+            }
+        }
+    }
+
+    let input_ptr = input.as_ptr();
+    let output_blocks = output.as_mut_ptr() as *mut Decoded4x4Block;
+    group.throughput(criterion::Throughput::Bytes(bc3_size as u64));
+
+    // Benchmark the BC3 decoding function with raw pointers
+    group.bench_function("decode_bc3_blocks_raw_ptr", |b| {
+        b.iter(|| {
+            unsafe {
+                // Decode blocks one by one.
+                for block_idx in 0..blocks_count {
+                    let block_ofs = block_idx * 16;
+
+                    // Decode one block at a time using raw pointer-based function
+                    *output_blocks.add(block_idx) = decode_bc3_block(input_ptr.add(block_ofs));
+                }
+            }
+        })
+    });
+
+    // Benchmark the has_identical_pixels method on decoded blocks
+    // Decode all blocks to have data to work with ahead of running bench.
+    unsafe {
+        for block_idx in 0..blocks_count {
+            let block_ofs = block_idx * 16;
+            *output_blocks.add(block_idx) = decode_bc3_block(input_ptr.add(block_ofs));
+        }
+    }
+
+    group.bench_function("has_identical_pixels", |b| {
+        unsafe {
+            // Then benchmark the has_identical_pixels method
+            b.iter(|| {
+                let mut identical_count = 0;
+                for block_idx in 0..blocks_count {
+                    if (*output_blocks.add(block_idx)).has_identical_pixels() {
+                        identical_count += 1;
+                    }
+                }
+                identical_count
+            })
+        }
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/projects/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc3/src/lib.rs
@@ -4,6 +4,7 @@
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod split_blocks;
+pub mod util;
 
 /// The information about the BC3 transform that was just performed.
 /// Each item transformed via [`transform_bc3`] will produce an instance of this struct.

--- a/projects/dxt-lossless-transform-bc3/src/util/bc3_decode.rs
+++ b/projects/dxt-lossless-transform-bc3/src/util/bc3_decode.rs
@@ -1,0 +1,193 @@
+//! BC3 (DXT4/DXT5) decoding implementation; based on etcpak
+//! <https://github.com/wolfpld/etcpak> and MSDN
+//! <https://learn.microsoft.com/en-us/windows/win32/direct3d10/d3d10-graphics-programming-guide-resources-block-compression#bc3>
+//!
+//! Uses the 'ideal' rounding/computing method described in the DX9 docs, as opposed to DX10, AMD or Nvidia
+//! method.
+
+use dxt_lossless_transform_common::{
+    color_565::Color565, color_8888::Color8888, decoded_4x4_block::Decoded4x4Block,
+};
+
+/// Decodes a BC3 block into a structured representation of pixels
+///
+/// # Parameters
+///
+/// - `src`: Pointer to the source BC3 block (must point to at least 16 bytes of valid memory)
+///
+/// # Returns
+///
+/// A [`Decoded4x4Block`] containing all 16 decoded pixels with alpha
+///
+/// # Safety
+///
+/// The caller must ensure that `src` points to at least 16 bytes of valid memory.
+///
+/// # Example
+///
+/// ```
+/// use dxt_lossless_transform_bc3::util::decode_bc3_block;
+///
+/// let bc3_block = [0u8; 16]; // Compressed BC3 block
+///
+/// // Decode the BC3 block into a structured representation
+/// unsafe {
+///     let decoded = decode_bc3_block(bc3_block.as_ptr());
+///     
+///     // Access individual pixels
+///     let pixel_at_0_0 = decoded.get_pixel_unchecked(0, 0);
+/// }
+/// ```
+#[inline(always)]
+#[allow(clippy::identity_op)]
+pub unsafe fn decode_bc3_block(src: *const u8) -> Decoded4x4Block {
+    // Last 8 bytes contain the color data (same format as BC1)
+    let color_src = src.add(8);
+
+    // Extract color endpoints and index data
+    let c0_raw: u16 = u16::from_le_bytes([*color_src, *color_src.add(1)]);
+    let c1_raw: u16 = u16::from_le_bytes([*color_src.add(2), *color_src.add(3)]);
+    let idx: u32 = u32::from_le_bytes([
+        *color_src.add(4),
+        *color_src.add(5),
+        *color_src.add(6),
+        *color_src.add(7),
+    ]);
+
+    // Create Color565 wrappers
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+
+    // Extract RGB components for the colors
+    let r0 = c0.red();
+    let g0 = c0.green();
+    let b0 = c0.blue();
+
+    let r1 = c1.red();
+    let g1 = c1.green();
+    let b1 = c1.blue();
+
+    // Create color dictionary - no bounds checks needed for fixed-size array
+    // BC3 always uses the 4-color mode (no transparency from color section)
+    let mut dict = [Color8888::new(0, 0, 0, 0); 4];
+    dict[0] = Color8888::new(r0, g0, b0, 255);
+    dict[1] = Color8888::new(r1, g1, b1, 255);
+
+    // Four-color block (BC3 always uses 4-color mode regardless of c0/c1 comparison)
+    let r = ((2 * r0 as u32) + r1 as u32) / 3;
+    let g = ((2 * g0 as u32) + g1 as u32) / 3;
+    let b = ((2 * b0 as u32) + b1 as u32) / 3;
+    dict[2] = Color8888::new(r as u8, g as u8, b as u8, 255);
+
+    let r = (r0 as u32 + 2 * r1 as u32) / 3;
+    let g = (g0 as u32 + 2 * g1 as u32) / 3;
+    let b = (b0 as u32 + 2 * b1 as u32) / 3;
+    dict[3] = Color8888::new(r as u8, g as u8, b as u8, 255);
+
+    // Initialize the result block
+    let mut result = Decoded4x4Block::new(Color8888::new(0, 0, 0, 0));
+
+    // First 8 bytes contain the BC4 compressed alpha data
+    let alpha_src = src;
+
+    // Extract alpha endpoints
+    let alpha0 = *alpha_src;
+    let alpha1 = *alpha_src.add(1);
+
+    // Create alpha lookup table
+    let mut alpha_values = [0u8; 8];
+    alpha_values[0] = alpha0;
+    alpha_values[1] = alpha1;
+
+    // In BC4/BC3, if alpha0 > alpha1, we have 8 interpolated values
+    // Otherwise we have 6 interpolated values plus transparent and opaque
+    if alpha0 > alpha1 {
+        // 8 interpolated alpha values
+        alpha_values[2] = ((6 * alpha0 as u16 + 1 * alpha1 as u16) / 7) as u8; // bit code 010
+        alpha_values[3] = ((5 * alpha0 as u16 + 2 * alpha1 as u16) / 7) as u8; // bit code 011
+        alpha_values[4] = ((4 * alpha0 as u16 + 3 * alpha1 as u16) / 7) as u8; // bit code 100
+        alpha_values[5] = ((3 * alpha0 as u16 + 4 * alpha1 as u16) / 7) as u8; // bit code 101
+        alpha_values[6] = ((2 * alpha0 as u16 + 5 * alpha1 as u16) / 7) as u8; // bit code 110
+        alpha_values[7] = ((1 * alpha0 as u16 + 6 * alpha1 as u16) / 7) as u8; // bit code 111
+    } else {
+        // 6 interpolated alpha values + transparent and opaque
+        alpha_values[2] = ((4 * alpha0 as u16 + 1 * alpha1 as u16) / 5) as u8; // bit code 010
+        alpha_values[3] = ((3 * alpha0 as u16 + 2 * alpha1 as u16) / 5) as u8; // bit code 011
+        alpha_values[4] = ((2 * alpha0 as u16 + 3 * alpha1 as u16) / 5) as u8; // bit code 100
+        alpha_values[5] = ((1 * alpha0 as u16 + 4 * alpha1 as u16) / 5) as u8; // bit code 101
+        alpha_values[6] = 0; // Transparent (bit code 110)
+        alpha_values[7] = 255; // Opaque (bit code 111)
+    }
+
+    // Extract alpha indices (3 bits per index, 48 bits total for 16 pixels)
+    // Read 6 bytes of indices (starting from byte 2)
+    let alpha_indices = [
+        *alpha_src.add(2),
+        *alpha_src.add(3),
+        *alpha_src.add(4),
+        *alpha_src.add(5),
+        *alpha_src.add(6),
+        *alpha_src.add(7),
+    ];
+
+    // Decode color indices and set pixels with alpha from BC4 compression
+    let mut index_pos = 0;
+    let mut alpha_bit_pos = 0;
+
+    // Compiler unrolls this!
+    // And also undoes the `if` branches
+    for y in 0..4 {
+        for x in 0..4 {
+            // Get color index and fetch color
+            let pixel_idx = (idx >> index_pos) & 0x3;
+            let mut pixel = *dict.get_unchecked(pixel_idx as usize);
+
+            // Get alpha index (3 bits) and corresponding alpha value
+            // Calculate byte position and bit position within the byte
+            let byte_pos = alpha_bit_pos / 8;
+            let bit_shift = alpha_bit_pos % 8;
+
+            let alpha_idx = if bit_shift <= 5 {
+                // Index contained within one byte
+                (alpha_indices[byte_pos] >> bit_shift) & 0b111
+            } else {
+                // Index spans two bytes (part from current byte, part from next byte)
+                let bits_from_current = alpha_indices[byte_pos] >> bit_shift;
+                let bits_from_next = alpha_indices[byte_pos + 1] << (8 - bit_shift);
+                (bits_from_current | bits_from_next) & 0b111
+            };
+
+            // Set alpha value
+            pixel.a = alpha_values[alpha_idx as usize];
+
+            // Set pixel with color and alpha
+            result.set_pixel_unchecked(x, y, pixel);
+
+            // Move to next indices
+            index_pos += 2;
+            alpha_bit_pos += 3; // BC3/BC4 uses 3 bits per alpha index
+        }
+    }
+
+    result
+}
+
+/// Safely wraps the unsafe [`decode_bc3_block`] function for use with slices
+///
+/// # Returns
+///
+/// A decoded block, else [`None`] if the slice is too short.
+#[inline(always)]
+pub fn decode_bc3_block_from_slice(src: &[u8]) -> Option<Decoded4x4Block> {
+    if src.len() < 16 {
+        return None;
+    }
+    unsafe { Some(decode_bc3_block(src.as_ptr())) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // There is also a fuzz test against a good known implementation in bc7enc, so this is minimal.
+}

--- a/projects/dxt-lossless-transform-bc3/src/util/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/util/mod.rs
@@ -1,0 +1,4 @@
+//! Utility functions for BC3 manipulation
+
+mod bc3_decode;
+pub use bc3_decode::*;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for decoding BC3 (DXT5) texture blocks to RGBA8888 format.
	- Introduced a new utility module for BC3 decoding functionality.
	- Added a benchmark to measure BC3 block decoding performance.
	- Implemented a fuzz test to validate BC3 decoding correctness against a reference.

- **Bug Fixes**
	- Ensured consistent configuration flags across all binary targets.

- **Documentation**
	- Removed outdated external reference comments from test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->