### PR TITLE
Added: BC3 Block Normalization

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -57,3 +57,10 @@ path = "fuzz_targets/bc2_normalize.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "bc3_normalize"
+path = "fuzz_targets/bc3_normalize.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/bc3_normalize.rs
+++ b/fuzz/fuzz_targets/bc3_normalize.rs
@@ -1,0 +1,78 @@
+#![no_main]
+
+// This fuzz test validates the BC3 normalizer by checking that the normalized blocks decode
+// to the same pixels as the original blocks.
+
+use dxt_lossless_transform_bc3::{
+    normalize_blocks::{normalize_blocks, AlphaNormalizationMode, ColorNormalizationMode},
+    util::decode_bc3_block,
+};
+use dxt_lossless_transform_common::color_565::Color565;
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc3Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test for BC3 normalization
+// Tests that normalizing a block preserves its visual appearance when decoded
+fuzz_target!(|block: Bc3Block| {
+    // Skip if c0 <= c1 for the color part, as that mode is not supported on all GPUs for BC3
+    // BC3 color data starts at offset 8
+    let c0_raw: u16 = u16::from_le_bytes([block.bytes[8], block.bytes[9]]);
+    let c1_raw: u16 = u16::from_le_bytes([block.bytes[10], block.bytes[11]]);
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+    if !c0.greater_than(&c1) {
+        return;
+    }
+
+    // Get a slice to the BC3 block data
+    let bc3_block = &block.bytes;
+
+    // Save the original block for later comparison
+    let original_decoded = unsafe { decode_bc3_block(bc3_block.as_ptr()) };
+
+    // Test different combinations of normalization modes
+    let alpha_modes = [
+        AlphaNormalizationMode::UniformAlphaZeroIndices,
+        AlphaNormalizationMode::OpaqueFillAll,
+        AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices,
+    ];
+
+    let color_modes = [
+        ColorNormalizationMode::Color0Only,
+        ColorNormalizationMode::ReplicateColor,
+    ];
+
+    for &alpha_mode in &alpha_modes {
+        for &color_mode in &color_modes {
+            // Create a buffer for the normalized block
+            let mut normalized_block = [0u8; 16];
+
+            // Normalize the block with the current modes
+            unsafe {
+                normalize_blocks(
+                    bc3_block.as_ptr(),
+                    normalized_block.as_mut_ptr(),
+                    16, // Size of BC3 block in bytes
+                    alpha_mode,
+                    color_mode,
+                );
+            }
+
+            // Decode the normalized block
+            let normalized_decoded = unsafe { decode_bc3_block(normalized_block.as_ptr()) };
+
+            // Compare the two decoded blocks - they should produce the same visual output
+            assert_eq!(
+                original_decoded, normalized_decoded,
+                "Normalized block doesn't decode to the same pixels as the original block\n\
+                 Alpha mode: {alpha_mode:?}, Color mode: {color_mode:?}\n\
+                 Original block: {bc3_block:?}\n\
+                 Normalized block: {normalized_block:?}"
+            );
+        }
+    }
+});

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -46,3 +46,8 @@ harness = false
 name = "block_decode"
 path = "benches/block_decode/main.rs"
 harness = false
+
+[[bench]]
+name = "normalize_blocks"
+path = "benches/normalize_blocks/main.rs"
+harness = false

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -21,6 +21,7 @@ nightly = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
+likely_stable = "0.1.3"
 
 [dev-dependencies]
 criterion = "0.5.1"

--- a/projects/dxt-lossless-transform-bc3/README.MD
+++ b/projects/dxt-lossless-transform-bc3/README.MD
@@ -53,11 +53,56 @@ Separates colours and indices into continuous streams:
 +-------+-------+-------+     +-------+
 ```
 
-### Making Solid Blocks Represented the Same Across Texture
+### Making Single Colour Blocks Represented the Same Across Texture
 
-BC3 can represent solid color blocks in multiple ways, which hinders compression.
+BC3 can represent single color blocks in multiple ways, which hinders compression.
 
-- TODO
+Recall BC3 block format:
+
+```text
+Address: 0       2          8   8        12        16
+         +-------+----------+   +---------+---------+
+Data:    | A0-A1 | AI0-AI15 |   | C00-C01 | I00-I15 |
+         +-------+----------+   +---------+---------+
+```
+
+Two bytes of Alpha (8 bits each) followed by 6 bytes of indices (3 bits each).
+The indices are used to interpolate the alpha values.
+
+There are 2 steps to normalizing here:
+
+#### Normalizing the Alphas
+
+Sometimes all items within a block have the same alpha component, for example, all pixels in a block
+are fully opaque (`0xFF`), or are semi transparent (`0xD0`). 
+
+When a block is fully opaque, there are multiple well compressible representations which can be used:
+
+- All 8 bytes set to `0xFF` (`0xFFFFFFFF 0xFFFFFFFF`).
+  - Because `A0` <= `A1`, index 0xFF is hardcoded to opaque on decoder side.
+- Zero alphas but indices set to `0xFF` (`0x0000FFFF 0xFFFFFFFF`).
+
+For all other values (including `0xFF`), the following representation is possible:
+
+- `A0` set to `0xFF` and everything else set to `0x00` (`0xFF000000 0x00000000`).
+  - Everything uses colour from the first item.
+
+Which means there's `3` modes for fully opaque, and single `1` mode for everything else.
+
+#### Normalizing the Colours
+
+(This is the same as BC2)
+
+Sometimes there is a clean conversion between `8888` and `565` colour, meaning that it's possible
+to represent a colour using only 1 out of the 2 colour components, i.e. only `C0` or `C1`.
+
+When an entire block is solid, and a clean conversion between `8888` and `565` is possible, we set
+colour `C0` to the colour of the block, and then set `C1`, `I0-I3` all to `0x00`. This results in a
+nice repetition of `0x00` across 6 bytes. In some cases, it's beneficial to replicate
+the colour across `C0` and `C1`. We determine based on whichever performs better by compressing the data.
+
+Note: With BC2, BC3 it's important that we put the colour in `C0` because the 'alternate alpha mode' of
+BC1 where `c0 <= c1` is unsupported; it leads to undefined behaviour on some GPUs.
 
 ### Decorrelating Colours
 

--- a/projects/dxt-lossless-transform-bc3/benches/normalize_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/normalize_blocks/main.rs
@@ -1,0 +1,128 @@
+use core::{alloc::Layout, ptr::copy_nonoverlapping};
+use criterion::{criterion_group, criterion_main, Criterion};
+use dxt_lossless_transform_bc3::normalize_blocks::{
+    normalize_blocks, AlphaNormalizationMode, ColorNormalizationMode,
+};
+use safe_allocator_api::RawAlloc;
+use std::fs;
+
+#[cfg(not(target_os = "windows"))]
+use pprof::criterion::{Output, PProfProfiler};
+
+// Path to the BC3 file to benchmark with
+// You may need to update this path to point to a valid BC3 texture file on your system
+const TEST_FILE_PATH: &str =
+    "/home/sewer/Temp/texture-stuff/bc3-raw/202x-architecture-10.01/whiterun/wrcastlecarpets01.dds";
+
+pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
+    let layout = Layout::from_size_align(num_bytes, 64).unwrap();
+    RawAlloc::new(layout).unwrap()
+}
+
+#[allow(clippy::needless_range_loop)]
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("BC3 Normalize Blocks");
+
+    // Try to load the test file
+    let file_data = match fs::read(TEST_FILE_PATH) {
+        Ok(data) => {
+            println!("Successfully loaded test file: {TEST_FILE_PATH}");
+            data
+        }
+        Err(e) => {
+            println!("Warning: Could not load test file '{TEST_FILE_PATH}': {e}");
+            println!("To run this benchmark, you need a valid BC3 texture file.");
+            println!("Please update the TEST_FILE_PATH constant to point to a valid BC3 file or create a sample BC3 file.");
+            println!("Alternatively, we'll create a synthetic BC3 file for benchmarking.");
+
+            // Create a synthetic file with 1024 identical BC3 blocks for benchmarking
+            // BC3 block is 16 bytes (8 for alpha, 4 for colors, 4 for indices)
+            let block_size = 16;
+            let num_blocks = 1024;
+            let total_size = block_size * num_blocks;
+
+            // Create a sample BC3 block with solid red color
+            let mut sample_block = [0u8; 16];
+
+            // Alpha part (first 8 bytes) - all fully opaque (255)
+            for x in 0..8 {
+                sample_block[x] = 0xFF;
+            }
+
+            // Color endpoints (RGB565)
+            // Red = 0xF800 in RGB565 (little endian: [0x00, 0xF8])
+            sample_block[8] = 0x00;
+            sample_block[9] = 0xF8;
+            sample_block[10] = 0x00; // Second color not used
+            sample_block[11] = 0x00;
+
+            // Indices (all 0)
+            sample_block[12] = 0;
+            sample_block[13] = 0;
+            sample_block[14] = 0;
+            sample_block[15] = 0;
+
+            // Create the synthetic file by repeating the sample block
+            let mut synthetic_data = Vec::with_capacity(total_size);
+            for _ in 0..num_blocks {
+                synthetic_data.extend_from_slice(&sample_block);
+            }
+
+            println!(
+                "Created synthetic BC3 file with {} blocks ({} bytes) for benchmarking.",
+                num_blocks,
+                synthetic_data.len()
+            );
+            synthetic_data
+        }
+    };
+
+    // Ensure we have a file size that's a multiple of 16 (BC3 block size)
+    let file_size = file_data.len();
+
+    // Allocate memory for input and output
+    let mut input = allocate_align_64(file_size);
+    let mut output = allocate_align_64(file_size);
+
+    // Copy file data to input buffer
+    unsafe {
+        copy_nonoverlapping(file_data.as_ptr(), input.as_mut_ptr(), file_size);
+    }
+
+    let input_ptr = input.as_ptr();
+    let output_ptr = output.as_mut_ptr();
+
+    group.throughput(criterion::Throughput::Bytes(file_size as u64));
+
+    // Benchmark the normalize_blocks function
+    group.bench_function("normalize_blocks", |b| {
+        b.iter(|| unsafe {
+            normalize_blocks(
+                input_ptr,
+                output_ptr,
+                file_size,
+                // The mode doesn't really matter, the bottleneck isn't in the write here.
+                AlphaNormalizationMode::UniformAlphaZeroIndices,
+                ColorNormalizationMode::Color0Only,
+            );
+        })
+    });
+
+    group.finish();
+}
+
+#[cfg(not(target_os = "windows"))]
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = criterion_benchmark
+}
+
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = criterion_benchmark
+}
+
+criterion_main!(benches);

--- a/projects/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc3/src/lib.rs
@@ -3,6 +3,7 @@
 #![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
+pub mod normalize_blocks;
 pub mod split_blocks;
 pub mod util;
 

--- a/projects/dxt-lossless-transform-bc3/src/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/normalize_blocks/mod.rs
@@ -1,0 +1,877 @@
+//! # Block Normalization Process
+//!
+//! This module contains the code used to normalize BC3 blocks to improve compression ratio
+//! by making solid color blocks and alpha values have consistent representations.
+//!
+//! ## BC3 Block Format
+//!
+//! First, let's recall the BC3 block format:
+//!
+//! ```text
+//! Address: 0       2        8       12      16
+//!          +-------+--------+  +-------+--------+
+//! Data:    | A0-A1 |AI0-AI15|  | C0-C1 | I0-I15 |
+//!          +-------+--------+  +-------+--------+
+//! ```
+//!
+//! Where:
+//! - `A0-A1` are two alpha endpoints (8-bit each)
+//! - `AI0-AI15` are 6 bytes containing sixteen 3-bit alpha indices
+//! - `C0-C1` are 16-bit RGB565 color values (2 bytes each)
+//! - `I0-I15` are 4 bytes containing sixteen 2-bit color indices
+//!
+//! ## Normalization Rules
+//!
+//! The normalization process applies different rules for alpha and color components:
+//!
+//! ### Alpha Normalization
+//!
+//! When an entire block has uniform alpha, several representations are possible:
+//!
+//! For fully opaque blocks (`0xFF`):
+//! - All 8 bytes set to `0xFF` i.e. (`0xFFFFFFFF 0xFFFFFFFF`).
+//!   - Because `A0` <= `A1`, index `0xFF` is hardcoded to opaque on the decoder side.
+//! - Zero alphas but indices set to `0xFF` i.e. (`0x0000FFFF 0xFFFFFFFF`).
+//!
+//! For all other values (including `0xFF`):
+//! - `A0` set to the alpha value, everything else to `0x00` i.e. (`0xFF000000 0x00000000`).
+//!   - Everything uses the alpha value from the first endpoint.
+//!
+//! ### Color Normalization
+//!
+//! For solid color blocks with clean RGB565 conversion:
+//! - Set color in `C0`, zeroes in `C1` and indices
+//!   - This results in a nice repetition of `0x00` across 6 bytes
+//! - Or replicate color in both `C0` and `C1`, zeroes in indices
+//!   - In some cases, this performs better in compression
+//!
+//! Note: With BC3, it's important that we put the color in `C0` because the 'alternate alpha mode' of
+//! BC1 where `c0 <= c1` is unsupported; it leads to undefined behavior on some GPUs.
+//!
+//! ## Implementation Details
+//!
+//! The normalization process:
+//!
+//! 1. Decodes the block to get all 16 pixels with their colors and alpha values
+//! 2. Checks for uniform alpha and solid colors
+//! 3. Applies appropriate normalization based on the selected modes
+//! 4. Writes the normalized block to the output
+
+use crate::util::decode_bc3_block;
+use core::ptr::copy_nonoverlapping;
+use dxt_lossless_transform_common::color_8888::Color8888;
+use likely_stable::unlikely;
+
+/// Reads an input of BC3 blocks from `input_ptr` and writes the normalized blocks to `output_ptr`.
+///
+/// # Parameters
+///
+/// - `input_ptr`: A pointer to the input data (input BC3 blocks)
+/// - `output_ptr`: A pointer to the output data (output BC3 blocks)
+/// - `len`: The length of the input data in bytes
+/// - `alpha_mode`: How to normalize alpha values
+/// - `color_mode`: How to normalize color values
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 16 (BC3 block size)
+///
+/// # Remarks
+///
+/// This function identifies and normalizes BC3 blocks based on their content:
+/// - Blocks with uniform alpha are normalized according to the alpha_mode
+/// - Solid color blocks are normalized according to the color_mode
+/// - Other blocks are preserved as-is
+///
+/// Normalization improves compression ratios by ensuring that similar visual blocks
+/// have identical binary representations, reducing entropy in the data.
+#[inline]
+pub unsafe fn normalize_blocks(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+    alpha_mode: AlphaNormalizationMode,
+    color_mode: ColorNormalizationMode,
+) {
+    debug_assert!(len % 16 == 0);
+
+    // Skip normalization if both modes are None
+    if alpha_mode == AlphaNormalizationMode::None && color_mode == ColorNormalizationMode::None {
+        copy_nonoverlapping(input_ptr, output_ptr, len);
+        return;
+    }
+
+    // Calculate pointers to current block
+    let mut src_block_ptr = input_ptr;
+    let mut dst_block_ptr = output_ptr;
+    let src_end_ptr = input_ptr.add(len);
+
+    // Process each block
+    while src_block_ptr < src_end_ptr {
+        // Decode the block to analyze its content
+        let decoded_block = decode_bc3_block(src_block_ptr);
+
+        // Check for uniform alpha
+        let has_uniform_alpha = decoded_block.has_identical_alpha();
+
+        // Check for solid color (ignoring alpha)
+        let has_solid_color = decoded_block.has_identical_pixels_ignore_alpha();
+
+        if (alpha_mode != AlphaNormalizationMode::None && has_uniform_alpha)
+            || (color_mode != ColorNormalizationMode::None && has_solid_color)
+        {
+            // Handle alpha normalization
+            if has_uniform_alpha {
+                let alpha_value = decoded_block.pixels[0].a;
+                normalize_alpha(src_block_ptr, dst_block_ptr, alpha_value, alpha_mode);
+            } else {
+                // Copy alpha data as-is (first 8 bytes)
+                copy_nonoverlapping(src_block_ptr, dst_block_ptr, 8);
+            }
+
+            // Handle color normalization
+            if color_mode != ColorNormalizationMode::None && has_solid_color {
+                // Get the first pixel (they all have the same color)
+                let pixel = decoded_block.pixels[0];
+
+                // Convert the color to RGB565
+                let color565 = pixel.to_color_565();
+
+                // Check if color can be round-tripped cleanly through RGB565
+                let color8888 = color565.to_color_8888();
+                let pixel_ignore_alpha = Color8888::new(pixel.r, pixel.g, pixel.b, 255);
+                let color8888_ignore_alpha =
+                    Color8888::new(color8888.r, color8888.g, color8888.b, 255);
+
+                if unlikely(color8888_ignore_alpha == pixel_ignore_alpha) {
+                    // Can be normalized
+                    normalize_color(color565.raw_value(), dst_block_ptr, color_mode);
+                } else {
+                    // Cannot normalize, copy color part as-is
+                    copy_nonoverlapping(src_block_ptr.add(8), dst_block_ptr.add(8), 8);
+                }
+            } else {
+                // Copy color data as-is (last 8 bytes)
+                copy_nonoverlapping(src_block_ptr.add(8), dst_block_ptr.add(8), 8);
+            }
+        } else {
+            // Block doesn't need normalization, copy as-is
+            copy_nonoverlapping(src_block_ptr, dst_block_ptr, 16);
+        }
+
+        // Move to the next block
+        src_block_ptr = src_block_ptr.add(16);
+        dst_block_ptr = dst_block_ptr.add(16);
+    }
+}
+
+/// Defines how alpha values should be normalized for BC3 blocks
+///
+/// BC3 blocks can represent uniform alpha values in multiple ways. This enum
+/// defines the strategies for normalizing these representations to improve compression.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum AlphaNormalizationMode {
+    /// No alpha normalization, preserves original alpha data
+    None,
+
+    /// For uniform alpha, set `A0` to the alpha value, `A1` to zero, and indices to zero
+    /// This creates a pattern of `alpha,0,0,0,0,0,0,0` for the alpha component
+    UniformAlphaZeroIndices,
+
+    /// For fully opaque, use all 0xFF bytes in the alpha component
+    /// Creates a pattern of `0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF`.
+    ///
+    /// If the alpha value is not fully opaque, this mode will use [`AlphaNormalizationMode::UniformAlphaZeroIndices`]
+    OpaqueFillAll,
+
+    /// For fully opaque, use zero alphas but 0xFF indices
+    /// Creates a pattern of `0,0,0xFF,0xFF,0xFF,0xFF,0xFF,0xFF`
+    ///
+    /// If the alpha value is not fully opaque, this mode will use [`AlphaNormalizationMode::UniformAlphaZeroIndices`]
+    OpaqueZeroAlphaMaxIndices,
+}
+
+/// Defines how colors should be normalized for BC3 blocks
+///
+/// BC3 blocks can represent solid colors in multiple ways. This enum
+/// defines the strategies for normalizing these representations to improve compression.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ColorNormalizationMode {
+    /// No color normalization, preserves original color data
+    None,
+
+    /// For solid color blocks, put color in C0, zeroes in C1 and indices
+    /// Creates a pattern of `color,0,0,0,0,0,0,0` for the color component
+    /// This results in a nice repetition of `0x00` across 6 bytes
+    Color0Only,
+
+    /// For solid color blocks, replicate color in both C0 and C1, zeroes in indices
+    /// Creates a pattern of `color,color,0,0,0,0` for the color component
+    /// In some cases, this performs better in compression.
+    ReplicateColor,
+}
+
+/// Normalizes the alpha component of a BC3 block
+///
+/// Applies the selected normalization mode to the alpha component of a BC3 block.
+/// This is particularly effective for blocks with uniform alpha values.
+///
+/// # Parameters
+///
+/// - `src_block_ptr`: Pointer to the source BC3 block
+/// - `dst_block_ptr`: Pointer to the destination where the normalized block will be written
+/// - `alpha_value`: The uniform alpha value found in the block (0-255)
+/// - `mode`: The alpha normalization mode to use
+///
+/// # Safety
+///
+/// This is an unsafe function that requires:
+/// - Valid pointers to source and destination blocks with at least 8 bytes accessible
+/// - Alpha value must be the actual uniform alpha found in the block
+#[inline]
+unsafe fn normalize_alpha(
+    src_block_ptr: *const u8,
+    dst_block_ptr: *mut u8,
+    alpha_value: u8,
+    mode: AlphaNormalizationMode,
+) {
+    match mode {
+        AlphaNormalizationMode::None => {
+            // Copy alpha data as-is (first 8 bytes)
+            copy_nonoverlapping(src_block_ptr, dst_block_ptr, 8);
+        }
+        AlphaNormalizationMode::UniformAlphaZeroIndices => {
+            // Set A0 to the alpha value, everything else to 0
+            *dst_block_ptr = alpha_value;
+            *dst_block_ptr.add(1) = 0;
+
+            // Zero all index bytes
+            for x in 2..8 {
+                *dst_block_ptr.add(x) = 0;
+            }
+        }
+        AlphaNormalizationMode::OpaqueFillAll => {
+            if alpha_value == 255 {
+                // Fill all alpha bytes with 0xFF
+                for x in 0..8 {
+                    *dst_block_ptr.add(x) = 0xFF;
+                }
+            } else {
+                // For non-opaque, use the same approach as UniformAlphaZeroIndices
+                normalize_alpha(
+                    src_block_ptr,
+                    dst_block_ptr,
+                    alpha_value,
+                    AlphaNormalizationMode::UniformAlphaZeroIndices,
+                );
+            }
+        }
+        AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices => {
+            if alpha_value == 255 {
+                // Set alpha endpoints to 0
+                *dst_block_ptr = 0;
+                *dst_block_ptr.add(1) = 0;
+
+                // Set all indices to max value (0xFF)
+                for x in 2..8 {
+                    *dst_block_ptr.add(x) = 0xFF;
+                }
+            } else {
+                // For non-opaque, use the same approach as UniformAlphaZeroIndices
+                normalize_alpha(
+                    src_block_ptr,
+                    dst_block_ptr,
+                    alpha_value,
+                    AlphaNormalizationMode::UniformAlphaZeroIndices,
+                );
+            }
+        }
+    }
+}
+
+/// Normalizes the color component of a BC3 block
+///
+/// Applies the selected normalization mode to the color component of a BC3 block.
+/// This is particularly effective for blocks with solid colors that have a clean
+/// conversion between 8888 and 565 color formats.
+///
+/// # Parameters
+///
+/// - `color565`: The RGB565 color value to use for normalization
+/// - `dst_block_ptr`: Pointer to the destination block where normalized color will be written
+/// - `mode`: The color normalization mode to use
+///
+/// # Safety
+///
+/// This is an unsafe function that requires:
+/// - Valid pointer to destination block with at least 8 bytes accessible at offset 8
+/// - color565 must be the actual RGB565 value corresponding to the solid color
+#[inline]
+unsafe fn normalize_color(color565: u16, dst_block_ptr: *mut u8, mode: ColorNormalizationMode) {
+    let color_ptr = dst_block_ptr.add(8);
+    let color_bytes = color565.to_le_bytes();
+
+    match mode {
+        ColorNormalizationMode::None => {
+            // Do nothing - color component was already copied elsewhere
+        }
+        ColorNormalizationMode::Color0Only => {
+            // Write Color0 (the solid color)
+            *color_ptr = color_bytes[0];
+            *color_ptr.add(1) = color_bytes[1];
+
+            // Write Color1 = 0
+            *color_ptr.add(2) = 0;
+            *color_ptr.add(3) = 0;
+
+            // Write indices = 0
+            *color_ptr.add(4) = 0;
+            *color_ptr.add(5) = 0;
+            *color_ptr.add(6) = 0;
+            *color_ptr.add(7) = 0;
+        }
+        ColorNormalizationMode::ReplicateColor => {
+            // Write Color0 (the solid color)
+            *color_ptr = color_bytes[0];
+            *color_ptr.add(1) = color_bytes[1];
+
+            // Write Color1 = same color
+            *color_ptr.add(2) = color_bytes[0];
+            *color_ptr.add(3) = color_bytes[1];
+
+            // Write indices = 0
+            *color_ptr.add(4) = 0;
+            *color_ptr.add(5) = 0;
+            *color_ptr.add(6) = 0;
+            *color_ptr.add(7) = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::needless_range_loop)]
+mod tests {
+    use rstest::rstest;
+
+    use super::*;
+
+    /// Test normalizing a solid color block with uniform alpha
+    #[rstest]
+    #[case(AlphaNormalizationMode::None, ColorNormalizationMode::Color0Only)]
+    #[case(AlphaNormalizationMode::None, ColorNormalizationMode::ReplicateColor)]
+    #[case(
+        AlphaNormalizationMode::UniformAlphaZeroIndices,
+        ColorNormalizationMode::Color0Only
+    )]
+    #[case(AlphaNormalizationMode::OpaqueFillAll, ColorNormalizationMode::None)]
+    #[case(
+        AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices,
+        ColorNormalizationMode::None
+    )]
+    #[case(
+        AlphaNormalizationMode::OpaqueFillAll,
+        ColorNormalizationMode::Color0Only
+    )]
+    #[case(
+        AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices,
+        ColorNormalizationMode::ReplicateColor
+    )]
+    fn can_normalize_block_opaque_alpha_single_colour(
+        #[case] alpha_mode: AlphaNormalizationMode,
+        #[case] color_mode: ColorNormalizationMode,
+    ) {
+        // Red in RGB565: (31, 0, 0) -> 0xF800
+        // This cleanly round trips into (255, 0, 0) and back to (31, 0, 0).
+        let red565 = 0xF800u16.to_le_bytes(); // Little endian: [0x00, 0xF8]
+
+        // This creates a BC3 block with the following characteristics:
+        // - Alpha endpoints (A0=A1=0xFF)
+        // - Alpha indices all point to A0
+        // - Color0 = Red (RGB565)
+        // - Color1 = Another color (doesn't matter)
+        // - Indices = All pointing to Color0 (all 0b00)
+        let mut block = [0u8; 16];
+
+        // Set alpha endpoints to fully opaque
+        block[0] = 0xFF; // A0
+        block[1] = 0xFF; // A1
+
+        // Set alpha indices to point to A0
+        for x in 2..8 {
+            block[x] = 0; // All indices point to A0
+        }
+
+        // Set Color0 to red
+        block[8] = red565[0];
+        block[9] = red565[1];
+
+        // Set Color1 to another color (doesn't matter)
+        block[10] = 0x12;
+        block[11] = 0x34;
+
+        // Set indices to all point to Color0
+        for x in 12..16 {
+            block[x] = 0; // All indices point to Color0
+        }
+
+        // Create output buffer
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(
+                block.as_ptr(),
+                output.as_mut_ptr(),
+                16,
+                alpha_mode,
+                color_mode,
+            );
+        }
+
+        // Verify normalization
+        // For alpha
+        match alpha_mode {
+            AlphaNormalizationMode::None => {
+                // Alpha part should be unchanged
+                assert_eq!(output[0], 0xFF);
+                assert_eq!(output[1], 0xFF);
+                for x in 2..8 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            AlphaNormalizationMode::UniformAlphaZeroIndices => {
+                // A0 set to alpha value, rest zero
+                assert_eq!(output[0], 0xFF);
+                assert_eq!(output[1], 0);
+                for x in 2..8 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            AlphaNormalizationMode::OpaqueFillAll => {
+                // For fully opaque, all alpha bytes should be 0xFF
+                for x in 0..8 {
+                    assert_eq!(output[x], 0xFF);
+                }
+            }
+            AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices => {
+                // For fully opaque, alpha endpoints should be 0, indices should be 0xFF
+                assert_eq!(output[0], 0);
+                assert_eq!(output[1], 0);
+                for x in 2..8 {
+                    assert_eq!(output[x], 0xFF);
+                }
+            }
+        }
+
+        // For color
+        match color_mode {
+            ColorNormalizationMode::Color0Only => {
+                // Color0 = red, Color1 = 0, indices = 0
+                assert_eq!(output[8], red565[0]);
+                assert_eq!(output[9], red565[1]);
+                assert_eq!(output[10], 0);
+                assert_eq!(output[11], 0);
+                for x in 12..16 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            ColorNormalizationMode::ReplicateColor => {
+                // Color0 = Color1 = red, indices = 0
+                assert_eq!(output[8], red565[0]);
+                assert_eq!(output[9], red565[1]);
+                assert_eq!(output[10], red565[0]);
+                assert_eq!(output[11], red565[1]);
+                for x in 12..16 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            _ => {}
+        }
+
+        // Decode the normalized block to verify it still represents the same pixels
+        let decoded = unsafe { decode_bc3_block(output.as_ptr()) };
+
+        // Check all pixels have the correct color and alpha
+        for x in 0..16 {
+            assert_eq!(decoded.pixels[x].r, 255); // Red
+            assert_eq!(decoded.pixels[x].g, 0);
+            assert_eq!(decoded.pixels[x].b, 0);
+            assert_eq!(decoded.pixels[x].a, 255); // Fully opaque
+        }
+    }
+
+    /// Test normalizing a block with uniform alpha but mixed colors
+    #[rstest]
+    #[case(AlphaNormalizationMode::UniformAlphaZeroIndices)]
+    #[case(AlphaNormalizationMode::OpaqueFillAll)]
+    fn can_normalize_uniform_alpha_mixed_colors(#[case] alpha_mode: AlphaNormalizationMode) {
+        // Create a BC3 block with uniform alpha but mixed colors
+        let mut block = [0u8; 16];
+
+        // Set alpha endpoints to fully opaque
+        block[0] = 0xFF; // A0
+        block[1] = 0xFF; // A1
+
+        // Set alpha indices to point to A0
+        for x in 2..8 {
+            block[x] = 0; // All indices point to A0
+        }
+
+        // Set Color0 and Color1 to different colors
+        block[8] = 0x00;
+        block[9] = 0xF8; // Red
+        block[10] = 0xE0;
+        block[11] = 0x07; // Green
+
+        // Set mixed indices (use both colors)
+        block[12] = 0x55; // Alternating 01 01 01 01
+        block[13] = 0x55;
+        block[14] = 0x55;
+        block[15] = 0x55;
+
+        // Create output buffer
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(
+                block.as_ptr(),
+                output.as_mut_ptr(),
+                16,
+                alpha_mode,
+                ColorNormalizationMode::None,
+            );
+        }
+
+        // Verify alpha normalization
+        match alpha_mode {
+            AlphaNormalizationMode::UniformAlphaZeroIndices => {
+                // A0 set to alpha value, rest zero
+                assert_eq!(output[0], 0xFF);
+                assert_eq!(output[1], 0);
+                for x in 2..8 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            AlphaNormalizationMode::OpaqueFillAll => {
+                // All alpha bytes set to 0xFF
+                for x in 0..8 {
+                    assert_eq!(output[x], 0xFF);
+                }
+            }
+            _ => {}
+        }
+
+        // Color part should be unchanged
+        assert_eq!(output[8], block[8]);
+        assert_eq!(output[9], block[9]);
+        assert_eq!(output[10], block[10]);
+        assert_eq!(output[11], block[11]);
+        assert_eq!(output[12], block[12]);
+        assert_eq!(output[13], block[13]);
+        assert_eq!(output[14], block[14]);
+        assert_eq!(output[15], block[15]);
+
+        // Decode the normalized block to verify it still represents the same visual data
+        let decoded = unsafe { decode_bc3_block(output.as_ptr()) };
+
+        // All pixels should have alpha = 255
+        for x in 0..16 {
+            assert_eq!(decoded.pixels[x].a, 255);
+        }
+    }
+
+    /// Test normalizing a block with mixed alpha and solid color
+    #[rstest]
+    #[case(ColorNormalizationMode::Color0Only)]
+    #[case(ColorNormalizationMode::ReplicateColor)]
+    fn can_normalize_mixed_alpha_solid_color(#[case] color_mode: ColorNormalizationMode) {
+        // Create a BC3 block with varying alpha but solid color
+        let mut block = [0u8; 16];
+
+        // Set different alpha endpoints
+        block[0] = 0xFF; // A0
+        block[1] = 0x80; // A1
+
+        // Set mixed alpha indices
+        for x in 2..8 {
+            block[x] = 0x55; // Mixed indices
+        }
+
+        // Set Color0 and Color1 to the same color (red)
+        let red565 = 0xF800u16.to_le_bytes();
+        block[8] = red565[0];
+        block[9] = red565[1];
+        block[10] = 0x12; // Different value for color1
+        block[11] = 0x34;
+
+        // Set all indices to point to Color0
+        for x in 12..16 {
+            block[x] = 0;
+        }
+
+        // Create output buffer
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(
+                block.as_ptr(),
+                output.as_mut_ptr(),
+                16,
+                AlphaNormalizationMode::OpaqueFillAll,
+                color_mode,
+            );
+        }
+
+        // Alpha part should be unchanged regardless of option
+        for x in 0..8 {
+            assert_eq!(output[x], block[x]);
+        }
+
+        // Verify color normalization
+        match color_mode {
+            ColorNormalizationMode::Color0Only => {
+                // Color0 = red, Color1 = 0, indices = 0
+                assert_eq!(output[8], red565[0]);
+                assert_eq!(output[9], red565[1]);
+                assert_eq!(output[10], 0);
+                assert_eq!(output[11], 0);
+                for x in 12..16 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            ColorNormalizationMode::ReplicateColor => {
+                // Color0 = Color1 = red, indices = 0
+                assert_eq!(output[8], red565[0]);
+                assert_eq!(output[9], red565[1]);
+                assert_eq!(output[10], red565[0]);
+                assert_eq!(output[11], red565[1]);
+                for x in 12..16 {
+                    assert_eq!(output[x], 0);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Test the OpaqueZeroAlphaMaxIndices alpha mode
+    #[test]
+    fn can_normalize_with_opaque_zero_alpha_max_indices() {
+        // Create a BC3 block with fully opaque alpha
+        let mut block = [0u8; 16];
+
+        // Set alpha endpoints to fully opaque
+        block[0] = 0xFF; // A0
+        block[1] = 0xFF; // A1
+
+        // Set some alpha indices
+        for x in 2..8 {
+            block[x] = 0; // All indices point to A0
+        }
+
+        // Set some color values (doesn't matter for this test)
+        for x in 8..16 {
+            block[x] = x as u8;
+        }
+
+        // Create output buffer
+        let mut output = [0u8; 16];
+
+        // Normalize the block
+        unsafe {
+            normalize_blocks(
+                block.as_ptr(),
+                output.as_mut_ptr(),
+                16,
+                AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices,
+                ColorNormalizationMode::None,
+            );
+        }
+
+        // Verify alpha normalization
+        // First two bytes should be zero
+        assert_eq!(output[0], 0);
+        assert_eq!(output[1], 0);
+
+        // All index bytes should be 0xFF
+        for x in 2..8 {
+            assert_eq!(output[x], 0xFF);
+        }
+
+        // Color bytes should be unchanged
+        for x in 8..16 {
+            assert_eq!(output[x], block[x]);
+        }
+
+        // Decode the normalized block to verify alphas are still 255
+        let decoded = unsafe { decode_bc3_block(output.as_ptr()) };
+        for x in 0..16 {
+            assert_eq!(decoded.pixels[x].a, 255);
+        }
+    }
+
+    /// Test that non-opaque uniform alpha is properly normalized
+    #[test]
+    fn can_normalize_non_opaque_uniform_alpha() {
+        // Create a BC3 block with semi-transparent alpha
+        let mut block = [0u8; 16];
+
+        // Set alpha endpoints to 128 (semi-transparent)
+        block[0] = 128; // A0
+        block[1] = 128; // A1
+
+        // Set all alpha indices to point to A0
+        for x in 2..8 {
+            block[x] = 0;
+        }
+
+        // Set some color values (doesn't matter for this test)
+        for x in 8..16 {
+            block[x] = x as u8;
+        }
+
+        // Create output buffer
+        let mut output = [0u8; 16];
+
+        // Test all alpha modes
+        let modes = [
+            AlphaNormalizationMode::UniformAlphaZeroIndices,
+            AlphaNormalizationMode::OpaqueFillAll,
+            AlphaNormalizationMode::OpaqueZeroAlphaMaxIndices,
+        ];
+
+        for mode in modes {
+            // Normalize the block
+            unsafe {
+                normalize_blocks(
+                    block.as_ptr(),
+                    output.as_mut_ptr(),
+                    16,
+                    mode,
+                    ColorNormalizationMode::None,
+                );
+            }
+
+            // For non-opaque alpha, all modes should behave like UniformAlphaZeroIndices
+            assert_eq!(output[0], 128); // A0 = alpha value
+            assert_eq!(output[1], 0); // A1 = 0
+
+            // All index bytes should be 0
+            for x in 2..8 {
+                assert_eq!(output[x], 0);
+            }
+
+            // Decode the normalized block to verify alphas are still 128
+            let decoded = unsafe { decode_bc3_block(output.as_ptr()) };
+            for x in 0..16 {
+                assert_eq!(decoded.pixels[x].a, 128);
+            }
+        }
+    }
+
+    /// Test normalizing multiple blocks in one call
+    #[test]
+    fn can_normalize_multiple_blocks() {
+        // Create two BC3 blocks
+        let mut blocks = [0u8; 32]; // 2 blocks, 16 bytes each
+
+        // Block 1: Solid red with uniform alpha
+        // Set alpha endpoints to fully opaque
+        blocks[0] = 0xFF;
+        blocks[1] = 0xFF;
+
+        // Set alpha indices
+        for x in 2..8 {
+            blocks[x] = 0;
+        }
+
+        // Set Color0 to red, Color1 to something else
+        let red565 = 0xF800u16.to_le_bytes();
+        blocks[8] = red565[0];
+        blocks[9] = red565[1];
+        blocks[10] = 0x12;
+        blocks[11] = 0x34;
+
+        // Set indices to all point to Color0
+        for x in 12..16 {
+            blocks[x] = 0;
+        }
+
+        // Block 2: Explicitly set to have mixed alpha and colors
+        // This should not get normalized
+
+        // Set different alpha endpoints
+        blocks[16] = 0x80; // A0
+        blocks[17] = 0x40; // A1
+
+        // Important: Need different alpha indices to create truly mixed alpha values
+        blocks[18] = 0xAA; // Mixed pattern of indices
+        blocks[19] = 0x55; // Different pattern
+        blocks[20] = 0x33; // Different pattern
+        blocks[21] = 0xCC; // Different pattern
+        blocks[22] = 0x0F; // Different pattern
+        blocks[23] = 0xF0; // Different pattern
+
+        // Set different colors in Color0 and Color1
+        let green565 = 0x07E0u16.to_le_bytes();
+        blocks[24] = green565[0]; // Green in Color0
+        blocks[25] = green565[1];
+
+        let blue565 = 0x001Fu16.to_le_bytes();
+        blocks[26] = blue565[0]; // Blue in Color1
+        blocks[27] = blue565[1];
+
+        // Set truly mixed color indices
+        blocks[28] = 0x55; // Mixed pattern 01 01 01 01
+        blocks[29] = 0xAA; // Mixed pattern 10 10 10 10
+        blocks[30] = 0x3C; // Mixed pattern 00 11 11 00
+        blocks[31] = 0x69; // Mixed pattern 01 10 01 00
+
+        // Create a copy of the blocks for later comparison
+        let blocks_copy = blocks;
+
+        // Create output buffer
+        let mut output = [0u8; 32];
+
+        // Normalize the blocks
+        unsafe {
+            normalize_blocks(
+                blocks.as_ptr(),
+                output.as_mut_ptr(),
+                32,
+                AlphaNormalizationMode::UniformAlphaZeroIndices,
+                ColorNormalizationMode::Color0Only,
+            );
+        }
+
+        // Block 1 should be normalized for both alpha and color
+        assert_eq!(output[0], 0xFF); // A0 = alpha value
+        assert_eq!(output[1], 0); // A1 = 0
+
+        // Alpha indices should be 0 (UniformAlphaZeroIndices)
+        for x in 2..8 {
+            assert_eq!(output[x], 0);
+        }
+
+        // Color0 should be red, Color1 and indices should be 0 (Color0Only mode)
+        assert_eq!(output[8], red565[0]);
+        assert_eq!(output[9], red565[1]);
+        assert_eq!(output[10], 0);
+        assert_eq!(output[11], 0);
+
+        for x in 12..16 {
+            assert_eq!(output[x], 0);
+        }
+
+        // Block 2 should be completely unchanged as it has mixed colors and mixed alpha
+        for x in 16..32 {
+            assert_eq!(
+                output[x], blocks_copy[x],
+                "Block 2 byte {x} was modified when it should be unchanged",
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc3/src/util/bc3_decode.rs
+++ b/projects/dxt-lossless-transform-bc3/src/util/bc3_decode.rs
@@ -96,8 +96,8 @@ pub unsafe fn decode_bc3_block(src: *const u8) -> Decoded4x4Block {
 
     // Create alpha lookup table
     let mut alpha_values = [0u8; 8];
-    alpha_values[0] = alpha0;
-    alpha_values[1] = alpha1;
+    alpha_values[0] = alpha0; // bit code 000
+    alpha_values[1] = alpha1; // bit code 001
 
     // In BC4/BC3, if alpha0 > alpha1, we have 8 interpolated values
     // Otherwise we have 6 interpolated values plus transparent and opaque

--- a/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
+++ b/projects/dxt-lossless-transform-common/src/decoded_4x4_block.rs
@@ -74,9 +74,6 @@ impl Decoded4x4Block {
     /// `true` if all pixels in the block are identical, `false` otherwise
     #[inline]
     pub fn has_identical_pixels_ignore_alpha(&self) -> bool {
-        // Assert at compile time that Color8888 is the same size as u32
-        const _: () = assert!(size_of::<Color8888>() == size_of::<u32>());
-
         // Get first pixel without alpha
         let first_pixel_u32_no_alpha = self.pixels[0].without_alpha();
 
@@ -84,5 +81,12 @@ impl Decoded4x4Block {
         self.pixels
             .iter()
             .all(|pixel| pixel.without_alpha() == first_pixel_u32_no_alpha)
+    }
+
+    /// Checks if all pixels in the block have the same alpha values
+    #[inline]
+    pub fn has_identical_alpha(&self) -> bool {
+        let first_pixel_alpha = self.pixels[0].a;
+        self.pixels.iter().all(|pixel| pixel.a == first_pixel_alpha)
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configurable normalization for BC3 texture blocks, enabling consistent binary representations for blocks with uniform alpha or solid colors.
  - Added new benchmarking tools to measure BC3 block normalization performance.
  - Added new fuzz tests to validate BC3 normalization correctness.
- **Documentation**
  - Expanded and clarified documentation on BC3 block normalization strategies and their impact on compression.
  - Improved code comments for better code understanding.
- **Bug Fixes**
  - Enhanced fuzz tests to skip unsupported BC2 block configurations.
- **Refactor**
  - Introduced utility methods for checking uniform alpha in decoded blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->