### PR TITLE
Added: BC2 Block Normalization

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -50,3 +50,10 @@ path = "fuzz_targets/bc1_normalize.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "bc2_normalize"
+path = "fuzz_targets/bc2_normalize.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/bc2_normalize.rs
+++ b/fuzz/fuzz_targets/bc2_normalize.rs
@@ -1,0 +1,72 @@
+#![no_main]
+
+// This fuzz test validates the BC2 normalizer by checking that the normalized blocks decode 
+// to the same pixels as the original blocks.
+
+use dxt_lossless_transform_bc2::{normalize_blocks::normalize_blocks, util::decode_bc2_block};
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc2Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test for BC2 normalization
+// Tests that normalizing a block preserves its visual appearance when decoded
+fuzz_target!(|block: Bc2Block| {
+    // Get a slice to the BC2 block data
+    let bc2_block = &block.bytes;
+    
+    // Save the original block for later comparison
+    let original_decoded = unsafe { decode_bc2_block(bc2_block.as_ptr()) };
+    
+    // Create a buffer for the normalized block
+    let mut normalized_block = [0u8; 16];
+    
+    // Normalize the block (with repeat_colour=false)
+    unsafe {
+        normalize_blocks(
+            bc2_block.as_ptr(),
+            normalized_block.as_mut_ptr(),
+            16, // Size of BC2 block in bytes
+            false
+        );
+    }
+    
+    // Decode the normalized block
+    let normalized_decoded = unsafe { decode_bc2_block(normalized_block.as_ptr()) };
+    
+    // Compare the two decoded blocks - they should produce the same visual output
+    assert_eq!(
+        original_decoded, 
+        normalized_decoded,
+        "Normalized block doesn't decode to the same pixels as the original block\n\
+         Original block: {bc2_block:?}\n\
+         Normalized block: {normalized_block:?}",
+    );
+    
+    // Also test normalization with repeat_colour=true
+    let mut normalized_block_repeated = [0u8; 16];
+    
+    // Normalize the block (with repeat_colour=true)
+    unsafe {
+        normalize_blocks(
+            bc2_block.as_ptr(),
+            normalized_block_repeated.as_mut_ptr(),
+            16, // Size of BC2 block in bytes
+            true
+        );
+    }
+    
+    // Decode the normalized block
+    let normalized_repeated_decoded = unsafe { decode_bc2_block(normalized_block_repeated.as_ptr()) };
+    
+    // Compare with original - visual appearance should still be the same
+    assert_eq!(
+        original_decoded, 
+        normalized_repeated_decoded,
+        "Normalized block (with repeat_color=true) doesn't decode to the same pixels as the original block\n\
+         Original block: {bc2_block:?}\n\
+         Normalized block: {normalized_block_repeated:?}",
+    );
+});

--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -67,7 +67,7 @@ We can split the colour endpoints
 +-------+-------+ +-------+-------+
 ```
 
-### Making Solid Blocks Represented the Same Across Texture
+### Making Solid Blocks Represented the Same Across Texture (Normalizing Blocks)
 
 BC1 can represent solid color blocks in multiple ways.
 We make this representation consistent whenever possible.
@@ -87,7 +87,7 @@ to represent a colour using only 1 out of the 2 colour components, i.e. only `C0
 When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
 colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`.
 This results in a nice repetition of `0x00` across 6 bytes. In some cases, it's beneficial to replicate
-the colour across `C0` and `C1`. We brute force to find the optimal choice.
+the colour across `C0` and `C1`. We determine based on whichever performs better.
 
 For fully transparent blocks, we instead set all the bits to `1`, so the block becomes filled with `0xFF`. 
 

--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -87,7 +87,7 @@ to represent a colour using only 1 out of the 2 colour components, i.e. only `C0
 When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
 colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`.
 This results in a nice repetition of `0x00` across 6 bytes. In some cases, it's beneficial to replicate
-the colour across `C0` and `C1`. We determine based on whichever performs better.
+the colour across `C0` and `C1`. We determine based on whichever performs better by compressing the data.
 
 For fully transparent blocks, we instead set all the bits to `1`, so the block becomes filled with `0xFF`. 
 

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -49,3 +49,8 @@ harness = false
 name = "block_decode"
 path = "benches/block_decode/main.rs"
 harness = false
+
+[[bench]]
+name = "normalize_blocks"
+path = "benches/normalize_blocks/main.rs"
+harness = false

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -20,6 +20,7 @@ nightly = []
 
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
+likely_stable = "0.1.3"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/projects/dxt-lossless-transform-bc2/README.MD
+++ b/projects/dxt-lossless-transform-bc2/README.MD
@@ -54,7 +54,30 @@ Separates colours and indices into continuous streams:
 
 BC2 can represent solid color blocks in multiple ways, which hinders compression.
 
-- TODO
+Recall BC2 block format:
+
+```text
+Address: 0         8         12       16
+         +---------+---------+---------+
+Data:    | A00-A15 | C00-C01 | I00-I15 |
+         +---------+---------+---------+
+```
+
+Sometimes there is a clean conversion between `8888` and `565` colour, meaning that it's possible
+to represent a colour using only 1 out of the 2 colour components, i.e. only `C0` or `C1`.
+
+When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
+colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`. This results in a
+nice repetition of `0x00` across 6 bytes. In some cases, it's beneficial to replicate
+the colour across `C0` and `C1`. We determine on whichever performs better.
+
+Note: With BC2, BC3 it's important that we put the colour in `C0`, because the 'alternate alpha mode' of
+BC1 where `c0 <= c1` is unsupported; it leads to undefined behaviour on some GPUs.
+
+There isn't much more we can do for BC2, so we stop here:
+
+- For fully transparent blocks, the `alphas` have the value `0`. Since they are in their own isolated section,
+we can't really improve the compression there.
 
 ### Decorrelating Colours
 

--- a/projects/dxt-lossless-transform-bc2/README.MD
+++ b/projects/dxt-lossless-transform-bc2/README.MD
@@ -69,9 +69,9 @@ to represent a colour using only 1 out of the 2 colour components, i.e. only `C0
 When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
 colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`. This results in a
 nice repetition of `0x00` across 6 bytes. In some cases, it's beneficial to replicate
-the colour across `C0` and `C1`. We determine on whichever performs better.
+the colour across `C0` and `C1`. We determine based on whichever performs better by compressing the data.
 
-Note: With BC2, BC3 it's important that we put the colour in `C0`, because the 'alternate alpha mode' of
+Note: With BC2, BC3 it's important that we put the colour in `C0` because the 'alternate alpha mode' of
 BC1 where `c0 <= c1` is unsupported; it leads to undefined behaviour on some GPUs.
 
 There isn't much more we can do for BC2, so we stop here:

--- a/projects/dxt-lossless-transform-bc2/benches/normalize_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/normalize_blocks/main.rs
@@ -1,0 +1,119 @@
+use core::{alloc::Layout, ptr::copy_nonoverlapping};
+use criterion::{criterion_group, criterion_main, Criterion};
+use dxt_lossless_transform_bc2::normalize_blocks::normalize_blocks;
+use safe_allocator_api::RawAlloc;
+use std::fs;
+
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+// Path to the BC2 file to benchmark with
+// You may need to update this path to point to a valid BC2 texture file on your system
+const TEST_FILE_PATH: &str =
+    "/home/sewer/Temp/texture-stuff/bc2-raw/202x-architecture-10.01/farmhouse/ivy01.dds";
+
+pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
+    let layout = Layout::from_size_align(num_bytes, 64).unwrap();
+    RawAlloc::new(layout).unwrap()
+}
+
+#[allow(clippy::needless_range_loop)]
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BC2 Normalize Blocks");
+
+    // Try to load the test file
+    let file_data = match fs::read(TEST_FILE_PATH) {
+        Ok(data) => {
+            println!("Successfully loaded test file: {TEST_FILE_PATH}");
+            data
+        }
+        Err(e) => {
+            println!("Warning: Could not load test file '{TEST_FILE_PATH}': {e}");
+            println!("To run this benchmark, you need a valid BC2 texture file.");
+            println!("Please update the TEST_FILE_PATH constant to point to a valid BC2 file or create a sample BC2 file.");
+            println!("Alternatively, we'll create a synthetic BC2 file for benchmarking.");
+
+            // Create a synthetic file with 1024 identical BC2 blocks for benchmarking
+            // BC2 block is 16 bytes (8 for alpha, 4 for colors, 4 for indices)
+            let block_size = 16;
+            let num_blocks = 1024;
+            let total_size = block_size * num_blocks;
+
+            // Create a sample BC2 block with solid red color
+            let mut sample_block = [0u8; 16];
+
+            // Alpha part (first 8 bytes) - all fully opaque (255)
+            for x in 0..8 {
+                sample_block[x] = 0xFF;
+            }
+
+            // Color endpoints (RGB565)
+            // Red = 0xF800 in RGB565 (little endian: [0x00, 0xF8])
+            sample_block[8] = 0x00;
+            sample_block[9] = 0xF8;
+            sample_block[10] = 0x00; // Second color not used
+            sample_block[11] = 0x00;
+
+            // Indices (all 0)
+            sample_block[12] = 0;
+            sample_block[13] = 0;
+            sample_block[14] = 0;
+            sample_block[15] = 0;
+
+            // Create the synthetic file by repeating the sample block
+            let mut synthetic_data = Vec::with_capacity(total_size);
+            for _ in 0..num_blocks {
+                synthetic_data.extend_from_slice(&sample_block);
+            }
+
+            println!(
+                "Created synthetic BC2 file with {} blocks ({} bytes) for benchmarking.",
+                num_blocks,
+                synthetic_data.len()
+            );
+            synthetic_data
+        }
+    };
+
+    // Ensure we have a file size that's a multiple of 16 (BC2 block size)
+    let file_size = file_data.len();
+
+    // Allocate memory for input and output
+    let mut input = allocate_align_64(file_size);
+    let mut output = allocate_align_64(file_size);
+
+    // Copy file data to input buffer
+    unsafe {
+        copy_nonoverlapping(file_data.as_ptr(), input.as_mut_ptr(), file_size);
+    }
+
+    let input_ptr = input.as_ptr();
+    let output_ptr = output.as_mut_ptr();
+
+    group.throughput(criterion::Throughput::Bytes(file_size as u64));
+
+    // Benchmark the normalize_blocks function
+    group.bench_function("normalize_blocks", |b| {
+        b.iter(|| unsafe {
+            normalize_blocks(input_ptr, output_ptr, file_size, false);
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/projects/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc2/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
+pub mod normalize_blocks;
 pub mod split_blocks;
 pub mod util;
 

--- a/projects/dxt-lossless-transform-bc2/src/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/normalize_blocks/mod.rs
@@ -1,0 +1,455 @@
+//! # Block Normalization Process
+//!
+//! This module contains the code used to normalize BC2 blocks to improve compression ratio
+//! by making solid color blocks have consistent representations.
+//!
+//! ## BC2 Block Format
+//!
+//! First, let's recall the BC2 block format:
+//!
+//! ```text
+//! Address: 0        8       12      16
+//!          +--------+-------+---------+
+//! Data:    | A00-A15| C0-C1 | Indices |
+//!          +--------+-------+---------+
+//! ```
+//!
+//! Where:
+//! - `A00-A15` are 8 bytes containing sixteen 4-bit alpha values (explicit alpha)
+//! - `C0-C1` are 16-bit RGB565 color values (2 bytes each)
+//! - `Indices` are 4 bytes containing sixteen 2-bit indices (one for each pixel in the 4x4 block)
+//!
+//! ## Normalization Rules
+//!
+//! The normalization process applies the following rules to improve compression:
+//!
+//! ### 1. Solid Color Blocks with Uniform Alpha
+//!
+//! When an entire block represents a single solid color with a clean conversion between RGBA8888
+//! and RGB565, we standardize the representation:
+//!
+//! ```text
+//! +--------+--------+--------+--------+
+//! | Alpha  | Color  | 0x0000 |  0x00  |
+//! +--------+--------+--------+--------+
+//! ```
+//!
+//! We preserve the alpha values as they are, place the block's color in `Color0`, set `Color1` to zero,
+//! and set all indices to zero (represented by all-zero bytes in the indices section).
+//! In some cases, it's beneficial to replicate the color across `C0` and `C1` instead.
+//!
+//! The implementation checks for this case by:
+//! 1. Decoding the block to get all 16 pixels
+//! 2. Checking that all pixels have the same color (ignoring alpha)
+//! 3. Verifying the color can be cleanly round-tripped through RGB565 encoding
+//! 4. Constructing a new normalized block with the pattern above
+//!
+//! ### 2. Other Blocks
+//!
+//! In BC2, the explicit alpha values in the first 8 bytes already handle transparency, so there's
+//! no special handling needed for transparent blocks based on color indices like in BC1.
+//!
+//! Unlike BC1, BC2 doesn't support the "punch-through alpha" mode (where `Color0 <= Color1`),
+//! as this leads to undefined behavior on some GPUs. BC2 always uses the 4-color mode.
+//!
+//! ## Implementation Details
+//!
+//! The normalization process uses the BC2 decoder to analyze the block content, then rebuilds
+//! blocks according to the rules above.
+//!
+//! When normalizing blocks, we:
+//!
+//! 1. Decode the block to get all 16 pixels with their colors and alpha values
+//! 2. Check if the block contains a solid color (ignoring alpha variations)
+//! 3. If it's a solid color that can be cleanly round-tripped, normalize the color part of the block
+//! 4. Leave the alpha values unchanged
+//! 5. Write the normalized block to the output
+
+use crate::util::decode_bc2_block;
+use core::ptr::copy_nonoverlapping;
+use dxt_lossless_transform_common::color_8888::Color8888;
+use likely_stable::unlikely;
+
+/// Reads an input of blocks from `input_ptr` and writes the normalized blocks to `output_ptr`.
+///
+/// # Parameters
+///
+/// - `input_ptr`: A pointer to the input data (input BC2 blocks)
+/// - `output_ptr`: A pointer to the output data (output BC2 blocks)
+/// - `len`: The length of the input data in bytes
+/// - `repeat_colour`: Whether to repeat the solid color in both color slots when normalizing.
+///   - When `true`: For solid color blocks, the same color value is written to both color0 and color1
+///     Example: A red block might become `[0xF800, 0xF800]`
+///   - When `false`: For solid color blocks, color0 contains the color and color1 is set to zero
+///     Example: A red block might become `[0xF800, 0x0000]`
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 16 (BC2 block size)
+///
+/// # Remarks
+///
+/// This function identifies and normalizes BC2 blocks based on their content:
+/// - Solid color blocks are normalized to a standard format with the color in color0
+/// - Alpha values are preserved as they are (in the first 8 bytes of each block)
+///
+/// Normalization improves compression ratios by ensuring that similar visual blocks
+/// have identical binary representations, reducing entropy in the data.
+///
+/// See the module-level documentation for more details on the normalization process.
+#[inline]
+pub unsafe fn normalize_blocks(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+    repeat_colour: bool,
+) {
+    debug_assert!(len % 16 == 0);
+
+    // Calculate pointers to current block
+    let mut src_block_ptr = input_ptr;
+    let mut dst_block_ptr = output_ptr;
+    let src_end_ptr = input_ptr.add(len);
+
+    // Process each block
+    while src_block_ptr < src_end_ptr {
+        // Decode the block to analyze its content
+        let decoded_block = decode_bc2_block(src_block_ptr);
+
+        // Check if all pixels in the block have identical RGB values
+        if decoded_block.has_identical_pixels_ignore_alpha() {
+            // Get the first pixel (they all have the same color)
+            let pixel = decoded_block.pixels[0];
+
+            // Case 1: Solid color block
+            // Convert the color to RGB565
+            let color565 = pixel.to_color_565();
+
+            // Check if color can be round-tripped cleanly through RGB565
+            let color8888 = color565.to_color_8888();
+            let pixel_ignore_alpha = Color8888::new(pixel.r, pixel.g, pixel.b, 255);
+            let color8888_ignore_alpha = Color8888::new(color8888.r, color8888.g, color8888.b, 255);
+
+            // Note: As the colour and alpha components are stored separately, we ignore the alpha
+            //       when checking if the color can be round-tripped.
+            if unlikely(color8888_ignore_alpha == pixel_ignore_alpha) {
+                // Copy alpha values (first 8 bytes) unchanged
+                copy_nonoverlapping(src_block_ptr, dst_block_ptr, 8);
+
+                // Can be normalized - write the standard pattern for the color part:
+                // Color0 = the color, Color1 = 0 or repeat, indices = 0
+                let color_bytes = color565.raw_value().to_le_bytes();
+
+                // Write Color0 (the solid color)
+                *dst_block_ptr.add(8) = color_bytes[0];
+                *dst_block_ptr.add(9) = color_bytes[1];
+
+                // Write Color1 = 0 or repeat
+                if repeat_colour {
+                    *dst_block_ptr.add(10) = color_bytes[0];
+                    *dst_block_ptr.add(11) = color_bytes[1];
+                } else {
+                    *dst_block_ptr.add(10) = 0;
+                    *dst_block_ptr.add(11) = 0;
+                }
+
+                // Write indices = 0
+                *dst_block_ptr.add(12) = 0;
+                *dst_block_ptr.add(13) = 0;
+                *dst_block_ptr.add(14) = 0;
+                *dst_block_ptr.add(15) = 0;
+            } else {
+                // Cannot normalize, copy source block as-is
+                copy_nonoverlapping(src_block_ptr, dst_block_ptr, 16);
+            }
+        } else {
+            // Mixed colors - copy source block as-is
+            copy_nonoverlapping(src_block_ptr, dst_block_ptr, 16);
+        }
+
+        // Move to the next block
+        src_block_ptr = src_block_ptr.add(16);
+        dst_block_ptr = dst_block_ptr.add(16);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_range_loop)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Test normalizing a solid color block with uniform alpha
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn can_normalize_solid_color_block(#[case] repeat_colour: bool) {
+        // Red in RGB565: (31, 0, 0) -> 0xF800
+        // This cleanly round trips into (255, 0, 0) and back to (31, 0, 0).
+        let red565 = 0xF800u16.to_le_bytes(); // Little endian: [0x00, 0xF8]
+
+        // This creates a BC2 block with the following characteristics:
+        // - Uniform alpha (all 0xFF)
+        // - Color0 = Red (RGB565)
+        // - Color1 = Another color (doesn't matter)
+        // - Indices = All pointing to Color0 (all 0b00)
+        let mut block = [0u8; 16];
+
+        // Fill alpha values with 0xFF (fully opaque)
+        for x in 0..8 {
+            block[x] = 0xFF;
+        }
+
+        // Color part
+        block[8] = red565[0]; // Color0 (low byte)
+        block[9] = red565[1]; // Color0 (high byte)
+        block[10] = 0x01; // Color1 (low byte)
+        block[11] = 0x01; // Color1 (high byte)
+
+        // All indices = 0, pointing to Color0
+        block[12] = 0x00;
+        block[13] = 0x00;
+        block[14] = 0x00;
+        block[15] = 0x00;
+
+        // Expected normalized block:
+        // - Alpha values remain the same
+        // - Color0 = the color (0xF800)
+        // - Color1 = 0 or repeated Color0
+        // - All indices = 0
+        let mut expected = [0u8; 16];
+
+        // Copy alpha values
+        for x in 0..8 {
+            expected[x] = 0xFF;
+        }
+
+        // Set Color0
+        expected[8] = red565[0];
+        expected[9] = red565[1];
+
+        // Set Color1 based on repeat_colour
+        if repeat_colour {
+            expected[10] = red565[0];
+            expected[11] = red565[1];
+        }
+        // All other bytes remain 0
+
+        // Output buffer for normalized block
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(block.as_ptr(), output.as_mut_ptr(), 16, repeat_colour);
+        }
+
+        // Check that the output matches expected
+        assert_eq!(output, expected, "Solid color block normalization failed");
+    }
+
+    /// Test that a mixed color block is preserved as-is
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn can_preserve_mixed_color_block(#[case] repeat_colour: bool) {
+        // Create a mixed color block with red and blue
+        // - Uniform alpha
+        // - Color0 = Red
+        // - Color1 = Blue
+        // - Indices = mix of 0 and 1
+
+        let red565 = 0xF800u16.to_le_bytes(); // Red: [0x00, 0xF8]
+        let blue565 = 0x001Fu16.to_le_bytes(); // Blue: [0x1F, 0x00]
+
+        let mut block = [0u8; 16];
+
+        // Fill alpha values with 0xFF (fully opaque)
+        for x in 0..8 {
+            block[x] = 0xFF;
+        }
+
+        // Color part
+        block[8] = red565[0]; // Color0 (low byte)
+        block[9] = red565[1]; // Color0 (high byte)
+        block[10] = blue565[0]; // Color1 (low byte)
+        block[11] = blue565[1]; // Color1 (high byte)
+
+        // Mix of indices pointing to both colors
+        block[12] = 0b00010001; // 00010001 (alternating indices)
+        block[13] = 0b00010001;
+        block[14] = 0b00010001;
+        block[15] = 0b00010001;
+
+        // Output buffer for normalized block
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(block.as_ptr(), output.as_mut_ptr(), 16, repeat_colour);
+        }
+
+        // Check that the output is identical to the source (preserved as-is)
+        assert_eq!(output, block, "Mixed color block should be preserved as-is");
+    }
+
+    /// Test that a solid color block that can't be cleanly round-tripped is preserved as-is
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn can_preserve_non_roundtrippable_color_block(#[case] repeat_colour: bool) {
+        // Create a mix of 2 colours that can't be cleanly round-tripped,
+        // this cannot be simplified down
+        let red565 = 0xF800u16.to_le_bytes(); // (31, 0, 0) -> 0xF800
+        let blue565 = 0x001Fu16.to_le_bytes(); // (0, 0, 31) -> 0x001F
+
+        // Create the source block that would decode to a solid non-roundtrippable color
+        let mut source = [0u8; 16];
+
+        // Fill alpha values with 0xFF (fully opaque)
+        for x in 0..8 {
+            source[x] = 0xFF;
+        }
+
+        source[8] = red565[0]; // Color0 (low byte)
+        source[9] = red565[1]; // Color0 (high byte)
+        source[10] = blue565[0]; // Color1 (low byte)
+        source[11] = blue565[1]; // Color1 (high byte)
+                                 // All indices pointing at 2/3 color0, 1/3 color1
+        source[12] = 0b10101010; // 0b10101010
+        source[13] = 0b10101010;
+        source[14] = 0b10101010;
+        source[15] = 0b10101010;
+
+        // Output buffer for normalized block
+        // Decoded 8888: (170, 0, 85, 255)
+        // Round Tripped 8888: (173, 0, 82, 255)
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(source.as_ptr(), output.as_mut_ptr(), 16, repeat_colour);
+        }
+
+        // Check that the output is identical to the source (preserved as-is)
+        assert_eq!(
+            output, source,
+            "Non-roundtrippable color block should be preserved as-is"
+        );
+    }
+
+    /// Test that varying alpha values are preserved as-is
+    #[rstest]
+    #[case(false)]
+    #[case(true)]
+    fn can_preserve_varying_alpha_block(#[case] repeat_colour: bool) {
+        // Create a block with uniform color but varying alpha values
+        let red565 = 0xF800u16.to_le_bytes(); // Red: [0x00, 0xF8]
+
+        let mut block = [0u8; 16];
+
+        // Fill alpha values with varying pattern
+        for x in 0..8 {
+            block[x] = (x * 32) as u8; // Creates a pattern of alpha values
+        }
+
+        // Color part - all red
+        block[8] = red565[0]; // Color0 (low byte)
+        block[9] = red565[1]; // Color0 (high byte)
+        block[10] = 0x00; // Color1 (low byte)
+        block[11] = 0x00; // Color1 (high byte)
+
+        // All indices pointing to Color0
+        block[12] = 0x00;
+        block[13] = 0x00;
+        block[14] = 0x00;
+        block[15] = 0x00;
+
+        // Create a copy for comparison
+        let mut expected = [0u8; 16];
+        expected.copy_from_slice(&block);
+
+        // If repeating colors, Color1 should be the same as Color0
+        if repeat_colour {
+            expected[10] = red565[0];
+            expected[11] = red565[1];
+        }
+
+        // Output buffer for normalized block
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(block.as_ptr(), output.as_mut_ptr(), 16, repeat_colour);
+        }
+
+        // Check that the output matches what we expect
+        assert_eq!(output, expected, "Varying alpha block normalization failed");
+    }
+
+    /// Test normalizing multiple blocks in one call
+    #[test]
+    fn can_normalize_multiple_blocks() {
+        // Create data for two blocks: one solid color and one mixed color
+        let red565 = 0xF800u16.to_le_bytes(); // Red: [0x00, 0xF8]
+        let blue565 = 0x001Fu16.to_le_bytes(); // Blue: [0x1F, 0x00]
+
+        // Source data for both blocks
+        let mut source = [0u8; 32]; // Two blocks (16 bytes each)
+
+        // First block: solid red with uniform alpha
+        for x in 0..8 {
+            source[x] = 0xFF; // Fully opaque alpha
+        }
+        source[8] = red565[0]; // Color0 (low byte)
+        source[9] = red565[1]; // Color0 (high byte)
+        source[10] = 0x00; // Color1 (low byte)
+        source[11] = 0x00; // Color1 (high byte)
+                           // All indices pointing to Color0
+        source[12] = 0x00;
+        source[13] = 0x00;
+        source[14] = 0x00;
+        source[15] = 0x00;
+
+        // Second block: mixed colors that won't be normalized
+        for x in 16..24 {
+            source[x] = 0xFF; // Fully opaque alpha
+        }
+        source[24] = red565[0]; // Color0 (low byte)
+        source[25] = red565[1]; // Color0 (high byte)
+        source[26] = blue565[0]; // Color1 (low byte)
+        source[27] = blue565[1]; // Color1 (high byte)
+                                 // Mix of indices pointing to both colors
+        source[28] = 0b00010001; // 00010001 (alternating indices)
+        source[29] = 0b00010001;
+        source[30] = 0b00010001;
+        source[31] = 0b00010001;
+
+        // Expected output
+        let mut expected = [0u8; 32];
+
+        // First block: normalized (alpha preserved, color0 red, color1 0, indices 0)
+        for x in 0..8 {
+            expected[x] = 0xFF; // Copy alpha values
+        }
+        expected[8] = red565[0];
+        expected[9] = red565[1];
+        // Rest of first block's color part is zeros
+
+        // Second block: preserved as-is
+        expected[16..32].copy_from_slice(&source[16..32]);
+
+        // Output buffer
+        let mut output = [0u8; 32];
+
+        // Normalize both blocks
+        unsafe {
+            normalize_blocks(source.as_ptr(), output.as_mut_ptr(), 32, false);
+        }
+
+        // Check that the output matches expected
+        assert_eq!(output, expected, "Multiple block normalization failed");
+    }
+}

--- a/projects/dxt-lossless-transform-bc2/src/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/normalize_blocks/mod.rs
@@ -123,7 +123,6 @@ pub unsafe fn normalize_blocks(
             // Get the first pixel (they all have the same color)
             let pixel = decoded_block.pixels[0];
 
-            // Case 1: Solid color block
             // Convert the color to RGB565
             let color565 = pixel.to_color_565();
 

--- a/projects/dxt-lossless-transform-common/src/color_8888.rs
+++ b/projects/dxt-lossless-transform-common/src/color_8888.rs
@@ -49,4 +49,19 @@ impl Color8888 {
     pub fn to_color_565(&self) -> Color565 {
         Color565::from_rgb(self.r, self.g, self.b)
     }
+
+    /// Returns a new [`Color8888`] with the alpha component set to 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_common::color_8888::Color8888;
+    ///
+    /// let pixel = Color8888::new(255, 0, 0, 255);
+    /// let pixel_without_alpha = pixel.without_alpha();
+    /// assert_eq!(pixel_without_alpha.a, 0);
+    /// ```
+    pub fn without_alpha(&self) -> Color8888 {
+        Color8888::new(self.r, self.g, self.b, 0)
+    }
 }

--- a/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
+++ b/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
@@ -66,4 +66,23 @@ impl Decoded4x4Block {
             pixel_u32 == first_pixel_u32
         })
     }
+
+    /// Checks if all pixels in the block have the same color values
+    /// Ignoring the alpha values.
+    ///
+    /// # Returns
+    /// `true` if all pixels in the block are identical, `false` otherwise
+    #[inline]
+    pub fn has_identical_pixels_ignore_alpha(&self) -> bool {
+        // Assert at compile time that Color8888 is the same size as u32
+        const _: () = assert!(size_of::<Color8888>() == size_of::<u32>());
+
+        // Get first pixel without alpha
+        let first_pixel_u32_no_alpha = self.pixels[0].without_alpha();
+
+        // Compare all other pixels to the first one
+        self.pixels
+            .iter()
+            .all(|pixel| pixel.without_alpha() == first_pixel_u32_no_alpha)
+    }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added normalization for BC2 texture blocks to standardize solid color representations, improving compression consistency.
  - Introduced a new benchmark to measure normalization performance on BC2 blocks.
  - Added a fuzz test to validate BC2 block normalization.
  - Exposed new methods for handling color values without alpha and checking for identical pixels (ignoring alpha).

- **Documentation**
  - Expanded and clarified explanations of BC2 block normalization and solid block representation in project documentation.

- **Chores**
  - Updated dependencies and configuration files to support new features and benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->