### PR TITLE
Added: BC1 Normalize to all variants/formats at once

### DIFF
--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -22,6 +22,7 @@ nightly = []
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
 likely_stable = "0.1.3"
 safe-allocator-api = "0.3.0"
+derive-enum-all-values = "0.2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dev-dependencies]

--- a/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/normalize_blocks/main.rs
@@ -10,7 +10,8 @@ use std::fs;
 use pprof::criterion::{Output, PProfProfiler};
 
 // Path to the BC1 file to benchmark with
-const TEST_FILE_PATH: &str = "/home/sewer/Downloads/texture-stuff/bc1-raw/202x-architecture-10.01/whiterun/wrwoodlattice01.dds";
+const TEST_FILE_PATH: &str =
+    "/home/sewer/Temp/texture-stuff/bc1-raw/202x-architecture-10.01/whiterun/wrwoodlattice01.dds";
 
 pub(crate) fn allocate_align_64(num_bytes: usize) -> RawAlloc {
     let layout = Layout::from_size_align(num_bytes, 64).unwrap();

--- a/projects/dxt-lossless-transform-common/src/color_565.rs
+++ b/projects/dxt-lossless-transform-common/src/color_565.rs
@@ -3,7 +3,7 @@ use multiversion::multiversion;
 
 /// Represents a 16-bit RGB565 color (5 bits red, 6 bits green, 5 bits blue)
 /// As encountered in many of the BC1 formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct Color565 {
     /// The underlying 16-bit RGB565 value
     value: u16,


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for normalizing blocks across all color normalization modes simultaneously, with results written to multiple output buffers.
  - Introduced new processing options for block types, improving normalization flexibility.
  - Enabled default instantiation for color values with the addition of a default trait.

- **Refactor**
  - Streamlined and modularized normalization logic for better clarity and maintainability.

- **Tests**
  - Expanded test coverage to verify correct multi-mode normalization behavior.

- **Chores**
  - Updated dependencies to include support for iterating over all color normalization modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->