### PR TITLE
Added: BC1 Benchmark for determine_optimal_transform + general cleanup

### DIFF
--- a/projects/dxt-lossless-transform-cli/src/debug/benchmark_common.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/benchmark_common.rs
@@ -206,6 +206,18 @@ where
     (result, duration)
 }
 
+/// Measures the time taken to execute a function that returns a Result and propagates errors.
+/// Returns the duration only on success, or the error if the function fails.
+pub fn measure_time_result<F, T, E>(func: F) -> Result<(T, Duration), E>
+where
+    F: FnOnce() -> Result<T, E>,
+{
+    let start = Instant::now();
+    let result = func()?;
+    let duration = start.elapsed();
+    Ok((result, duration))
+}
+
 /// Prints the results for a single file's benchmark.
 pub fn print_file_result(result: &BenchmarkResult) {
     let filename = get_filename(&result.file_path);

--- a/projects/dxt-lossless-transform-cli/src/debug/calc_compression_stats_common.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/calc_compression_stats_common.rs
@@ -3,12 +3,9 @@
 //! This module provides shared data structures, utilities, and analysis functions that can be
 //! reused across different BC format implementations for compression statistics analysis.
 
-use crate::error::TransformError;
 use bytesize::ByteSize;
-use core::{fmt::Debug, slice};
-use std::{collections::HashMap, hash::Hash, path::Path, sync::Mutex};
-
-use super::{calculate_content_hash, compression_size_cache::CompressionSizeCache, zstd};
+use core::fmt::Debug;
+use std::{collections::HashMap, hash::Hash, path::Path};
 
 /// Generic compression statistics result for a single file analysis.
 ///
@@ -82,78 +79,6 @@ where
     pub fn compression_ratio(&self, original_size: usize) -> f64 {
         self.compressed_size as f64 / original_size.max(1) as f64
     }
-}
-
-/// Calculates ZStandard compressed size without caching.
-/// This is a simplified version of calc_compression_stats_common::zstd_calc_size_with_cache
-/// that doesn't use any caching mechanisms for pure performance measurement.
-pub unsafe fn zstd_calc_size_uncached(
-    data_ptr: *const u8,
-    len_bytes: usize,
-    compression_level: i32,
-) -> Result<usize, TransformError> {
-    let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
-    let mut compressed_buffer = Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init();
-
-    let compressed_size = {
-        let original_slice = slice::from_raw_parts(data_ptr, len_bytes);
-        match zstd::compress(compression_level, original_slice, &mut compressed_buffer) {
-            Ok(size) => size,
-            Err(_) => {
-                return Err(TransformError::Debug(
-                    "Benchmark: Compression failed".to_owned(),
-                ))
-            }
-        }
-    };
-
-    Ok(compressed_size)
-}
-
-/// Calculates ZStandard compressed size with caching support.
-///
-/// This function first checks if the compressed size is already cached, and if not,
-/// compresses the data and stores the result in the cache for future use.
-pub fn zstd_calc_size_with_cache(
-    data_ptr: *const u8,
-    len_bytes: usize,
-    compression_level: i32,
-    cache: &Mutex<CompressionSizeCache>,
-) -> Result<usize, TransformError> {
-    let content_hash = calculate_content_hash(data_ptr, len_bytes);
-
-    // Try to get from cache
-    {
-        let cache_guard = cache.lock().unwrap();
-        if let Some(cached_size) = cache_guard.get(content_hash, compression_level) {
-            return Ok(cached_size);
-        }
-    }
-
-    // Not in cache, compute it
-    let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
-    let mut compressed_buffer =
-        unsafe { Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init() };
-
-    let compressed_size = unsafe {
-        let original_slice = slice::from_raw_parts(data_ptr, len_bytes);
-        match zstd::compress(compression_level, original_slice, &mut compressed_buffer) {
-            Ok(size) => size,
-            Err(_) => {
-                return Err(TransformError::Debug(
-                    "Debug: Compression failed".to_owned(),
-                ))
-            }
-        }
-    };
-
-    // Store in cache
-    {
-        let mut cache_guard = cache.lock().unwrap();
-        cache_guard.insert(content_hash, compression_level, compressed_size);
-    }
-
-    Ok(compressed_size)
 }
 
 /// Formats a byte count as a human-readable string using [`ByteSize`].

--- a/projects/dxt-lossless-transform-cli/src/debug/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/mod.rs
@@ -11,6 +11,7 @@ pub mod compressed_data_cache;
 pub mod compression_size_cache;
 pub mod throughput;
 pub mod zstd;
+pub mod zstd_helpers;
 
 /// Extracts BC1-BC7 blocks from a DDS file in memory.
 /// Raw block data from found DDS files is passed to the `test_fn` parameter for processing.

--- a/projects/dxt-lossless-transform-cli/src/debug/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/mod.rs
@@ -9,6 +9,7 @@ pub mod benchmark_common;
 pub mod calc_compression_stats_common;
 pub mod compressed_data_cache;
 pub mod compression_size_cache;
+pub mod throughput;
 pub mod zstd;
 
 /// Extracts BC1-BC7 blocks from a DDS file in memory.

--- a/projects/dxt-lossless-transform-cli/src/debug/throughput.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/throughput.rs
@@ -1,0 +1,39 @@
+use bytesize::ByteSize;
+use core::fmt;
+
+/// A wrapper around [`ByteSize`] that represents throughput in bytes per second.
+///
+/// This type automatically appends "/s" to the display output to make it clear
+/// that the value represents bytes per second throughput.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Throughput(pub ByteSize);
+
+impl Throughput {
+    /// Creates a new [`Throughput`] from bytes per second.
+    pub fn from_bytes_per_sec(bytes_per_sec: u64) -> Self {
+        Self(ByteSize(bytes_per_sec))
+    }
+
+    /// Returns the raw bytes per second value.
+    pub fn bytes_per_sec(&self) -> u64 {
+        self.0 .0
+    }
+}
+
+impl fmt::Display for Throughput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/s", self.0)
+    }
+}
+
+impl From<ByteSize> for Throughput {
+    fn from(byte_size: ByteSize) -> Self {
+        Self(byte_size)
+    }
+}
+
+impl From<u64> for Throughput {
+    fn from(bytes_per_sec: u64) -> Self {
+        Self::from_bytes_per_sec(bytes_per_sec)
+    }
+}

--- a/projects/dxt-lossless-transform-cli/src/debug/zstd.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/zstd.rs
@@ -1,4 +1,4 @@
-//! Copied from sewer56.archives.nx crate.
+//! Copied from sewer56.archives.nx crate and stripped down.
 
 use core::ffi::c_void;
 use thiserror_no_std::Error;

--- a/projects/dxt-lossless-transform-cli/src/debug/zstd.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/zstd.rs
@@ -1,9 +1,6 @@
 //! Copied from sewer56.archives.nx crate.
 
 use core::ffi::c_void;
-use derive_more::Deref;
-use derive_more::DerefMut;
-use derive_new::new;
 use thiserror_no_std::Error;
 use zstd_sys::ZSTD_cParameter::*;
 use zstd_sys::ZSTD_dParameter::*;
@@ -131,16 +128,6 @@ pub(crate) fn zstd_setcommondecompressionparams(dctx: *mut ZSTD_DCtx_s) {
             ZSTD_f_zstd1_magicless as i32,
         );
     };
-}
-
-#[derive(Deref, DerefMut, new)]
-pub struct SafeCStream(*mut ZSTD_CStream);
-impl Drop for SafeCStream {
-    fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe { ZSTD_freeCStream(self.0) };
-        }
-    }
 }
 
 /// A result type around compression functions..

--- a/projects/dxt-lossless-transform-cli/src/debug/zstd_helpers.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug/zstd_helpers.rs
@@ -1,0 +1,179 @@
+//! Wrappers for ZStandard around the `zstd` module, with caching support for benchmarking
+//! and 'native' error handling.
+
+use super::{
+    calculate_content_hash, compressed_data_cache::CompressedDataCache,
+    compression_size_cache::CompressionSizeCache, zstd,
+};
+use crate::error::TransformError;
+use core::slice;
+use std::sync::Mutex;
+
+/// References to the caches used during benchmarking
+pub struct CacheRefs<'a> {
+    pub compressed_size_cache: &'a Mutex<CompressionSizeCache>,
+    pub compressed_data_cache: &'a CompressedDataCache,
+}
+
+/// Compresses data using ZStandard with caching support.
+///
+/// This function first checks if compressed data is already cached, and if not,
+/// compresses the data and stores the result in the cache for future use.
+/// Returns both the compressed data and size, just like [`zstd_compress_data`].
+///
+/// Also populates a [`CompressionSizeCache`] with the compressed size for future size-only queries.
+pub fn zstd_compress_data_cached(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    compression_level: i32,
+    caches: &CacheRefs,
+) -> Result<(Box<[u8]>, usize), TransformError> {
+    // Calculate content hash once
+    let content_hash = calculate_content_hash(data_ptr, len_bytes);
+
+    // Try to load from cache first
+    if let Some((cached_data, cached_size)) = caches
+        .compressed_data_cache
+        .load_compressed_data(content_hash, compression_level)?
+    {
+        // Data cache and size cache should be synced, so no need to write to size cache here
+        return Ok((cached_data, cached_size));
+    }
+
+    // Not in cache, compress the data using the original function
+    let (compressed_data, compressed_size) =
+        zstd_compress_data(data_ptr, len_bytes, compression_level)?;
+
+    // Save to cache for future use
+    if let Err(e) = caches.compressed_data_cache.save_compressed_data(
+        content_hash,
+        compression_level,
+        &compressed_data[..compressed_size],
+    ) {
+        // Log the error but don't fail the operation
+        eprintln!("Warning: Failed to save compressed data to cache: {e}");
+    }
+
+    // Also populate the size cache when writing to data cache
+    {
+        let mut size_cache_guard = caches.compressed_size_cache.lock().unwrap();
+        size_cache_guard.insert(content_hash, compression_level, compressed_size);
+    }
+
+    Ok((compressed_data, compressed_size))
+}
+
+/// Compresses data using ZStandard and returns both the compressed data and size.
+///
+/// This function allocates a buffer for the compressed data and returns ownership
+/// of that buffer along with the actual compressed size.
+pub fn zstd_compress_data(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    compression_level: i32,
+) -> Result<(Box<[u8]>, usize), TransformError> {
+    let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
+    let mut compressed_buffer =
+        unsafe { Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init() };
+
+    let compressed_size = unsafe {
+        let original_slice = slice::from_raw_parts(data_ptr, len_bytes);
+        match zstd::compress(compression_level, original_slice, &mut compressed_buffer) {
+            Ok(size) => size,
+            Err(_) => {
+                return Err(TransformError::Debug(
+                    "Benchmark: Compression failed".to_owned(),
+                ))
+            }
+        }
+    };
+
+    Ok((compressed_buffer, compressed_size))
+}
+
+/// Calculates ZStandard compressed size without caching.
+/// This is a simplified version of calc_compression_stats_common::zstd_calc_size_with_cache
+/// that doesn't use any caching mechanisms for pure performance measurement.
+pub unsafe fn zstd_calc_size(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    compression_level: i32,
+) -> Result<usize, TransformError> {
+    let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
+    let mut compressed_buffer = Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init();
+
+    let compressed_size = {
+        let original_slice = slice::from_raw_parts(data_ptr, len_bytes);
+        match zstd::compress(compression_level, original_slice, &mut compressed_buffer) {
+            Ok(size) => size,
+            Err(_) => {
+                return Err(TransformError::Debug(
+                    "Benchmark: Compression failed".to_owned(),
+                ))
+            }
+        }
+    };
+
+    Ok(compressed_size)
+}
+
+/// Calculates ZStandard compressed size with caching support.
+///
+/// This function first checks if the compressed size is already cached, and if not,
+/// compresses the data and stores the result in the cache for future use.
+pub fn zstd_calc_size_with_cache(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    compression_level: i32,
+    cache: &Mutex<CompressionSizeCache>,
+) -> Result<usize, TransformError> {
+    let content_hash = calculate_content_hash(data_ptr, len_bytes);
+
+    // Try to get from cache
+    {
+        let cache_guard = cache.lock().unwrap();
+        if let Some(cached_size) = cache_guard.get(content_hash, compression_level) {
+            return Ok(cached_size);
+        }
+    }
+
+    // Not in cache, compute it
+    let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
+    let mut compressed_buffer =
+        unsafe { Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init() };
+
+    let compressed_size = unsafe {
+        let original_slice = slice::from_raw_parts(data_ptr, len_bytes);
+        match zstd::compress(compression_level, original_slice, &mut compressed_buffer) {
+            Ok(size) => size,
+            Err(_) => {
+                return Err(TransformError::Debug(
+                    "Debug: Compression failed".to_owned(),
+                ))
+            }
+        }
+    };
+
+    // Store in cache
+    {
+        let mut cache_guard = cache.lock().unwrap();
+        cache_guard.insert(content_hash, compression_level, compressed_size);
+    }
+
+    Ok(compressed_size)
+}
+
+/// Decompresses ZStandard data into a pre-allocated buffer.
+///
+/// This function decompresses the provided compressed data into the given buffer.
+pub fn zstd_decompress_data(
+    compressed_data: &[u8],
+    output_buffer: &mut [u8],
+) -> Result<usize, TransformError> {
+    match zstd::decompress(compressed_data, output_buffer) {
+        Ok(decompressed_size) => Ok(decompressed_size),
+        Err(_) => Err(TransformError::Debug(
+            "Benchmark: Decompression failed".to_owned(),
+        )),
+    }
+}

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark.rs
@@ -13,6 +13,7 @@ use crate::{
     util::find_all_files,
     DdsFilter,
 };
+use core::time::Duration;
 use dxt_lossless_transform_api::DdsFormat;
 use dxt_lossless_transform_bc1::{
     determine_optimal_transform::{determine_best_transform_details, Bc1TransformOptions},
@@ -331,7 +332,7 @@ unsafe fn process_scenario(
     }
 
     // Benchmark decompression
-    let (_, decompress_time_ms) = benchmark_common::measure_time(|| {
+    let (_, decompress_time) = benchmark_common::measure_time(|| {
         for _ in 0..config.iterations {
             zstd_decompress_data(
                 &compressed_data[..compressed_size],
@@ -342,7 +343,7 @@ unsafe fn process_scenario(
     });
 
     // Benchmark detransform
-    let (_, detransform_time_ms) = benchmark_common::measure_time(|| {
+    let (_, detransform_time) = benchmark_common::measure_time(|| {
         for _ in 0..config.iterations {
             untransform_bc1(
                 decompressed_data.as_ptr(),
@@ -355,8 +356,8 @@ unsafe fn process_scenario(
     });
 
     // Average the times over iterations
-    let avg_decompress_time = decompress_time_ms / config.iterations as f64;
-    let avg_detransform_time = detransform_time_ms / config.iterations as f64;
+    let avg_decompress_time = decompress_time / config.iterations;
+    let avg_detransform_time = detransform_time / config.iterations;
 
     Ok(Some(BenchmarkScenarioResult::new(
         scenario_name.to_string(),
@@ -399,7 +400,7 @@ unsafe fn process_untransformed_scenario(
     }
 
     // Benchmark decompression
-    let (_, decompress_time_ms) = benchmark_common::measure_time(|| {
+    let (_, decompress_time) = benchmark_common::measure_time(|| {
         for _ in 0..config.iterations {
             zstd_decompress_data(
                 &compressed_data_ptr[..compressed_size],
@@ -410,12 +411,12 @@ unsafe fn process_untransformed_scenario(
     });
 
     // Average the time over iterations
-    let avg_decompress_time = decompress_time_ms / config.iterations as f64;
+    let avg_decompress_time = decompress_time / config.iterations;
 
     Ok(Some(BenchmarkScenarioResult::new(
         scenario_name.to_string(),
         len_bytes,
         avg_decompress_time,
-        0.0, // No detransform time for untransformed scenario
+        Duration::ZERO, // No detransform time for untransformed scenario
     )))
 }

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark.rs
@@ -259,7 +259,10 @@ unsafe fn get_api_recommended_details(
             cache,
         ) {
             Ok(size) => size,
-            Err(_) => usize::MAX, // Return max size on error to make this option less favorable
+            Err(e) => {
+                eprintln!("Warning: Compression estimation failed: {e}");
+                usize::MAX // Return max size on error to make this option less favorable
+            }
         }
     };
 

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -192,8 +192,7 @@ unsafe fn zstd_calc_size_uncached(
     compression_level: i32,
 ) -> Result<usize, TransformError> {
     let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
-    let mut compressed_buffer =
-        unsafe { Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init() };
+    let mut compressed_buffer = Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init();
 
     let compressed_size = {
         let original_slice = slice::from_raw_parts(data_ptr, len_bytes);

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -166,7 +166,10 @@ unsafe fn run_determine_best_once(
     let estimator = move |data_ptr: *const u8, len: usize| -> usize {
         match zstd_calc_size_uncached(data_ptr, len, estimate_compression_level) {
             Ok(size) => size,
-            Err(_) => usize::MAX, // Return max size on error to make this option less favorable
+            Err(e) => {
+                eprintln!("Warning: Compression estimation failed: {e}");
+                usize::MAX // Return max size on error to make this option less favorable
+            }
         }
     };
 

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -10,7 +10,7 @@ use crate::{
     util::find_all_files,
     DdsFilter,
 };
-use core::slice;
+use core::{slice, time::Duration};
 use dxt_lossless_transform_api::DdsFormat;
 use dxt_lossless_transform_bc1::{
     determine_optimal_transform::{determine_best_transform_details, Bc1TransformOptions},
@@ -137,7 +137,7 @@ unsafe fn process_determine_best_scenario(
     }
 
     // Benchmark determine_best_transform_details
-    let (_, execution_time_ms) = benchmark_common::measure_time(|| {
+    let (_, execution_time) = benchmark_common::measure_time(|| {
         for _ in 0..config.iterations {
             let _ = run_determine_best_once(data_ptr, len_bytes, config.estimate_compression_level)
                 .unwrap();
@@ -145,14 +145,14 @@ unsafe fn process_determine_best_scenario(
     });
 
     // Average the time over iterations
-    let avg_execution_time = execution_time_ms / config.iterations as f64;
+    let avg_execution_time = execution_time / config.iterations;
 
     // For this benchmark, we consider the entire determine_best_transform_details as "detransform"
     // and set decompress time to 0, as we're only measuring the algorithm performance
     Ok(Some(BenchmarkScenarioResult::new(
         scenario_name.to_string(),
         len_bytes,
-        0.0,                // No decompress time for this specific benchmark
+        Duration::ZERO,     // No decompress time for this specific benchmark
         avg_execution_time, // All time is considered "detransform" time
     )))
 }
@@ -215,7 +215,7 @@ fn print_file_result_throughput(result: &BenchmarkResult) {
     println!("   📊 File size: {file_size_mib:.2} MiB");
 
     for scenario in &result.scenarios {
-        let execution_time_ms = scenario.detransform_time_ms;
+        let execution_time_ms = scenario.detransform_time.as_secs_f64() * 1000.0;
         let throughput = scenario.detransform_throughput;
         println!(
             "   ⚡ {}: {execution_time_ms:.3} ms ({throughput:.2}/s)",

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -2,8 +2,7 @@ use super::BenchmarkDetermineBestCmd;
 use crate::{
     debug::{
         benchmark_common::{
-            self, print_overall_statistics, BenchmarkResult,
-            BenchmarkScenarioResult,
+            self, print_overall_statistics, BenchmarkResult, BenchmarkScenarioResult,
         },
         extract_blocks_from_dds, zstd,
     },
@@ -211,22 +210,15 @@ unsafe fn zstd_calc_size_uncached(
 /// Print file result with throughput measured in MiB/s for determine_best_transform_details benchmark
 fn print_file_result_throughput(result: &BenchmarkResult) {
     let file_size_mib = result.file_size_bytes as f64 / (1024.0 * 1024.0);
-    
+
     println!("📁 {}", result.file_path);
     println!("   📊 File size: {file_size_mib:.2} MiB");
-    
+
     for scenario in &result.scenarios {
-        // For this benchmark, execution time is stored in detransform_time_ms
         let execution_time_ms = scenario.detransform_time_ms;
-        let execution_time_s = execution_time_ms / 1000.0;
-        let throughput_mib_s = if execution_time_s > 0.0 {
-            file_size_mib / execution_time_s
-        } else {
-            0.0
-        };
-        
+        let throughput = scenario.detransform_throughput;
         println!(
-            "   ⚡ {}: {execution_time_ms:.3} ms ({throughput_mib_s:.2} MiB/s)",
+            "   ⚡ {}: {execution_time_ms:.3} ms ({throughput:.2}/s)",
             scenario.scenario_name
         );
     }

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -4,8 +4,8 @@ use crate::{
         benchmark_common::{
             self, print_overall_statistics, BenchmarkResult, BenchmarkScenarioResult,
         },
-        calc_compression_stats_common::zstd_calc_size_uncached,
         extract_blocks_from_dds,
+        zstd_helpers::zstd_calc_size,
     },
     error::TransformError,
     util::find_all_files,
@@ -170,7 +170,7 @@ unsafe fn run_determine_best_once(
 ) -> Result<Bc1TransformDetails, TransformError> {
     // Create a zstd file size estimator that compresses data without caching
     let estimator = move |data_ptr: *const u8, len: usize| -> usize {
-        match zstd_calc_size_uncached(data_ptr, len, estimate_compression_level) {
+        match zstd_calc_size(data_ptr, len, estimate_compression_level) {
             Ok(size) => size,
             Err(e) => {
                 eprintln!("Warning: Compression estimation failed: {e}");

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -218,7 +218,7 @@ fn print_file_result_throughput(result: &BenchmarkResult) {
         let execution_time_ms = scenario.detransform_time.as_secs_f64() * 1000.0;
         let throughput = scenario.detransform_throughput;
         println!(
-            "   ⚡ {}: {execution_time_ms:.3} ms ({throughput:.2}/s)",
+            "   ⚡ {}: {execution_time_ms:.3} ms ({throughput:.2})",
             scenario.scenario_name
         );
     }

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -137,12 +137,17 @@ unsafe fn process_determine_best_scenario(
     }
 
     // Benchmark determine_best_transform_details
-    let (_, execution_time) = benchmark_common::measure_time(|| {
-        for _ in 0..config.iterations {
-            let _ = run_determine_best_once(data_ptr, len_bytes, config.estimate_compression_level)
-                .unwrap();
-        }
-    });
+    let (_, execution_time) =
+        benchmark_common::measure_time_result(|| -> Result<(), TransformError> {
+            for _ in 0..config.iterations {
+                let _ = run_determine_best_once(
+                    data_ptr,
+                    len_bytes,
+                    config.estimate_compression_level,
+                )?;
+            }
+            Ok(())
+        })?;
 
     // Average the time over iterations
     let avg_execution_time = execution_time / config.iterations;

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark_determine_best.rs
@@ -1,0 +1,234 @@
+use super::BenchmarkDetermineBestCmd;
+use crate::{
+    debug::{
+        benchmark_common::{
+            self, print_overall_statistics, BenchmarkResult,
+            BenchmarkScenarioResult,
+        },
+        extract_blocks_from_dds, zstd,
+    },
+    error::TransformError,
+    util::find_all_files,
+    DdsFilter,
+};
+use core::slice;
+use dxt_lossless_transform_api::DdsFormat;
+use dxt_lossless_transform_bc1::{
+    determine_optimal_transform::{determine_best_transform_details, Bc1TransformOptions},
+    Bc1TransformDetails,
+};
+use std::fs;
+
+/// Configuration for benchmark execution
+struct BenchmarkConfig {
+    iterations: u32,
+    warmup_iterations: u32,
+    estimate_compression_level: i32,
+}
+
+pub(crate) fn handle_benchmark_determine_best_command(
+    cmd: BenchmarkDetermineBestCmd,
+) -> Result<(), TransformError> {
+    let input_path = &cmd.input_directory;
+    println!(
+        "Benchmarking BC1 determine_best_transform_details performance for files in: {} (recursive)",
+        input_path.display()
+    );
+    println!("Iterations per file: {}", cmd.iterations);
+    println!("Warmup iterations: {}", cmd.warmup_iterations);
+    println!(
+        "Estimate compression level: {}",
+        cmd.estimate_compression_level
+    );
+
+    // Collect all files recursively
+    let mut entries = Vec::new();
+    find_all_files(input_path, &mut entries)?;
+    println!("Found {} files to benchmark", entries.len());
+
+    if entries.is_empty() {
+        println!("No files found to benchmark.");
+        return Ok(());
+    }
+
+    println!("Starting benchmarks...\n");
+    let mut results = Vec::new();
+
+    // Process files (not in parallel!! we want clean results!)
+    for entry in entries {
+        match process_file(
+            &entry,
+            &BenchmarkConfig {
+                iterations: cmd.iterations,
+                warmup_iterations: cmd.warmup_iterations,
+                estimate_compression_level: cmd.estimate_compression_level,
+            },
+        ) {
+            Ok(Some(file_result)) => {
+                print_file_result_throughput(&file_result);
+                results.push(file_result);
+            }
+            Ok(None) => {
+                // No result to process
+            }
+            Err(e) => {
+                println!("✗ Error benchmarking {}: {}", entry.path().display(), e);
+            }
+        }
+    }
+
+    // Print overall statistics
+    print_overall_statistics(&results);
+
+    Ok(())
+}
+
+fn process_file(
+    entry: &fs::DirEntry,
+    config: &BenchmarkConfig,
+) -> Result<Option<BenchmarkResult>, TransformError> {
+    let mut file_result = Some(BenchmarkResult::new(entry.path().display().to_string(), 0));
+
+    unsafe {
+        extract_blocks_from_dds(
+            entry,
+            DdsFilter::BC1,
+            |data_ptr: *const u8,
+             len_bytes: usize,
+             format: DdsFormat|
+             -> Result<(), TransformError> {
+                // Only benchmark BC1 blocks
+                if format != DdsFormat::BC1 {
+                    return Ok(()); // Skip non-BC1 data
+                }
+
+                if let Some(ref mut result) = file_result {
+                    result.file_size_bytes = len_bytes;
+                }
+
+                // Benchmark determine_best_transform_details function
+                if let Some(scenario_result) = process_determine_best_scenario(
+                    data_ptr,
+                    len_bytes,
+                    "determine_best_transform_details",
+                    config,
+                )? {
+                    if let Some(ref mut result) = file_result {
+                        result.add_scenario(scenario_result);
+                    }
+                }
+
+                Ok(())
+            },
+        )?;
+    }
+
+    Ok(file_result)
+}
+
+unsafe fn process_determine_best_scenario(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    scenario_name: &str,
+    config: &BenchmarkConfig,
+) -> Result<Option<BenchmarkScenarioResult>, TransformError> {
+    // Warmup phase
+    for _ in 0..config.warmup_iterations {
+        let _ = run_determine_best_once(data_ptr, len_bytes, config.estimate_compression_level)?;
+    }
+
+    // Benchmark determine_best_transform_details
+    let (_, execution_time_ms) = benchmark_common::measure_time(|| {
+        for _ in 0..config.iterations {
+            let _ = run_determine_best_once(data_ptr, len_bytes, config.estimate_compression_level)
+                .unwrap();
+        }
+    });
+
+    // Average the time over iterations
+    let avg_execution_time = execution_time_ms / config.iterations as f64;
+
+    // For this benchmark, we consider the entire determine_best_transform_details as "detransform"
+    // and set decompress time to 0, as we're only measuring the algorithm performance
+    Ok(Some(BenchmarkScenarioResult::new(
+        scenario_name.to_string(),
+        len_bytes,
+        0.0,                // No decompress time for this specific benchmark
+        avg_execution_time, // All time is considered "detransform" time
+    )))
+}
+
+unsafe fn run_determine_best_once(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    estimate_compression_level: i32,
+) -> Result<Bc1TransformDetails, TransformError> {
+    // Create a zstd file size estimator that compresses data without caching
+    let estimator = move |data_ptr: *const u8, len: usize| -> usize {
+        match zstd_calc_size_uncached(data_ptr, len, estimate_compression_level) {
+            Ok(size) => size,
+            Err(_) => usize::MAX, // Return max size on error to make this option less favorable
+        }
+    };
+
+    // Create transform options
+    let transform_options = Bc1TransformOptions {
+        file_size_estimator: estimator,
+    };
+
+    // Determine the best transform details using the API
+    determine_best_transform_details(data_ptr, len_bytes, transform_options)
+        .map_err(|e| TransformError::Debug(format!("determine_best_transform_details failed: {e}")))
+}
+
+/// Calculates ZStandard compressed size without caching.
+/// This is a simplified version of calc_compression_stats_common::zstd_calc_size_with_cache
+/// that doesn't use any caching mechanisms for pure performance measurement.
+unsafe fn zstd_calc_size_uncached(
+    data_ptr: *const u8,
+    len_bytes: usize,
+    compression_level: i32,
+) -> Result<usize, TransformError> {
+    let max_compressed_size = zstd::max_alloc_for_compress_size(len_bytes);
+    let mut compressed_buffer =
+        unsafe { Box::<[u8]>::new_uninit_slice(max_compressed_size).assume_init() };
+
+    let compressed_size = {
+        let original_slice = slice::from_raw_parts(data_ptr, len_bytes);
+        match zstd::compress(compression_level, original_slice, &mut compressed_buffer) {
+            Ok(size) => size,
+            Err(_) => {
+                return Err(TransformError::Debug(
+                    "Benchmark: Compression failed".to_owned(),
+                ))
+            }
+        }
+    };
+
+    Ok(compressed_size)
+}
+
+/// Print file result with throughput measured in MiB/s for determine_best_transform_details benchmark
+fn print_file_result_throughput(result: &BenchmarkResult) {
+    let file_size_mib = result.file_size_bytes as f64 / (1024.0 * 1024.0);
+    
+    println!("📁 {}", result.file_path);
+    println!("   📊 File size: {file_size_mib:.2} MiB");
+    
+    for scenario in &result.scenarios {
+        // For this benchmark, execution time is stored in detransform_time_ms
+        let execution_time_ms = scenario.detransform_time_ms;
+        let execution_time_s = execution_time_ms / 1000.0;
+        let throughput_mib_s = if execution_time_s > 0.0 {
+            file_size_mib / execution_time_s
+        } else {
+            0.0
+        };
+        
+        println!(
+            "   ⚡ {}: {execution_time_ms:.3} ms ({throughput_mib_s:.2} MiB/s)",
+            scenario.scenario_name
+        );
+    }
+    println!();
+}

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/calc_compression_stats.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/calc_compression_stats.rs
@@ -199,7 +199,10 @@ unsafe fn analyze_bc1_api_recommendation(
             cache,
         ) {
             Ok(size) => size,
-            Err(_) => usize::MAX, // Return max size on error to make this option less favorable
+            Err(e) => {
+                eprintln!("Warning: Compression estimation failed: {e}");
+                usize::MAX // Return max size on error to make this option less favorable
+            }
         }
     };
 

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod benchmark;
+pub(crate) mod benchmark_determine_best;
 pub(crate) mod calc_compression_stats;
 pub(crate) mod roundtrip;
 
@@ -23,6 +24,7 @@ pub enum DebugCommands {
     Roundtrip(RoundtripCmd),
     CompressionStats(CompressionStatsCmd),
     Benchmark(BenchmarkCmd),
+    BenchmarkDetermineBest(BenchmarkDetermineBestCmd),
 }
 
 #[derive(FromArgs, Debug)]
@@ -76,6 +78,27 @@ pub struct BenchmarkCmd {
     pub warmup_iterations: u32,
 }
 
+#[derive(FromArgs, Debug)]
+/// Benchmark BC1 determine_best_transform_details function performance on files in a directory
+#[argh(subcommand, name = "benchmark-determine-best")]
+pub struct BenchmarkDetermineBestCmd {
+    /// input directory path to benchmark (recursively)
+    #[argh(positional)]
+    pub input_directory: PathBuf,
+
+    /// compression level for zstd when using API best method estimation (default: 1)
+    #[argh(option, default = "1")]
+    pub estimate_compression_level: i32,
+
+    /// number of iterations per file for performance measurement (default: 2)
+    #[argh(option, default = "2")]
+    pub iterations: u32,
+
+    /// warmup iterations before measurement (default: 1)
+    #[argh(option, default = "1")]
+    pub warmup_iterations: u32,
+}
+
 pub fn handle_debug_command(cmd: DebugCmd) -> Result<(), TransformError> {
     match cmd.command {
         DebugCommands::Roundtrip(roundtrip_cmd) => handle_roundtrip_command(roundtrip_cmd),
@@ -83,5 +106,10 @@ pub fn handle_debug_command(cmd: DebugCmd) -> Result<(), TransformError> {
             handle_compression_stats_command(compression_stats_cmd)
         }
         DebugCommands::Benchmark(benchmark_cmd) => handle_benchmark_command(benchmark_cmd),
+        DebugCommands::BenchmarkDetermineBest(benchmark_determine_best_cmd) => {
+            benchmark_determine_best::handle_benchmark_determine_best_command(
+                benchmark_determine_best_cmd,
+            )
+        }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new benchmarking command for evaluating the performance of the BC1 texture compression transform function on files within a directory. This command provides options for input directory, compression level, iteration count, and warmup iterations, with detailed reporting of execution times and throughput.
  - Added a new throughput display format for benchmarking results.

- **Refactor**
  - Updated benchmarking tools to use precise duration and throughput types for all timing and performance measurements, improving accuracy and consistency in reporting.
  - Enhanced error reporting in compression size estimation with warning messages for better diagnostics.

- **Chores**
  - Removed an unused struct related to compression stream management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->