### PR TITLE
Added: Normalization of split blocks for BC1-BC3 (hello from airport)

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -99,3 +99,10 @@ path = "fuzz_targets/bc2_normalize_in_place.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "bc3_normalize_in_place"
+path = "fuzz_targets/bc3_normalize_in_place.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -92,3 +92,10 @@ path = "fuzz_targets/bc1_normalize_in_place.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "bc2_normalize_in_place"
+path = "fuzz_targets/bc2_normalize_in_place.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -85,3 +85,10 @@ path = "fuzz_targets/bc3_normalize_all_modes.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "bc1_normalize_in_place"
+path = "fuzz_targets/bc1_normalize_in_place.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/bc1_normalize_in_place.rs
+++ b/fuzz/fuzz_targets/bc1_normalize_in_place.rs
@@ -1,0 +1,68 @@
+#![no_main]
+
+// This fuzz test validates the BC1 normalize_split_blocks_in_place function by checking that
+// the normalized blocks decode to the same pixels as the original blocks.
+
+use core::ptr::copy_nonoverlapping;
+use dxt_lossless_transform_bc1::{
+    normalize_blocks::{normalize_split_blocks_in_place, ColorNormalizationMode},
+    util::decode_bc1_block,
+};
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc1Block {
+    pub bytes: [u8; 8],
+}
+
+// Fuzz test for BC1 normalization of split blocks
+// Tests that normalizing split blocks preserves visual appearance when decoded
+fuzz_target!(|block: Bc1Block| {
+    // Get a slice to the BC1 block data
+    let bc1_block = &block.bytes;
+
+    // Save the original block for later comparison
+    let original_decoded = unsafe { decode_bc1_block(bc1_block.as_ptr()) };
+
+    // Test each normalization mode
+    for &color_mode in ColorNormalizationMode::all_values() {
+        // Create buffers for the split block data (colors and indices)
+        let mut colors = [0u8; 4];
+        let mut indices = [0u8; 4];
+
+        // Split the BC1 block into colors and indices
+        unsafe {
+            copy_nonoverlapping(bc1_block.as_ptr(), colors.as_mut_ptr(), 4);
+            copy_nonoverlapping(bc1_block.as_ptr().add(4), indices.as_mut_ptr(), 4);
+        }
+
+        // Normalize the split blocks in place with the current mode
+        unsafe {
+            normalize_split_blocks_in_place(
+                colors.as_mut_ptr(),
+                indices.as_mut_ptr(),
+                1, // Process 1 block
+                color_mode,
+            );
+        }
+
+        // Reconstruct the normalized block
+        let mut normalized_block = [0u8; 8];
+        unsafe {
+            copy_nonoverlapping(colors.as_ptr(), normalized_block.as_mut_ptr(), 4);
+            copy_nonoverlapping(indices.as_ptr(), normalized_block.as_mut_ptr().add(4), 4);
+        }
+
+        // Decode the normalized block
+        let normalized_decoded = unsafe { decode_bc1_block(normalized_block.as_ptr()) };
+
+        // Compare the two decoded blocks - they should produce the same visual output
+        assert_eq!(
+            original_decoded,
+            normalized_decoded,
+            "Normalized block (with color_mode={color_mode:?}) doesn't decode to the same pixels as the original block\n\
+             Original block: {bc1_block:?}\n\
+             Normalized block: {normalized_block:?}",
+        );
+    }
+});

--- a/fuzz/fuzz_targets/bc2_normalize_in_place.rs
+++ b/fuzz/fuzz_targets/bc2_normalize_in_place.rs
@@ -1,0 +1,82 @@
+#![no_main]
+
+// This fuzz test validates the BC2 normalize_split_blocks_in_place function by checking that
+// the normalized blocks decode to the same pixels as the original blocks.
+
+use core::ptr::copy_nonoverlapping;
+use dxt_lossless_transform_bc2::{
+    normalize_blocks::{normalize_split_blocks_in_place, ColorNormalizationMode},
+    util::decode_bc2_block,
+};
+use dxt_lossless_transform_common::color_565::Color565;
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc2Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test for BC2 normalization of split blocks
+// Tests that normalizing split blocks preserves visual appearance when decoded
+fuzz_target!(|block: Bc2Block| {
+    // Skip if c0 <= c1 as that mode is not supported on all GPUs.
+    let c0_raw: u16 = u16::from_le_bytes([block.bytes[8], block.bytes[9]]);
+    let c1_raw: u16 = u16::from_le_bytes([block.bytes[10], block.bytes[11]]);
+    let c0 = Color565::from_raw(c0_raw);
+    let c1 = Color565::from_raw(c1_raw);
+    if !c0.greater_than(&c1) {
+        return;
+    }
+
+    // Get a slice to the BC2 block data
+    let bc2_block = &block.bytes;
+
+    // Save the original block for later comparison
+    let original_decoded = unsafe { decode_bc2_block(bc2_block.as_ptr()) };
+
+    // Test each normalization mode
+    for &color_mode in ColorNormalizationMode::all_values() {
+        // Create buffers for the split block data (alpha, colors and indices)
+        let mut alpha = [0u8; 8];
+        let mut colors = [0u8; 4];
+        let mut indices = [0u8; 4];
+
+        // Split the BC2 block into alpha, colors and indices
+        unsafe {
+            copy_nonoverlapping(bc2_block.as_ptr(), alpha.as_mut_ptr(), 8);
+            copy_nonoverlapping(bc2_block.as_ptr().add(8), colors.as_mut_ptr(), 4);
+            copy_nonoverlapping(bc2_block.as_ptr().add(12), indices.as_mut_ptr(), 4);
+        }
+
+        // Normalize the split blocks in place with the current mode
+        unsafe {
+            normalize_split_blocks_in_place(
+                alpha.as_ptr(),
+                colors.as_mut_ptr(),
+                indices.as_mut_ptr(),
+                1, // Process 1 block
+                color_mode,
+            );
+        }
+
+        // Reconstruct the normalized block
+        let mut normalized_block = [0u8; 16];
+        unsafe {
+            copy_nonoverlapping(alpha.as_ptr(), normalized_block.as_mut_ptr(), 8);
+            copy_nonoverlapping(colors.as_ptr(), normalized_block.as_mut_ptr().add(8), 4);
+            copy_nonoverlapping(indices.as_ptr(), normalized_block.as_mut_ptr().add(12), 4);
+        }
+
+        // Decode the normalized block
+        let normalized_decoded = unsafe { decode_bc2_block(normalized_block.as_ptr()) };
+
+        // Compare the two decoded blocks - they should produce the same visual output
+        assert_eq!(
+            original_decoded,
+            normalized_decoded,
+            "Normalized block (with color_mode={color_mode:?}) doesn't decode to the same pixels as the original block\n\
+             Original block: {bc2_block:?}\n\
+             Normalized block: {normalized_block:?}",
+        );
+    }
+});

--- a/fuzz/fuzz_targets/bc3_normalize_in_place.rs
+++ b/fuzz/fuzz_targets/bc3_normalize_in_place.rs
@@ -1,0 +1,85 @@
+#![no_main]
+
+// This fuzz test validates the BC3 normalize_split_blocks_in_place function by checking that
+// the normalized blocks decode to the same pixels as the original blocks.
+
+use core::ptr::copy_nonoverlapping;
+use dxt_lossless_transform_bc3::{
+    normalize_blocks::{
+        normalize_split_blocks_in_place, AlphaNormalizationMode, ColorNormalizationMode,
+    },
+    util::decode_bc3_block,
+};
+use libfuzzer_sys::{arbitrary, fuzz_target};
+
+#[derive(Clone, Debug, arbitrary::Arbitrary)]
+pub struct Bc3Block {
+    pub bytes: [u8; 16],
+}
+
+// Fuzz test for BC3 normalization of split blocks
+// Tests that normalizing split blocks preserves visual appearance when decoded
+fuzz_target!(|block: Bc3Block| {
+    // Get a slice to the BC3 block data
+    let bc3_block = &block.bytes;
+
+    // Save the original block for later comparison
+    let original_decoded = unsafe { decode_bc3_block(bc3_block.as_ptr()) };
+
+    // Test each normalization mode combination
+    for &alpha_mode in AlphaNormalizationMode::all_values() {
+        for &color_mode in ColorNormalizationMode::all_values() {
+            // Create buffers for the split block data (alpha endpoints, alpha indices, colors and indices)
+            let mut alpha_endpoints = [0u8; 2];
+            let mut alpha_indices = [0u8; 6];
+            let mut colors = [0u8; 4];
+            let mut indices = [0u8; 4];
+
+            // Split the BC3 block into alpha endpoints, alpha indices, colors and indices
+            unsafe {
+                copy_nonoverlapping(bc3_block.as_ptr(), alpha_endpoints.as_mut_ptr(), 2);
+                copy_nonoverlapping(bc3_block.as_ptr().add(2), alpha_indices.as_mut_ptr(), 6);
+                copy_nonoverlapping(bc3_block.as_ptr().add(8), colors.as_mut_ptr(), 4);
+                copy_nonoverlapping(bc3_block.as_ptr().add(12), indices.as_mut_ptr(), 4);
+            }
+
+            // Normalize the split blocks in place with the current modes
+            unsafe {
+                normalize_split_blocks_in_place(
+                    alpha_endpoints.as_mut_ptr(),
+                    alpha_indices.as_mut_ptr(),
+                    colors.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    1, // Process 1 block
+                    alpha_mode,
+                    color_mode,
+                );
+            }
+
+            // Reconstruct the normalized block
+            let mut normalized_block = [0u8; 16];
+            unsafe {
+                copy_nonoverlapping(alpha_endpoints.as_ptr(), normalized_block.as_mut_ptr(), 2);
+                copy_nonoverlapping(
+                    alpha_indices.as_ptr(),
+                    normalized_block.as_mut_ptr().add(2),
+                    6,
+                );
+                copy_nonoverlapping(colors.as_ptr(), normalized_block.as_mut_ptr().add(8), 4);
+                copy_nonoverlapping(indices.as_ptr(), normalized_block.as_mut_ptr().add(12), 4);
+            }
+
+            // Decode the normalized block
+            let normalized_decoded = unsafe { decode_bc3_block(normalized_block.as_ptr()) };
+
+            // Compare the two decoded blocks - they should produce the same visual output
+            assert_eq!(
+                original_decoded,
+                normalized_decoded,
+                "Normalized block (with alpha_mode={alpha_mode:?}, color_mode={color_mode:?}) doesn't decode to the same pixels as the original block\n\
+                 Original block: {bc3_block:?}\n\
+                 Normalized block: {normalized_block:?}",
+            );
+        }
+    }
+});

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 use dxt_lossless_transform_common::color_565::YCoCgVariant;

--- a/projects/dxt-lossless-transform-bc1/src/normalize_blocks.rs
+++ b/projects/dxt-lossless-transform-bc1/src/normalize_blocks.rs
@@ -334,6 +334,132 @@ unsafe fn write_normalized_solid_color_block(
     }
 }
 
+/// Normalizes BC1 blocks that are already split into separate color and indices sections.
+///
+/// # Parameters
+///
+/// - `colors_ptr`: A pointer to the section containing the colors (4 bytes per block)
+/// - `indices_ptr`: A pointer to the section containing the indices (4 bytes per block)
+/// - `num_blocks`: The number of blocks to process (1 block = 8 bytes)
+/// - `color_mode`: How to normalize color values
+///
+/// # Safety
+///
+/// - colors_ptr must be valid for reads and writes of num_blocks * 4 bytes
+/// - indices_ptr must be valid for reads and writes of num_blocks * 4 bytes
+/// - This function works in-place, modifying both buffers directly
+///
+/// # Remarks
+///
+/// This function normalizes blocks that have already been split, with colors and indices
+/// in separate memory locations. It applies the same normalization rules as [`normalize_blocks`]
+/// - Solid color blocks are normalized to a standard format
+/// - Fully transparent blocks are normalized to all 0xFF bytes
+/// - Mixed color/alpha blocks are preserved as-is
+///
+/// See the module-level documentation for more details on the normalization process.
+#[inline]
+pub unsafe fn normalize_split_blocks_in_place(
+    colors_ptr: *mut u8,
+    indices_ptr: *mut u8,
+    num_blocks: usize,
+    color_mode: ColorNormalizationMode,
+) {
+    // Skip normalization if mode is None
+    if color_mode == ColorNormalizationMode::None {
+        return;
+    }
+
+    // Process each blockw
+    for block_idx in 0..num_blocks {
+        // Calculate current block pointers
+        let curr_colors_ptr = colors_ptr.add(block_idx * 4);
+        let curr_indices_ptr = indices_ptr.add(block_idx * 4);
+
+        // Reconstruct a temporary block for analysis
+        // Thank god for intrinsics, else it would be ugly with big endian
+        let mut temp_block = [0u8; 8];
+        copy_nonoverlapping(curr_colors_ptr, temp_block.as_mut_ptr(), 4);
+        copy_nonoverlapping(curr_indices_ptr, temp_block.as_mut_ptr().add(4), 4);
+
+        // Decode the block to analyze its content
+        let decoded_block = decode_bc1_block(temp_block.as_ptr());
+
+        // Check if all pixels in the block are identical
+        if decoded_block.has_identical_pixels() {
+            // Get the first pixel (they're all the same)
+            let pixel = decoded_block.pixels[0];
+
+            // Check if the block is fully transparent
+            if unlikely(pixel.a == 0) {
+                // Case 2: Fully transparent block, write all 0xFF.
+                // In this specific case, we 
+                write_bytes(curr_colors_ptr, 0xFF, 4);
+                write_bytes(curr_indices_ptr, 0xFF, 4);
+            } else {
+                // Case 1: Solid color block
+                // Convert the color to RGB565
+                let color565 = pixel.to_color_565();
+
+                // Check if color can be round-tripped cleanly through RGB565
+                let color8888 = color565.to_color_8888();
+
+                if unlikely(color8888 == pixel) {
+                    // Can be normalized, write the standard pattern. 
+                    // Color0 = the color, Color1 = 0, indices = 0
+                    let color_bytes = color565.raw_value().to_le_bytes();
+
+                    
+                    // Write Color1 and indices based on the mode
+                    match color_mode {
+                        ColorNormalizationMode::None => {
+                            // For None mode, the operation is a no-op.
+                            // Since this is a transform in place, we do nothing.
+                        }
+                        ColorNormalizationMode::Color0Only => {
+                            // Write Color0 (the solid color)
+                            *curr_colors_ptr = color_bytes[0];
+                            *curr_colors_ptr.add(1) = color_bytes[1];
+                            
+                            // Write Color1 = 0
+                            *curr_colors_ptr.add(2) = 0;
+                            *curr_colors_ptr.add(3) = 0;
+
+                            // Write indices = 0
+                            *curr_indices_ptr = 0;
+                            *curr_indices_ptr.add(1) = 0;
+                            *curr_indices_ptr.add(2) = 0;
+                            *curr_indices_ptr.add(3) = 0;
+                        }
+                        ColorNormalizationMode::ReplicateColor => {
+                            // Write Color0 (the solid color)
+                            *curr_colors_ptr = color_bytes[0];
+                            *curr_colors_ptr.add(1) = color_bytes[1];
+
+                            // Write Color1 = same as Color0
+                            *curr_colors_ptr.add(2) = color_bytes[0];
+                            *curr_colors_ptr.add(3) = color_bytes[1];
+
+                            // Write indices = 0
+                            *curr_indices_ptr = 0;
+                            *curr_indices_ptr.add(1) = 0;
+                            *curr_indices_ptr.add(2) = 0;
+                            *curr_indices_ptr.add(3) = 0;
+                        }
+                    }
+                } else {
+                    // Case 3: Cannot normalize
+                    // This is a no-op, since this is an 'in-place' operation.
+                }
+            }
+        }
+        else {
+            // Case 3: Mixed colors
+            // Cannot normalize, so this is a no-op as this is an 'in-place' operation.
+        }
+    }
+}
+
 /// Reads an input of blocks from `input_ptr` and writes the normalized blocks to multiple output pointers,
 /// one for each available [`ColorNormalizationMode`].
 ///
@@ -850,4 +976,158 @@ mod tests {
             assert_eq!(*byte, 0xFF, "Byte {x} should be 0xFF");
         }
     }
+}
+
+#[test]
+fn can_normalize_split_blocks_in_place() {
+    // Create test data with three solid color blocks
+    let mut test_colors = [0u8; 12];
+
+    // Set up color endpoints (0xF800 = bright red in RGB565)
+    // Block #0
+    test_colors[0] = 0x00; // color0
+    test_colors[1] = 0xF8;
+    test_colors[2] = 0x00; // color1
+    test_colors[3] = 0xF8;
+
+    // Block #1
+    test_colors[4] = 0x00; // color0
+    test_colors[5] = 0xF8;
+    test_colors[6] = 0x00; // color1
+    test_colors[7] = 0xF8;
+    
+    // Block #2 (should remain untouched)
+    test_colors[8] = 0x00; // color0
+    test_colors[9] = 0xF8;
+    test_colors[10] = 0x00; // color1
+    test_colors[11] = 0xF8;
+
+    // Create test indices array with three blocks worth of data
+    let mut test_indices = [0u8; 12];
+
+    // Set indices to non-zero values
+    test_indices.fill(0xAA);
+
+    // Get a pointer to the test data for reading and writing
+    let colors_ptr = test_colors.as_mut_ptr();
+    let indices_ptr = test_indices.as_mut_ptr();
+
+    // Call normalize_blocks with the same buffer for input and output
+    // Only normalize the first 2 blocks
+    unsafe {
+        normalize_split_blocks_in_place(colors_ptr, indices_ptr, 2, ColorNormalizationMode::Color0Only);
+    }
+
+    // First block should be normalized (Color0 = red, Color1 = 0, indices = 0)
+    assert_eq!(test_colors[0], 0x00);
+    assert_eq!(test_colors[1], 0xF8);
+    assert_eq!(test_colors[2], 0x00);
+    assert_eq!(test_colors[3], 0x00);
+    
+    // Second block should also be normalized
+    assert_eq!(test_colors[4], 0x00);
+    assert_eq!(test_colors[5], 0xF8);
+    assert_eq!(test_colors[6], 0x00);
+    assert_eq!(test_colors[7], 0x00);
+    
+    // Third block should remain untouched
+    assert_eq!(test_colors[8], 0x00);
+    assert_eq!(test_colors[9], 0xF8);
+    assert_eq!(test_colors[10], 0x00);
+    assert_eq!(test_colors[11], 0xF8);
+    
+    // First block indices should be zeros
+    assert_eq!(test_indices[0], 0x00);
+    assert_eq!(test_indices[1], 0x00);
+    assert_eq!(test_indices[2], 0x00);
+    assert_eq!(test_indices[3], 0x00);
+    
+    // Second block indices should also be zeros
+    assert_eq!(test_indices[4], 0x00);
+    assert_eq!(test_indices[5], 0x00);
+    assert_eq!(test_indices[6], 0x00);
+    assert_eq!(test_indices[7], 0x00);
+    
+    // Third block indices should remain untouched
+    assert_eq!(test_indices[8], 0xAA);
+    assert_eq!(test_indices[9], 0xAA);
+    assert_eq!(test_indices[10], 0xAA);
+    assert_eq!(test_indices[11], 0xAA);
+}
+
+#[test]
+fn can_normalize_split_blocks_in_place_with_replicate_color() {
+    // Create test data with three solid color blocks
+    let mut test_colors = [0u8; 12];
+
+    // Set up color endpoints (0xF800 = bright red in RGB565)
+    // Block #0
+    test_colors[0] = 0x00;
+    test_colors[1] = 0xF8;
+    test_colors[2] = 0x00;
+    test_colors[3] = 0xF8;
+    
+    // Block #1
+    test_colors[4] = 0x00;
+    test_colors[5] = 0xF8;
+    test_colors[6] = 0x00;
+    test_colors[7] = 0xF8;
+    
+    // Block #2 (should remain untouched)
+    test_colors[8] = 0x00;
+    test_colors[9] = 0xF8;
+    test_colors[10] = 0x00;
+    test_colors[11] = 0xF8;
+
+    // Create test indices array with three blocks worth of data
+    let mut test_indices = [0u8; 12];
+
+    // Set indices to non-zero values
+    test_indices.fill(0x55);
+
+    // Get a pointer to the test data for reading and writing
+    let colors_ptr = test_colors.as_mut_ptr();
+    let indices_ptr = test_indices.as_mut_ptr();
+
+    // Call normalize_blocks with the same buffer for input and output using ReplicateColor mode
+    // Only normalize the first 2 blocks
+    unsafe {
+        normalize_split_blocks_in_place(colors_ptr, indices_ptr, 2, ColorNormalizationMode::ReplicateColor);
+    }
+
+    // First block should be normalized (Color0 = red, Color1 = red (replicated), indices = 0)
+    assert_eq!(test_colors[0], 0x00);
+    assert_eq!(test_colors[1], 0xF8);
+    assert_eq!(test_colors[2], 0x00); // Color1 should be the same as Color0 for ReplicateColor
+    assert_eq!(test_colors[3], 0xF8); // Color1 should be the same as Color0 for ReplicateColor
+    
+    // Second block should also be normalized
+    assert_eq!(test_colors[4], 0x00);
+    assert_eq!(test_colors[5], 0xF8);
+    assert_eq!(test_colors[6], 0x00); // Color1 should be the same as Color0 for ReplicateColor
+    assert_eq!(test_colors[7], 0xF8); // Color1 should be the same as Color0 for ReplicateColor
+    
+    // Third block should remain untouched
+    assert_eq!(test_colors[8], 0x00);
+    assert_eq!(test_colors[9], 0xF8);
+    assert_eq!(test_colors[10], 0x00);
+    assert_eq!(test_colors[11], 0xF8);
+    
+    // First block indices should be zeros
+    assert_eq!(test_indices[0], 0x00);
+    assert_eq!(test_indices[1], 0x00);
+    assert_eq!(test_indices[2], 0x00);
+    assert_eq!(test_indices[3], 0x00);
+    
+    // Second block indices should also be zeros
+    assert_eq!(test_indices[4], 0x00);
+    assert_eq!(test_indices[5], 0x00);
+    assert_eq!(test_indices[6], 0x00);
+    assert_eq!(test_indices[7], 0x00);
+    
+    // Third block indices should remain untouched
+    assert_eq!(test_indices[8], 0x55);
+    assert_eq!(test_indices[9], 0x55);
+    assert_eq!(test_indices[10], 0x55);
+    assert_eq!(test_indices[11], 0x55);
 }

--- a/projects/dxt-lossless-transform-bc1/src/normalize_blocks.rs
+++ b/projects/dxt-lossless-transform-bc1/src/normalize_blocks.rs
@@ -80,7 +80,7 @@
 //! 4. Write the normalized block to the output
 
 use crate::util::decode_bc1_block;
-use core::ptr::{copy_nonoverlapping, eq, null_mut, read_unaligned, write_bytes};
+use core::{hint::unreachable_unchecked, ptr::{copy_nonoverlapping, eq, null_mut, read_unaligned, write_bytes}};
 use dxt_lossless_transform_common::{color_565::Color565, decoded_4x4_block::Decoded4x4Block};
 use likely_stable::unlikely;
 
@@ -393,7 +393,6 @@ pub unsafe fn normalize_split_blocks_in_place(
             // Check if the block is fully transparent
             if unlikely(pixel.a == 0) {
                 // Case 2: Fully transparent block, write all 0xFF.
-                // In this specific case, we 
                 write_bytes(curr_colors_ptr, 0xFF, 4);
                 write_bytes(curr_indices_ptr, 0xFF, 4);
             } else {
@@ -414,6 +413,7 @@ pub unsafe fn normalize_split_blocks_in_place(
                         ColorNormalizationMode::None => {
                             // For None mode, the operation is a no-op.
                             // Since this is a transform in place, we do nothing.
+                            unreachable_unchecked()
                         }
                         ColorNormalizationMode::Color0Only => {
                             // Write Color0 (the solid color)

--- a/projects/dxt-lossless-transform-bc1/src/normalize_blocks.rs
+++ b/projects/dxt-lossless-transform-bc1/src/normalize_blocks.rs
@@ -370,7 +370,7 @@ pub unsafe fn normalize_split_blocks_in_place(
         return;
     }
 
-    // Process each blockw
+    // Process each block
     for block_idx in 0..num_blocks {
         // Calculate current block pointers
         let curr_colors_ptr = colors_ptr.add(block_idx * 4);
@@ -408,7 +408,6 @@ pub unsafe fn normalize_split_blocks_in_place(
                     // Can be normalized, write the standard pattern. 
                     // Color0 = the color, Color1 = 0, indices = 0
                     let color_bytes = color565.raw_value().to_le_bytes();
-
                     
                     // Write Color1 and indices based on the mode
                     match color_mode {

--- a/projects/dxt-lossless-transform-bc2/README.MD
+++ b/projects/dxt-lossless-transform-bc2/README.MD
@@ -90,6 +90,29 @@ We apply the [YCoCg-R] transform to decorrelate the colours.
 Since the colours are stored in `565`, we use the upper 5 bits of the green endpoint, leaving the
 remaining bit untouched.
 
+### Delta Encoding the Transparency Values [Not Yet Implemented]
+
+A lot of textures have transparent regions which all have the same (or very similar) alpha values.
+
+In such cases, we can represent the stored alpha values as the delta (difference) from the first alpha value.
+
+```rust
+fn encode_delta_dif(data: &mut [u8]) {
+    let mut prev = 0u8;
+    for item in data.iter_mut() {
+        let v = *item;
+        *item = v.wrapping_sub(prev);
+        prev = v;
+    }
+}
+```
+
+We take the previous (first) value, subtract the previous (first) value from each subsequent value,
+and lastly, store the result.
+
+In our current case, the values are 4-bit, which can be a bit hard to do efficiently, given that our processors
+work with bytes. Therefore, we do the diff at the byte level.
+
 ## Development
 
 For information on how to work with this codebase, see [README-DEV.MD][readme-dev].

--- a/projects/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc2/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod normalize_blocks;

--- a/projects/dxt-lossless-transform-bc3/README.MD
+++ b/projects/dxt-lossless-transform-bc3/README.MD
@@ -30,7 +30,8 @@ Data:    | A0-A1 |AIdx0-47| C0-C1 |I0-I15 |   | A2-A3 |AIdx48-95| C2-C3 |I16-I31
 ```
 
 Each 16-byte block contains:
-- 8 bytes of explicit alpha (sixteen 4-bit alpha values)
+- 2 bytes of alpha endpoints (8 bits each)
+- 6 bytes of alpha indices (16x 3-bit)
 - 4 bytes colours (2x RGB565 values)
 - 4 bytes of packed color indices (sixteen 2-bit indices)
 

--- a/projects/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc3/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 
 pub mod normalize_blocks;

--- a/projects/dxt-lossless-transform-common/src/lib.rs
+++ b/projects/dxt-lossless-transform-common/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "nightly", feature(avx512_target_feature))]
 #![cfg_attr(feature = "nightly", feature(stdarch_x86_avx512))]
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added in-place normalization functions for BC1, BC2, and BC3 texture blocks stored in split buffer layouts, enabling more flexible and efficient texture processing.
  - Added new binary targets for fuzz testing BC1, BC2, and BC3 normalization functions.
- **Tests**
  - Introduced comprehensive fuzz and functional tests to ensure normalization preserves visual output across all supported modes and layouts.
- **Documentation**
  - Updated and clarified documentation for BC2 and BC3 formats, including alpha data layout corrections and a proposed (not yet implemented) delta encoding method for transparency.
- **Chores**
  - Removed unstable Rust feature flags related to AVX-512 from crate-level attributes across BC1, BC2, BC3, and common projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->