### PR TITLE
Improved: Color565 Backports from bc1-determine-best

### DIFF
--- a/projects/dxt-lossless-transform-common/Cargo.toml
+++ b/projects/dxt-lossless-transform-common/Cargo.toml
@@ -22,6 +22,7 @@ nightly = ["safe-allocator-api/nightly"]
 multiversion = { version = "0.8.0", default-features = false }
 thiserror = "2.0.12"
 safe-allocator-api = "0.4.0"
+derive-enum-all-values = "0.2.0"
 
 [target.'cfg(any(target_arch = "x86_64", target_arch = "x86"))'.dependencies]
 cpufeatures = "0.2.17"


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->
