### PR TITLE
Added: Optimized code paths for transforming BC1 data

### DIFF
--- a/projects/dxt-lossless-transform-api/src/api.rs
+++ b/projects/dxt-lossless-transform-api/src/api.rs
@@ -13,7 +13,6 @@ pub use dxt_lossless_transform_dds::dds::*;
 ///
 /// - `input_ptr` must be valid for reads of len bytes
 /// - `output_ptr` must be valid for writes of len bytes
-/// - `work_ptr` must be valid for writes of len/2 bytes
 /// - `len` must be divisible by 8 (BC1 block size)
 /// - `input_ptr` and `output_ptr` must be 64-byte aligned (for performance and required by some platforms).
 /// - `format` must be a valid [`DdsFormat`]
@@ -21,7 +20,6 @@ pub use dxt_lossless_transform_dds::dds::*;
 pub unsafe fn transform_format(
     input_ptr: *const u8,
     output_ptr: *mut u8,
-    work_ptr: *mut u8,
     len: usize,
     format: DdsFormat,
 ) {
@@ -31,7 +29,6 @@ pub unsafe fn transform_format(
             dxt_lossless_transform_bc1::transform_bc1(
                 input_ptr,
                 output_ptr,
-                work_ptr,
                 len,
                 Bc1TransformDetails::default(),
             );
@@ -57,7 +54,6 @@ pub unsafe fn transform_format(
 ///
 /// - `input_ptr` must be valid for reads of len bytes
 /// - `output_ptr` must be valid for writes of len bytes
-/// - `work_ptr` must be valid for writes of len bytes
 /// - `len` must be divisible by 8 (BC1 block size)
 /// - `input_ptr` and `output_ptr` must be 64-byte aligned (for performance and required by some platforms).
 /// - `format` must be a valid [`DdsFormat`], and the same format passed to [`transform_format`].

--- a/projects/dxt-lossless-transform-api/src/exports.rs
+++ b/projects/dxt-lossless-transform-api/src/exports.rs
@@ -59,7 +59,6 @@ pub unsafe extern "C" fn parse_dds(ptr: *const u8, len: usize) -> DdsInfo {
 ///
 /// - `input_ptr` must be valid for reads of len bytes
 /// - `output_ptr` must be valid for writes of len bytes
-/// - `work_ptr` must be valid for writes of len bytes
 /// - `len` must be divisible by 8 (BC1 block size)
 /// - `input_ptr` and `output_ptr` must be 32-byte aligned (for performance and required by some platforms).
 /// - `format` must be a valid [`DdsFormat`]
@@ -67,11 +66,10 @@ pub unsafe extern "C" fn parse_dds(ptr: *const u8, len: usize) -> DdsInfo {
 pub unsafe extern "C" fn transform_format(
     input_ptr: *const u8,
     output_ptr: *mut u8,
-    work_ptr: *mut u8,
     len: usize,
     format: DdsFormat,
 ) {
-    crate::transform_format(input_ptr, output_ptr, work_ptr, len, format)
+    crate::transform_format(input_ptr, output_ptr, len, format)
 }
 
 /// Untransforms data from a compression suitable one to the standard format.
@@ -83,7 +81,6 @@ pub unsafe extern "C" fn transform_format(
 ///
 /// - `input_ptr` must be valid for reads of len bytes
 /// - `output_ptr` must be valid for writes of len bytes
-/// - `work_ptr` must be valid for writes of len bytes
 /// - `len` must be divisible by 8 (BC1 block size)
 /// - `input_ptr` and `output_ptr` must be 32-byte aligned (for performance and required by some platforms).
 /// - `format` must be a valid [`DdsFormat`], and the same format passed to [`transform_format`].

--- a/projects/dxt-lossless-transform-api/src/exports.rs
+++ b/projects/dxt-lossless-transform-api/src/exports.rs
@@ -59,7 +59,7 @@ pub unsafe extern "C" fn parse_dds(ptr: *const u8, len: usize) -> DdsInfo {
 ///
 /// - `input_ptr` must be valid for reads of len bytes
 /// - `output_ptr` must be valid for writes of len bytes
-/// - `len` must be divisible by 8 (BC1 block size)
+/// - `len` must be divisible by the block size of the specified format (e.g., 8 for BC1, 16 for BC2/BC3)
 /// - `input_ptr` and `output_ptr` must be 32-byte aligned (for performance and required by some platforms).
 /// - `format` must be a valid [`DdsFormat`]
 #[no_mangle]
@@ -81,7 +81,7 @@ pub unsafe extern "C" fn transform_format(
 ///
 /// - `input_ptr` must be valid for reads of len bytes
 /// - `output_ptr` must be valid for writes of len bytes
-/// - `len` must be divisible by 8 (BC1 block size)
+/// - `len` must be divisible by the block size of the specified format (e.g., 8 for BC1, 16 for BC2/BC3)
 /// - `input_ptr` and `output_ptr` must be 32-byte aligned (for performance and required by some platforms).
 /// - `format` must be a valid [`DdsFormat`], and the same format passed to [`transform_format`].
 #[no_mangle]

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+// Not yet in stable today, but will be in 1.89.0
+#![allow(stable_features)]
 #![cfg_attr(
     all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")),
     feature(stdarch_x86_avx512)

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -126,7 +126,7 @@ impl Bc1TransformDetails {
 ///
 /// - `input_ptr`: A pointer to the input data (input BC1 blocks)
 /// - `output_ptr`: A pointer to the output data (output BC1 blocks)
-/// - `len`: The length of the input data in bytes (size of `input_ptr`, `output_ptr` and half size of `work_ptr`)
+/// - `len`: The length of the input data in bytes (size of `input_ptr`, `output_ptr`)
 /// - `transform_options`: The transform options to use.
 ///   Obtained from [`determine_optimal_transform::determine_best_transform_details`] or
 ///   [`Bc1TransformDetails::default`] for less optimal result(s).

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -168,10 +168,10 @@ pub unsafe fn transform_bc1(
             );
         }
     } else if transform_options.decorrelation_mode == YCoCgVariant::None {
-        // Only split blocks
+        // Standard transform – no split-colour and no decorrelation.
         transform(input_ptr, output_ptr, len);
     } else {
-        // Split the blocks directly into expected output.
+        // Standard transform + decorrelate.
         with_recorrelate::transform_with_decorrelate(
             input_ptr,
             output_ptr,
@@ -231,10 +231,10 @@ pub unsafe fn untransform_bc1(
             );
         }
     } else if detransform_options.decorrelation_mode == YCoCgVariant::None {
-        // Only split blocks.
+        // Standard transform – no split-colour and no decorrelation.
         untransform(input_ptr, output_ptr, len);
     } else {
-        // Unsplit blocks + decorrelate.
+        // Standard transform + recorrelate.
         with_recorrelate::untransform_with_recorrelate(
             input_ptr,
             output_ptr,

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -13,7 +13,7 @@ use dxt_lossless_transform_common::{
     color_565::{Color565, YCoCgVariant},
     transforms::split_565_color_endpoints::split_color_endpoints,
 };
-use experimental::normalize_blocks::{normalize_split_blocks_in_place, ColorNormalizationMode};
+use experimental::normalize_blocks::ColorNormalizationMode;
 
 pub mod determine_optimal_transform;
 pub mod experimental;
@@ -187,8 +187,7 @@ pub unsafe fn transform_bc1(
     } else if transform_options.decorrelation_mode == YCoCgVariant::None {
         // Only split blocks
         transform(input_ptr, output_ptr, len);
-    }
-    else {
+    } else {
         // Split the blocks directly into expected output.
         transform(input_ptr, output_ptr, len);
 

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -189,13 +189,10 @@ pub unsafe fn transform_bc1(
         transform(input_ptr, output_ptr, len);
     } else {
         // Split the blocks directly into expected output.
-        transform(input_ptr, output_ptr, len);
-
-        // And if there's colour decorrelation, do it right now (if needed, no-ops if mode is 'none')
-        Color565::decorrelate_ycocg_r_ptr(
-            output_ptr as *const Color565,
-            output_ptr as *mut Color565,
-            (len / 2) / size_of::<Color565>(), // (len / 2): Length of colour endpoints in bytes
+        with_recorrelate::transform_with_decorrelate(
+            input_ptr,
+            output_ptr,
+            len,
             transform_options.decorrelation_mode,
         );
     }

--- a/projects/dxt-lossless-transform-bc1/src/test_prelude.rs
+++ b/projects/dxt-lossless-transform-bc1/src/test_prelude.rs
@@ -30,8 +30,5 @@ pub use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
 pub use core::ptr::{copy_nonoverlapping, write_bytes};
 pub use safe_allocator_api::RawAlloc;
 
-// Common untransform functions that are frequently tested
-pub use crate::with_split_colour_and_recorr::untransform_with_split_colour_and_recorr;
-
 // Re-export super for convenience in test modules
 pub use super::*;

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/mod.rs
@@ -70,7 +70,7 @@ pub unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 /// - The color and index buffers must not overlap with each other or the input buffer
 #[inline]
-pub unsafe fn transform_with_separate_pointers(
+pub(crate) unsafe fn transform_with_separate_pointers(
     input_ptr: *const u8,
     colors_ptr: *mut u32,
     indices_ptr: *mut u32,
@@ -89,7 +89,7 @@ pub unsafe fn transform_with_separate_pointers(
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     untransform::untransform(input_ptr, output_ptr, len);
 }
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/avx2.rs
@@ -341,8 +341,8 @@ pub unsafe fn shuffle_permute_unroll_2(input_ptr: *const u8, output_ptr: *mut u8
 #[target_feature(enable = "avx2")]
 pub unsafe fn shuffle_permute_unroll_2_with_separate_pointers(
     mut input_ptr: *const u8,
-    mut colors_ptr: *mut u32,
-    mut indices_ptr: *mut u32,
+    mut colors_out: *mut u32,
+    mut indices_out: *mut u32,
     len: usize,
 ) {
     debug_assert!(len % 8 == 0);
@@ -390,8 +390,8 @@ pub unsafe fn shuffle_permute_unroll_2_with_separate_pointers(
                 "jb 2b",
 
                 src_ptr = inout(reg) input_ptr,
-                colors_ptr = inout(reg) colors_ptr,
-                indices_ptr = inout(reg) indices_ptr,
+                colors_ptr = inout(reg) colors_out,
+                indices_ptr = inout(reg) indices_out,
                 end = inout(reg) aligned_end,
                 ymm0 = out(ymm_reg) _,
                 ymm1 = out(ymm_reg) _,
@@ -408,15 +408,13 @@ pub unsafe fn shuffle_permute_unroll_2_with_separate_pointers(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_with_separate_pointers(input_ptr, colors_ptr, indices_ptr, remaining);
-    }
+    u32_with_separate_pointers(input_ptr, colors_out, indices_out, remaining);
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
     use core::ptr::copy_nonoverlapping;
 
     type PermuteFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/portable32.rs
@@ -21,17 +21,16 @@ pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - colours_ptr must be valid for writes of len/2 bytes
 /// - indices_ptr must be valid for writes of len/2 bytes
 /// - len must be divisible by 8
+#[inline]
 pub(crate) unsafe fn u32_with_separate_pointers(
-    input_ptr: *const u8,
-    mut colours_ptr: *mut u32,
-    mut indices_ptr: *mut u32,
+    mut input_ptr: *const u8,
+    mut colours_out: *mut u32,
+    mut indices_out: *mut u32,
     len: usize,
 ) {
     debug_assert!(len % 8 == 0);
 
     let max_ptr = input_ptr.add(len) as *mut u8;
-    let mut input_ptr = input_ptr as *mut u8;
-
     while input_ptr < max_ptr {
         // Split into colours (lower 4 bytes) and indices (upper 4 bytes)
         let color_value = read_unaligned(input_ptr as *const u32);
@@ -39,11 +38,11 @@ pub(crate) unsafe fn u32_with_separate_pointers(
         input_ptr = input_ptr.add(8);
 
         // Store colours and indices to their respective halves
-        write_unaligned(colours_ptr, color_value);
-        write_unaligned(indices_ptr, index_value);
+        write_unaligned(colours_out, color_value);
+        write_unaligned(indices_out, index_value);
 
-        colours_ptr = colours_ptr.add(1);
-        indices_ptr = indices_ptr.add(1);
+        colours_out = colours_out.add(1);
+        indices_out = indices_out.add(1);
     }
 }
 
@@ -254,8 +253,8 @@ pub unsafe fn u32_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
     use core::ptr::copy_nonoverlapping;
 
     type PermuteFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/sse2.rs
@@ -244,8 +244,8 @@ pub unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: us
 #[target_feature(enable = "sse2")]
 pub unsafe fn shufps_unroll_4_with_separate_pointers(
     mut input_ptr: *const u8,
-    mut colors_ptr: *mut u32,
-    mut indices_ptr: *mut u32,
+    mut colors_out: *mut u32,
+    mut indices_out: *mut u32,
     len: usize,
 ) {
     debug_assert!(len % 8 == 0);
@@ -289,8 +289,8 @@ pub unsafe fn shufps_unroll_4_with_separate_pointers(
                 "jb 2b",
 
                 src_ptr = inout(reg) input_ptr,
-                colors_ptr = inout(reg) colors_ptr,
-                indices_ptr = inout(reg) indices_ptr,
+                colors_ptr = inout(reg) colors_out,
+                indices_ptr = inout(reg) indices_out,
                 end = inout(reg) aligned_end,
                 xmm0 = out(xmm_reg) _,
                 xmm1 = out(xmm_reg) _,
@@ -305,15 +305,13 @@ pub unsafe fn shufps_unroll_4_with_separate_pointers(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_with_separate_pointers(input_ptr, colors_ptr, indices_ptr, remaining);
-    }
+    u32_with_separate_pointers(input_ptr, colors_out, indices_out, remaining);
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
     use core::ptr::copy_nonoverlapping;
     type PermuteFn = unsafe fn(*const u8, *mut u8, usize);
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/avx2.rs
@@ -156,12 +156,12 @@ pub unsafe fn permd_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut 
 pub unsafe fn permd_detransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
-    mut indices_ptr: *const u8,
-    mut colors_ptr: *const u8,
+    mut indices_in: *const u8,
+    mut colors_in: *const u8,
 ) {
     debug_assert!(len % 8 == 0, "len must be divisible by 8");
     let aligned_len = len - (len % 128);
-    let colors_aligned_end = colors_ptr.add(aligned_len / 2);
+    let colors_aligned_end = colors_in.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -199,8 +199,8 @@ pub unsafe fn permd_detransform_unroll_2_with_components(
                 "cmp {colors_ptr}, {end}",
                 "jb 2b",
 
-                colors_ptr = inout(reg) colors_ptr,
-                indices_ptr = inout(reg) indices_ptr,
+                colors_ptr = inout(reg) colors_in,
+                indices_ptr = inout(reg) indices_in,
                 dst_ptr = inout(reg) output_ptr,
                 end = in(reg) colors_aligned_end,
                 ymm0 = out(ymm_reg) _,
@@ -218,14 +218,12 @@ pub unsafe fn permd_detransform_unroll_2_with_components(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_detransform_with_separate_pointers(
-            colors_ptr as *const u32,
-            indices_ptr as *const u32,
-            output_ptr,
-            remaining,
-        );
-    }
+    u32_detransform_with_separate_pointers(
+        colors_in as *const u32,
+        indices_in as *const u32,
+        output_ptr,
+        remaining,
+    );
 }
 
 /// # Safety
@@ -379,8 +377,8 @@ pub unsafe fn unpck_detransform_unroll_2(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::standard::transform::u32;
 
     type DetransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/portable32.rs
@@ -21,6 +21,7 @@ pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: us
 /// - indices_ptr must be valid for reads of len/2 bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
+#[inline]
 pub(crate) unsafe fn u32_detransform_with_separate_pointers(
     mut colours_ptr: *const u32,
     mut indices_ptr: *const u32,
@@ -250,8 +251,8 @@ pub unsafe fn u32_detransform_unroll_8(input_ptr: *const u8, output_ptr: *mut u8
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::standard::transform::u32;
 
     type DetransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/sse2.rs
@@ -88,12 +88,12 @@ pub unsafe fn unpck_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut 
 pub unsafe fn unpck_detransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
-    mut indices_ptr: *const u8,
-    mut colors_ptr: *const u8,
+    mut indices_in: *const u8,
+    mut colors_in: *const u8,
 ) {
     debug_assert!(len % 8 == 0);
     let aligned_len = len - (len % 64);
-    let colors_aligned_end = colors_ptr.add(aligned_len / 2);
+    let colors_aligned_end = colors_in.add(aligned_len / 2);
 
     if aligned_len > 0 {
         unsafe {
@@ -129,8 +129,8 @@ pub unsafe fn unpck_detransform_unroll_2_with_components(
                 "cmp {colors_ptr}, {end}",
                 "jb 2b",
 
-                colors_ptr = inout(reg) colors_ptr,
-                indices_ptr = inout(reg) indices_ptr,
+                colors_ptr = inout(reg) colors_in,
+                indices_ptr = inout(reg) indices_in,
                 dst_ptr = inout(reg) output_ptr,
                 end = in(reg) colors_aligned_end,
                 xmm0 = out(xmm_reg) _,
@@ -146,14 +146,12 @@ pub unsafe fn unpck_detransform_unroll_2_with_components(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_detransform_with_separate_pointers(
-            colors_ptr as *const u32,
-            indices_ptr as *const u32,
-            output_ptr,
-            remaining,
-        );
-    }
+    u32_detransform_with_separate_pointers(
+        colors_in as *const u32,
+        indices_in as *const u32,
+        output_ptr,
+        remaining,
+    );
 }
 
 /// # Safety
@@ -259,8 +257,8 @@ pub unsafe fn unpck_detransform_unroll_4(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::standard::transform::u32;
 
     type DetransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/mod.rs
@@ -68,7 +68,7 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn transform_with_decorrelate(
+pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -87,7 +87,7 @@ pub unsafe fn transform_with_decorrelate(
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn untransform_with_recorrelate(
+pub(crate) unsafe fn untransform_with_recorrelate(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/mod.rs
@@ -58,6 +58,25 @@ pub mod untransform;
 
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
+/// Transform BC1 data from standard interleaved format to separated color/index format
+/// while applying YCoCg decorrelation using best known implementation for current CPU.
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 8
+/// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
+#[inline]
+pub unsafe fn transform_with_decorrelate(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    transform::transform_with_decorrelate(input_ptr, output_ptr, len, decorrelation_mode);
+}
+
 /// Transform BC1 data from separated color/index format back to standard interleaved format
 /// while applying YCoCg recorrelation using best known implementation for current CPU.
 ///

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
@@ -19,7 +19,8 @@ unsafe fn transform_decorr<const VARIANT: u8>(
 ) {
     let mut in_ptr = input_ptr;
     let blocks16 = num_blocks / 16;
-    for _ in 0..blocks16 {
+    let input_end = input_ptr.add(blocks16 * 16 * 8); // blocks16 * 16 blocks per iteration * 8 bytes per block
+    while in_ptr < input_end {
         // Load 16 blocks = 128 bytes
         let data0 = _mm256_loadu_si256(in_ptr as *const __m256i);
         let data1 = _mm256_loadu_si256(in_ptr.add(32) as *const __m256i);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
@@ -1,21 +1,198 @@
 use crate::transforms::with_recorrelate::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::hint::unreachable_unchecked;
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
+use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::avx2::{
+    decorrelate_ycocg_r_var1_avx2, decorrelate_ycocg_r_var2_avx2, decorrelate_ycocg_r_var3_avx2,
+};
 
-/// AVX2 stub for transform with YCoCg-R decorrelation.
-/// Falls back to generic implementation.
+/// AVX2 implementation for transform with YCoCg-R decorrelation.
+#[target_feature(enable = "avx2")]
+unsafe fn transform_decorr<const VARIANT: u8>(
+    input_ptr: *const u8,
+    mut colours_ptr: *mut u32,
+    mut indices_ptr: *mut u32,
+    num_blocks: usize,
+) {
+    let mut in_ptr = input_ptr;
+    let blocks16 = num_blocks / 16;
+    for _ in 0..blocks16 {
+        // Load 16 blocks = 128 bytes
+        let data0 = _mm256_loadu_si256(in_ptr as *const __m256i);
+        let data1 = _mm256_loadu_si256(in_ptr.add(32) as *const __m256i);
+        let data2 = _mm256_loadu_si256(in_ptr.add(64) as *const __m256i);
+        let data3 = _mm256_loadu_si256(in_ptr.add(96) as *const __m256i);
+        in_ptr = in_ptr.add(128);
+
+        // Split colours and indices using shuffle patterns per 128-bit lane
+        let col0_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(data0),
+            _mm256_castsi256_ps(data1),
+            0x88,
+        ));
+        let col0 = _mm256_permute4x64_epi64(col0_shuffled, 0xD8); // 0b11011000 = 216
+        let col1_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(data2),
+            _mm256_castsi256_ps(data3),
+            0x88,
+        ));
+        let col1 = _mm256_permute4x64_epi64(col1_shuffled, 0xD8); // 0b11011000 = 216
+        let idx0_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(data0),
+            _mm256_castsi256_ps(data1),
+            0xDD,
+        ));
+        let idx0 = _mm256_permute4x64_epi64(idx0_shuffled, 0xD8); // 0b11011000 = 216
+        let idx1_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(data2),
+            _mm256_castsi256_ps(data3),
+            0xDD,
+        ));
+        let idx1 = _mm256_permute4x64_epi64(idx1_shuffled, 0xD8); // 0b11011000 = 216
+
+        // Apply decorrelation
+        let rec_lo = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx2(col0),
+            2 => decorrelate_ycocg_r_var2_avx2(col0),
+            3 => decorrelate_ycocg_r_var3_avx2(col0),
+            _ => unreachable_unchecked(),
+        };
+        let rec_hi = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx2(col1),
+            2 => decorrelate_ycocg_r_var2_avx2(col1),
+            3 => decorrelate_ycocg_r_var3_avx2(col1),
+            _ => unreachable_unchecked(),
+        };
+
+        // Store results
+        _mm256_storeu_si256(colours_ptr as *mut __m256i, rec_lo);
+        _mm256_storeu_si256(colours_ptr.add(8) as *mut __m256i, rec_hi);
+        _mm256_storeu_si256(indices_ptr as *mut __m256i, idx0);
+        _mm256_storeu_si256(indices_ptr.add(8) as *mut __m256i, idx1);
+
+        colours_ptr = colours_ptr.add(16);
+        indices_ptr = indices_ptr.add(16);
+    }
+    let rem = num_blocks % 16;
+    if rem > 0 {
+        let variant_enum = match VARIANT {
+            1 => YCoCgVariant::Variant1,
+            2 => YCoCgVariant::Variant2,
+            3 => YCoCgVariant::Variant3,
+            _ => unreachable_unchecked(),
+        };
+        generic::transform_with_decorrelate_generic(
+            in_ptr,
+            colours_ptr,
+            indices_ptr,
+            rem,
+            variant_enum,
+        );
+    }
+}
+
+// Wrappers for asm inspection
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var1(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<1>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var2(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<2>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var3(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<3>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+// Runtime dispatcher
+#[allow(dead_code)]
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     colours_ptr: *mut u32,
     indices_ptr: *mut u32,
     num_blocks: usize,
-    decorrelation_mode: YCoCgVariant,
+    variant: YCoCgVariant,
 ) {
-    generic::transform_with_decorrelate_generic(
-        input_ptr,
-        colours_ptr,
-        indices_ptr,
-        num_blocks,
-        decorrelation_mode,
-    );
+    match variant {
+        YCoCgVariant::Variant1 => {
+            transform_decorr_var1(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_decorr_var2(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_decorr_var3(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_recorrelate::untransform::untransform_with_recorrelate;
+
+    #[rstest]
+    #[case(transform_decorr_var1, YCoCgVariant::Variant1)]
+    #[case(transform_decorr_var2, YCoCgVariant::Variant2)]
+    #[case(transform_decorr_var3, YCoCgVariant::Variant3)]
+    fn avx2_transform_roundtrip(
+        #[case] func: unsafe fn(*const u8, *mut u32, *mut u32, usize),
+        #[case] variant: YCoCgVariant,
+    ) {
+        for num_blocks in 1..=128 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut transformed = vec![0u8; len];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                func(
+                    input.as_ptr(),
+                    transformed.as_mut_ptr() as *mut u32,
+                    transformed.as_mut_ptr().add(len / 2) as *mut u32,
+                    num_blocks,
+                );
+                untransform_with_recorrelate(
+                    transformed.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks * 8,
+                    variant,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "Mismatch AVX2 roundtrip variant {variant:?}",
+            );
+        }
+    }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
@@ -12,87 +12,87 @@ use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::avx2::{
 /// AVX2 implementation for transform with YCoCg-R decorrelation.
 #[target_feature(enable = "avx2")]
 unsafe fn transform_decorr<const VARIANT: u8>(
-    input_ptr: *const u8,
-    mut colours_ptr: *mut u32,
-    mut indices_ptr: *mut u32,
+    mut input_ptr: *const u8,
+    mut colours_out: *mut u32,
+    mut indices_out: *mut u32,
     num_blocks: usize,
 ) {
-    let mut in_ptr = input_ptr;
     let blocks16 = num_blocks / 16;
     let input_end = input_ptr.add(blocks16 * 16 * 8); // blocks16 * 16 blocks per iteration * 8 bytes per block
-    while in_ptr < input_end {
+    while input_ptr < input_end {
         // Load 16 blocks = 128 bytes
-        let data0 = _mm256_loadu_si256(in_ptr as *const __m256i);
-        let data1 = _mm256_loadu_si256(in_ptr.add(32) as *const __m256i);
-        let data2 = _mm256_loadu_si256(in_ptr.add(64) as *const __m256i);
-        let data3 = _mm256_loadu_si256(in_ptr.add(96) as *const __m256i);
-        in_ptr = in_ptr.add(128);
+        let data0 = _mm256_loadu_si256(input_ptr as *const __m256i);
+        let data1 = _mm256_loadu_si256(input_ptr.add(32) as *const __m256i);
+        let data2 = _mm256_loadu_si256(input_ptr.add(64) as *const __m256i);
+        let data3 = _mm256_loadu_si256(input_ptr.add(96) as *const __m256i);
+        input_ptr = input_ptr.add(128);
 
         // Split colours and indices using shuffle patterns per 128-bit lane
-        let col0_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+        let colors_only_0 = _mm256_castps_si256(_mm256_shuffle_ps(
             _mm256_castsi256_ps(data0),
             _mm256_castsi256_ps(data1),
             0x88,
         ));
-        let col0 = _mm256_permute4x64_epi64(col0_shuffled, 0xD8); // 0b11011000 = 216
-        let col1_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+        let colors0 = _mm256_permute4x64_epi64(colors_only_0, 0xD8); // 0b11011000 = 216
+
+        let colors_only_1 = _mm256_castps_si256(_mm256_shuffle_ps(
             _mm256_castsi256_ps(data2),
             _mm256_castsi256_ps(data3),
             0x88,
         ));
-        let col1 = _mm256_permute4x64_epi64(col1_shuffled, 0xD8); // 0b11011000 = 216
-        let idx0_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+        let colors1 = _mm256_permute4x64_epi64(colors_only_1, 0xD8); // 0b11011000 = 216
+
+        let indices_only_0 = _mm256_castps_si256(_mm256_shuffle_ps(
             _mm256_castsi256_ps(data0),
             _mm256_castsi256_ps(data1),
             0xDD,
         ));
-        let idx0 = _mm256_permute4x64_epi64(idx0_shuffled, 0xD8); // 0b11011000 = 216
-        let idx1_shuffled = _mm256_castps_si256(_mm256_shuffle_ps(
+        let indices0 = _mm256_permute4x64_epi64(indices_only_0, 0xD8); // 0b11011000 = 216
+
+        let indices_only_1 = _mm256_castps_si256(_mm256_shuffle_ps(
             _mm256_castsi256_ps(data2),
             _mm256_castsi256_ps(data3),
             0xDD,
         ));
-        let idx1 = _mm256_permute4x64_epi64(idx1_shuffled, 0xD8); // 0b11011000 = 216
+        let indices1 = _mm256_permute4x64_epi64(indices_only_1, 0xD8); // 0b11011000 = 216
 
         // Apply decorrelation
-        let rec_lo = match VARIANT {
-            1 => decorrelate_ycocg_r_var1_avx2(col0),
-            2 => decorrelate_ycocg_r_var2_avx2(col0),
-            3 => decorrelate_ycocg_r_var3_avx2(col0),
+        let colors0 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx2(colors0),
+            2 => decorrelate_ycocg_r_var2_avx2(colors0),
+            3 => decorrelate_ycocg_r_var3_avx2(colors0),
             _ => unreachable_unchecked(),
         };
-        let rec_hi = match VARIANT {
-            1 => decorrelate_ycocg_r_var1_avx2(col1),
-            2 => decorrelate_ycocg_r_var2_avx2(col1),
-            3 => decorrelate_ycocg_r_var3_avx2(col1),
+        let colors1 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx2(colors1),
+            2 => decorrelate_ycocg_r_var2_avx2(colors1),
+            3 => decorrelate_ycocg_r_var3_avx2(colors1),
             _ => unreachable_unchecked(),
         };
 
         // Store results
-        _mm256_storeu_si256(colours_ptr as *mut __m256i, rec_lo);
-        _mm256_storeu_si256(colours_ptr.add(8) as *mut __m256i, rec_hi);
-        _mm256_storeu_si256(indices_ptr as *mut __m256i, idx0);
-        _mm256_storeu_si256(indices_ptr.add(8) as *mut __m256i, idx1);
+        _mm256_storeu_si256(colours_out as *mut __m256i, colors0);
+        _mm256_storeu_si256(colours_out.add(8) as *mut __m256i, colors1);
+        _mm256_storeu_si256(indices_out as *mut __m256i, indices0);
+        _mm256_storeu_si256(indices_out.add(8) as *mut __m256i, indices1);
 
-        colours_ptr = colours_ptr.add(16);
-        indices_ptr = indices_ptr.add(16);
+        colours_out = colours_out.add(16);
+        indices_out = indices_out.add(16);
     }
-    let rem = num_blocks % 16;
-    if rem > 0 {
-        let variant_enum = match VARIANT {
-            1 => YCoCgVariant::Variant1,
-            2 => YCoCgVariant::Variant2,
-            3 => YCoCgVariant::Variant3,
-            _ => unreachable_unchecked(),
-        };
-        generic::transform_with_decorrelate_generic(
-            in_ptr,
-            colours_ptr,
-            indices_ptr,
-            rem,
-            variant_enum,
-        );
-    }
+    let remaining = num_blocks % 16;
+    let variant_enum = match VARIANT {
+        1 => YCoCgVariant::Variant1,
+        2 => YCoCgVariant::Variant2,
+        3 => YCoCgVariant::Variant3,
+        _ => unreachable_unchecked(),
+    };
+    generic::transform_with_decorrelate_generic(
+        input_ptr,
+        colours_out,
+        indices_out,
+        remaining,
+        variant_enum,
+    );
 }
 
 // Wrappers for asm inspection
@@ -133,20 +133,20 @@ pub(crate) unsafe fn transform_decorr_var3(
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
-    colours_ptr: *mut u32,
-    indices_ptr: *mut u32,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
     num_blocks: usize,
     variant: YCoCgVariant,
 ) {
     match variant {
         YCoCgVariant::Variant1 => {
-            transform_decorr_var1(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr_var1(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::Variant2 => {
-            transform_decorr_var2(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr_var2(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::Variant3 => {
-            transform_decorr_var3(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr_var3(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::None => unreachable_unchecked(),
     }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
@@ -1,0 +1,21 @@
+use crate::transforms::with_recorrelate::transform::generic;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+
+/// AVX2 stub for transform with YCoCg-R decorrelation.
+/// Falls back to generic implementation.
+#[inline(always)]
+pub(crate) unsafe fn transform_with_recorrelate(
+    input_ptr: *const u8,
+    colours_ptr: *mut u32,
+    indices_ptr: *mut u32,
+    num_blocks: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    generic::transform_with_recorrelate_generic(
+        input_ptr,
+        colours_ptr,
+        indices_ptr,
+        num_blocks,
+        decorrelation_mode,
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
@@ -97,7 +97,6 @@ unsafe fn transform_decorr<const VARIANT: u8>(
 // Wrappers for asm inspection
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx2")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var1(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -109,7 +108,6 @@ pub(crate) unsafe fn transform_decorr_var1(
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx2")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var2(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -121,7 +119,6 @@ pub(crate) unsafe fn transform_decorr_var2(
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx2")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var3(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -132,7 +129,6 @@ pub(crate) unsafe fn transform_decorr_var3(
 }
 
 // Runtime dispatcher
-#[allow(dead_code)]
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx2.rs
@@ -4,14 +4,14 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 /// AVX2 stub for transform with YCoCg-R decorrelation.
 /// Falls back to generic implementation.
 #[inline(always)]
-pub(crate) unsafe fn transform_with_recorrelate(
+pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     colours_ptr: *mut u32,
     indices_ptr: *mut u32,
     num_blocks: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
-    generic::transform_with_recorrelate_generic(
+    generic::transform_with_decorrelate_generic(
         input_ptr,
         colours_ptr,
         indices_ptr,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
@@ -33,7 +33,8 @@ unsafe fn transform_decorr<const VARIANT: u8>(
             _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_COLORS_BYTES.as_ptr() as *const _));
         let perm_indices =
             _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_INDICES_BYTES.as_ptr() as *const _));
-        for _ in 0..blocks32 {
+        let input_end = input_ptr.add(blocks32 * 32 * 8); // blocks32 * 32 blocks per iteration * 8 bytes per block
+        while src < input_end {
             // Load 256 bytes = 32 blocks
             let src0 = _mm512_loadu_si512(src as *const __m512i);
             let src1 = _mm512_loadu_si512(src.add(64) as *const __m512i);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
@@ -4,14 +4,14 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 /// AVX512 stub for transform with YCoCg-R decorrelation.
 /// Falls back to generic implementation.
 #[inline(always)]
-pub(crate) unsafe fn transform_with_recorrelate(
+pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     colours_ptr: *mut u32,
     indices_ptr: *mut u32,
     num_blocks: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
-    generic::transform_with_recorrelate_generic(
+    generic::transform_with_decorrelate_generic(
         input_ptr,
         colours_ptr,
         indices_ptr,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
@@ -1,21 +1,181 @@
 use crate::transforms::with_recorrelate::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::hint::unreachable_unchecked;
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
+use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::avx512::{
+    decorrelate_ycocg_r_var1_avx512, decorrelate_ycocg_r_var2_avx512,
+    decorrelate_ycocg_r_var3_avx512,
+};
 
-/// AVX512 stub for transform with YCoCg-R decorrelation.
-/// Falls back to generic implementation.
+// Add local byte-index constants for AVX512 permutations
+const PERM_COLORS_BYTES: [i8; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+const PERM_INDICES_BYTES: [i8; 16] = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31];
+
+#[target_feature(enable = "avx512f")]
+unsafe fn transform_decorr<const VARIANT: u8>(
+    input_ptr: *const u8,
+    colours_ptr: *mut u32,
+    indices_ptr: *mut u32,
+    num_blocks: usize,
+) {
+    // Pointer and block setup
+    let mut src = input_ptr;
+    let mut col_out = colours_ptr;
+    let mut idx_out = indices_ptr;
+    let blocks32 = num_blocks / 32;
+    let rem = num_blocks % 32;
+    if blocks32 > 0 {
+        // Load permutation patterns and sign-extend to dwords
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_INDICES_BYTES.as_ptr() as *const _));
+        for _ in 0..blocks32 {
+            // Load 256 bytes = 32 blocks
+            let src0 = _mm512_loadu_si512(src as *const __m512i);
+            let src1 = _mm512_loadu_si512(src.add(64) as *const __m512i);
+            let src2 = _mm512_loadu_si512(src.add(128) as *const __m512i);
+            let src3 = _mm512_loadu_si512(src.add(192) as *const __m512i);
+            src = src.add(256);
+            // Split and decorrelate colors
+            let col0 = _mm512_permutex2var_epi32(src0, perm_colors, src1);
+            let rec0 = match VARIANT {
+                1 => decorrelate_ycocg_r_var1_avx512(col0),
+                2 => decorrelate_ycocg_r_var2_avx512(col0),
+                3 => decorrelate_ycocg_r_var3_avx512(col0),
+                _ => unreachable_unchecked(),
+            };
+            _mm512_storeu_si512(col_out as *mut __m512i, rec0);
+            let col1 = _mm512_permutex2var_epi32(src2, perm_colors, src3);
+            let rec1 = match VARIANT {
+                1 => decorrelate_ycocg_r_var1_avx512(col1),
+                2 => decorrelate_ycocg_r_var2_avx512(col1),
+                3 => decorrelate_ycocg_r_var3_avx512(col1),
+                _ => unreachable_unchecked(),
+            };
+            _mm512_storeu_si512(col_out.add(16) as *mut __m512i, rec1);
+            col_out = col_out.add(32);
+            // Split indices and store
+            let idx0 = _mm512_permutex2var_epi32(src0, perm_indices, src1);
+            _mm512_storeu_si512(idx_out as *mut __m512i, idx0);
+            let idx1 = _mm512_permutex2var_epi32(src2, perm_indices, src3);
+            _mm512_storeu_si512(idx_out.add(16) as *mut __m512i, idx1);
+            idx_out = idx_out.add(32);
+        }
+    }
+    if rem > 0 {
+        let variant_enum = match VARIANT {
+            1 => YCoCgVariant::Variant1,
+            2 => YCoCgVariant::Variant2,
+            3 => YCoCgVariant::Variant3,
+            _ => unreachable_unchecked(),
+        };
+        generic::transform_with_decorrelate_generic(src, col_out, idx_out, rem, variant_enum);
+    }
+}
+
+// Wrappers for asm inspection
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var1(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<1>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var2(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<2>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var3(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<3>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+// Runtime dispatcher
+#[allow(dead_code)]
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     colours_ptr: *mut u32,
     indices_ptr: *mut u32,
     num_blocks: usize,
-    decorrelation_mode: YCoCgVariant,
+    variant: YCoCgVariant,
 ) {
-    generic::transform_with_decorrelate_generic(
-        input_ptr,
-        colours_ptr,
-        indices_ptr,
-        num_blocks,
-        decorrelation_mode,
-    );
+    match variant {
+        YCoCgVariant::Variant1 => {
+            transform_decorr_var1(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_decorr_var2(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_decorr_var3(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_recorrelate::untransform::untransform_with_recorrelate;
+
+    #[rstest]
+    #[case(transform_decorr_var1, YCoCgVariant::Variant1)]
+    #[case(transform_decorr_var2, YCoCgVariant::Variant2)]
+    #[case(transform_decorr_var3, YCoCgVariant::Variant3)]
+    fn avx512_transform_roundtrip(
+        #[case] func: unsafe fn(*const u8, *mut u32, *mut u32, usize),
+        #[case] variant: YCoCgVariant,
+    ) {
+        for num_blocks in 1..=128 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut transformed = vec![0u8; len];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                func(
+                    input.as_ptr(),
+                    transformed.as_mut_ptr() as *mut u32,
+                    transformed.as_mut_ptr().add(len / 2) as *mut u32,
+                    num_blocks,
+                );
+                untransform_with_recorrelate(
+                    transformed.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks * 8,
+                    variant,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "Mismatch AVX512 roundtrip variant {variant:?}",
+            );
+        }
+    }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
@@ -80,7 +80,6 @@ unsafe fn transform_decorr<const VARIANT: u8>(
 // Wrappers for asm inspection
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx512f")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var1(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -92,7 +91,6 @@ pub(crate) unsafe fn transform_decorr_var1(
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx512f")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var2(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -104,7 +102,6 @@ pub(crate) unsafe fn transform_decorr_var2(
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[target_feature(enable = "avx512f")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var3(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -115,7 +112,6 @@ pub(crate) unsafe fn transform_decorr_var3(
 }
 
 // Runtime dispatcher
-#[allow(dead_code)]
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
@@ -1,0 +1,21 @@
+use crate::transforms::with_recorrelate::transform::generic;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+
+/// AVX512 stub for transform with YCoCg-R decorrelation.
+/// Falls back to generic implementation.
+#[inline(always)]
+pub(crate) unsafe fn transform_with_recorrelate(
+    input_ptr: *const u8,
+    colours_ptr: *mut u32,
+    indices_ptr: *mut u32,
+    num_blocks: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    generic::transform_with_recorrelate_generic(
+        input_ptr,
+        colours_ptr,
+        indices_ptr,
+        num_blocks,
+        decorrelation_mode,
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/avx512.rs
@@ -120,20 +120,20 @@ pub(crate) unsafe fn transform_decorr_var3(
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
-    colours_ptr: *mut u32,
-    indices_ptr: *mut u32,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
     num_blocks: usize,
     variant: YCoCgVariant,
 ) {
     match variant {
         YCoCgVariant::Variant1 => {
-            transform_decorr_var1(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr_var1(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::Variant2 => {
-            transform_decorr_var2(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr_var2(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::Variant3 => {
-            transform_decorr_var3(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr_var3(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::None => unreachable_unchecked(),
     }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/generic.rs
@@ -1,0 +1,121 @@
+use core::hint::unreachable_unchecked;
+use core::ptr::{read_unaligned, write_unaligned};
+use dxt_lossless_transform_common::color_565::{Color565, YCoCgVariant};
+
+/// Generic implementation of BC1 transform with YCoCg-R decorrelation.
+///
+/// Splits standard interleaved BC1 blocks into separate color and index buffers,
+/// applying YCoCg-R decorrelation to color endpoints.
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of num_blocks * 8 bytes
+/// - colours_ptr must be valid for writes of num_blocks * 4 bytes
+/// - indices_ptr must be valid for writes of num_blocks * 4 bytes
+/// - decorrelation_mode must be a valid [`YCoCgVariant`]
+pub(crate) unsafe fn transform_with_recorrelate_generic(
+    input_ptr: *const u8,
+    colours_ptr: *mut u32,
+    indices_ptr: *mut u32,
+    num_blocks: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    match decorrelation_mode {
+        YCoCgVariant::Variant1 => {
+            transform_recorr::<1>(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_recorr::<2>(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_recorr::<3>(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+unsafe fn transform_recorr<const VARIANT: u8>(
+    mut input_ptr: *const u8,
+    mut colours_ptr: *mut u32,
+    mut indices_ptr: *mut u32,
+    num_blocks: usize,
+) {
+    for _ in 0..num_blocks {
+        // Read color endpoints and indices
+        let color_raw = read_unaligned(input_ptr as *const u32);
+        let index_value = read_unaligned(input_ptr.add(4) as *const u32);
+        input_ptr = input_ptr.add(8);
+
+        // Extract two 16-bit colors
+        let color0 = Color565::from_raw(color_raw as u16);
+        let color1 = Color565::from_raw((color_raw >> 16) as u16);
+
+        // Apply YCoCg-R decorrelation based on variant
+        let (decorr0, decorr1) = match VARIANT {
+            1 => (
+                color0.decorrelate_ycocg_r_var1(),
+                color1.decorrelate_ycocg_r_var1(),
+            ),
+            2 => (
+                color0.decorrelate_ycocg_r_var2(),
+                color1.decorrelate_ycocg_r_var2(),
+            ),
+            3 => (
+                color0.decorrelate_ycocg_r_var3(),
+                color1.decorrelate_ycocg_r_var3(),
+            ),
+            _ => unreachable_unchecked(),
+        };
+
+        // Pack decorated colors into u32
+        let decorated_colors = (decorr0.raw_value() as u32) | ((decorr1.raw_value() as u32) << 16);
+
+        // Write to separate buffers
+        write_unaligned(colours_ptr, decorated_colors);
+        write_unaligned(indices_ptr, index_value);
+
+        colours_ptr = colours_ptr.add(1);
+        indices_ptr = indices_ptr.add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_recorrelate::untransform::generic::untransform_with_recorrelate_generic;
+
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn roundtrip_transform_with_recorrelate(#[case] variant: YCoCgVariant) {
+        for num_blocks in 1..=512 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut transformed = vec![0u8; len];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                transform_with_recorrelate_generic(
+                    input.as_ptr(),
+                    transformed.as_mut_ptr() as *mut u32,
+                    transformed.as_mut_ptr().add(len / 2) as *mut u32,
+                    num_blocks,
+                    variant,
+                );
+                untransform_with_recorrelate_generic(
+                    transformed.as_ptr() as *const u32,
+                    transformed.as_ptr().add(len / 2) as *const u32,
+                    reconstructed.as_mut_ptr(),
+                    num_blocks,
+                    variant,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "roundtrip mismatch for variant {variant:?}"
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/generic.rs
@@ -40,7 +40,8 @@ unsafe fn transform_decorr<const VARIANT: u8>(
     mut indices_ptr: *mut u32,
     num_blocks: usize,
 ) {
-    for _ in 0..num_blocks {
+    let input_end = input_ptr.add(num_blocks * 8);
+    while input_ptr < input_end {
         // Read color endpoints and indices
         let color_raw = read_unaligned(input_ptr as *const u32);
         let index_value = read_unaligned(input_ptr.add(4) as *const u32);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/generic.rs
@@ -10,25 +10,26 @@ use dxt_lossless_transform_common::color_565::{Color565, YCoCgVariant};
 /// # Safety
 ///
 /// - input_ptr must be valid for reads of num_blocks * 8 bytes
-/// - colours_ptr must be valid for writes of num_blocks * 4 bytes
-/// - indices_ptr must be valid for writes of num_blocks * 4 bytes
+/// - colours_out must be valid for writes of num_blocks * 4 bytes
+/// - indices_out must be valid for writes of num_blocks * 4 bytes
 /// - decorrelation_mode must be a valid [`YCoCgVariant`]
+#[inline]
 pub(crate) unsafe fn transform_with_decorrelate_generic(
     input_ptr: *const u8,
-    colours_ptr: *mut u32,
-    indices_ptr: *mut u32,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
     num_blocks: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
     match decorrelation_mode {
         YCoCgVariant::Variant1 => {
-            transform_decorr::<1>(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr::<1>(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::Variant2 => {
-            transform_decorr::<2>(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr::<2>(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::Variant3 => {
-            transform_decorr::<3>(input_ptr, colours_ptr, indices_ptr, num_blocks)
+            transform_decorr::<3>(input_ptr, colours_out, indices_out, num_blocks)
         }
         YCoCgVariant::None => unreachable_unchecked(),
     }
@@ -36,8 +37,8 @@ pub(crate) unsafe fn transform_with_decorrelate_generic(
 
 unsafe fn transform_decorr<const VARIANT: u8>(
     mut input_ptr: *const u8,
-    mut colours_ptr: *mut u32,
-    mut indices_ptr: *mut u32,
+    mut colours_out: *mut u32,
+    mut indices_out: *mut u32,
     num_blocks: usize,
 ) {
     let input_end = input_ptr.add(num_blocks * 8);
@@ -72,11 +73,11 @@ unsafe fn transform_decorr<const VARIANT: u8>(
         let decorated_colors = (decorr0.raw_value() as u32) | ((decorr1.raw_value() as u32) << 16);
 
         // Write to separate buffers
-        write_unaligned(colours_ptr, decorated_colors);
-        write_unaligned(indices_ptr, index_value);
+        write_unaligned(colours_out, decorated_colors);
+        write_unaligned(indices_out, index_value);
 
-        colours_ptr = colours_ptr.add(1);
-        indices_ptr = indices_ptr.add(1);
+        colours_out = colours_out.add(1);
+        indices_out = indices_out.add(1);
     }
 }
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
@@ -1,1 +1,152 @@
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx2;
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx512;
+pub mod generic;
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod sse2;
+
+/// Split BC1 blocks from standard interleaved format to separate color/index format,
+/// applying YCoCg-R decorrelation to color endpoints.
+///
+/// # Safety
+///
+/// - `input_ptr` must be valid for reads of `len` bytes
+/// - `output_ptr` must be valid for writes of `len` bytes
+/// - `len` must be divisible by 8
+#[inline]
+pub(crate) unsafe fn transform_with_recorrelate(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    debug_assert!(len % 8 == 0);
+
+    let colors_ptr = output_ptr as *mut u32;
+    let indices_ptr = output_ptr.add(len / 2) as *mut u32;
+    let num_blocks = len / 8;
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    {
+        transform_with_recorrelate_x86(
+            input_ptr,
+            colors_ptr,
+            indices_ptr,
+            num_blocks,
+            decorrelation_mode,
+        );
+    }
+
+    #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+    {
+        generic::transform_with_recorrelate_generic(
+            input_ptr,
+            colors_ptr,
+            indices_ptr,
+            num_blocks,
+            decorrelation_mode,
+        );
+    }
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[inline(always)]
+unsafe fn transform_with_recorrelate_x86(
+    input_ptr: *const u8,
+    colors_ptr: *mut u32,
+    indices_ptr: *mut u32,
+    num_blocks: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    use dxt_lossless_transform_common::cpu_detect::*;
+
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    {
+        #[cfg(feature = "nightly")]
+        if has_avx512f() && has_avx512bw() {
+            avx512::transform_with_recorrelate(
+                input_ptr,
+                colors_ptr,
+                indices_ptr,
+                num_blocks,
+                decorrelation_mode,
+            );
+            return;
+        }
+
+        if has_avx2() {
+            avx2::transform_with_recorrelate(
+                input_ptr,
+                colors_ptr,
+                indices_ptr,
+                num_blocks,
+                decorrelation_mode,
+            );
+            return;
+        }
+
+        if has_sse2() {
+            sse2::transform_with_recorrelate(
+                input_ptr,
+                colors_ptr,
+                indices_ptr,
+                num_blocks,
+                decorrelation_mode,
+            );
+            return;
+        }
+    }
+
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512bw") {
+            avx512::transform_with_recorrelate(
+                input_ptr,
+                colors_ptr,
+                indices_ptr,
+                num_blocks,
+                decorrelation_mode,
+            );
+            return;
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        if cfg!(target_feature = "avx2") {
+            avx2::transform_with_recorrelate(
+                input_ptr,
+                colors_ptr,
+                indices_ptr,
+                num_blocks,
+                decorrelation_mode,
+            );
+            return;
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        if cfg!(target_feature = "sse2") {
+            sse2::transform_with_recorrelate(
+                input_ptr,
+                colors_ptr,
+                indices_ptr,
+                num_blocks,
+                decorrelation_mode,
+            );
+            return;
+        }
+    }
+
+    // Fallback to generic implementation
+    generic::transform_with_recorrelate_generic(
+        input_ptr,
+        colors_ptr,
+        indices_ptr,
+        num_blocks,
+        decorrelation_mode,
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
@@ -57,8 +57,8 @@ pub(crate) unsafe fn transform_with_decorrelate(
 #[inline(always)]
 unsafe fn transform_with_decorrelate_x86(
     input_ptr: *const u8,
-    colors_ptr: *mut u32,
-    indices_ptr: *mut u32,
+    colors_out: *mut u32,
+    indices_out: *mut u32,
     num_blocks: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
@@ -71,8 +71,8 @@ unsafe fn transform_with_decorrelate_x86(
         if has_avx512f() && has_avx512bw() {
             avx512::transform_with_decorrelate(
                 input_ptr,
-                colors_ptr,
-                indices_ptr,
+                colors_out,
+                indices_out,
                 num_blocks,
                 decorrelation_mode,
             );
@@ -82,8 +82,8 @@ unsafe fn transform_with_decorrelate_x86(
         if has_avx2() {
             avx2::transform_with_decorrelate(
                 input_ptr,
-                colors_ptr,
-                indices_ptr,
+                colors_out,
+                indices_out,
                 num_blocks,
                 decorrelation_mode,
             );
@@ -93,8 +93,8 @@ unsafe fn transform_with_decorrelate_x86(
         if has_sse2() {
             sse2::transform_with_decorrelate(
                 input_ptr,
-                colors_ptr,
-                indices_ptr,
+                colors_out,
+                indices_out,
                 num_blocks,
                 decorrelation_mode,
             );
@@ -108,8 +108,8 @@ unsafe fn transform_with_decorrelate_x86(
         if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512bw") {
             avx512::transform_with_decorrelate(
                 input_ptr,
-                colors_ptr,
-                indices_ptr,
+                colors_out,
+                indices_out,
                 num_blocks,
                 decorrelation_mode,
             );
@@ -120,8 +120,8 @@ unsafe fn transform_with_decorrelate_x86(
         if cfg!(target_feature = "avx2") {
             avx2::transform_with_decorrelate(
                 input_ptr,
-                colors_ptr,
-                indices_ptr,
+                colors_out,
+                indices_out,
                 num_blocks,
                 decorrelation_mode,
             );
@@ -132,8 +132,8 @@ unsafe fn transform_with_decorrelate_x86(
         if cfg!(target_feature = "sse2") {
             sse2::transform_with_decorrelate(
                 input_ptr,
-                colors_ptr,
-                indices_ptr,
+                colors_out,
+                indices_out,
                 num_blocks,
                 decorrelation_mode,
             );
@@ -144,8 +144,8 @@ unsafe fn transform_with_decorrelate_x86(
     // Fallback to generic implementation
     generic::transform_with_decorrelate_generic(
         input_ptr,
-        colors_ptr,
-        indices_ptr,
+        colors_out,
+        indices_out,
         num_blocks,
         decorrelation_mode,
     );

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
@@ -18,7 +18,7 @@ pub mod sse2;
 /// - `output_ptr` must be valid for writes of `len` bytes
 /// - `len` must be divisible by 8
 #[inline]
-pub(crate) unsafe fn transform_with_recorrelate(
+pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -32,7 +32,7 @@ pub(crate) unsafe fn transform_with_recorrelate(
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     {
-        transform_with_recorrelate_x86(
+        transform_with_decorrelate_x86(
             input_ptr,
             colors_ptr,
             indices_ptr,
@@ -43,7 +43,7 @@ pub(crate) unsafe fn transform_with_recorrelate(
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        generic::transform_with_recorrelate_generic(
+        generic::transform_with_decorrelate_generic(
             input_ptr,
             colors_ptr,
             indices_ptr,
@@ -55,7 +55,7 @@ pub(crate) unsafe fn transform_with_recorrelate(
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
-unsafe fn transform_with_recorrelate_x86(
+unsafe fn transform_with_decorrelate_x86(
     input_ptr: *const u8,
     colors_ptr: *mut u32,
     indices_ptr: *mut u32,
@@ -69,7 +69,7 @@ unsafe fn transform_with_recorrelate_x86(
     {
         #[cfg(feature = "nightly")]
         if has_avx512f() && has_avx512bw() {
-            avx512::transform_with_recorrelate(
+            avx512::transform_with_decorrelate(
                 input_ptr,
                 colors_ptr,
                 indices_ptr,
@@ -80,7 +80,7 @@ unsafe fn transform_with_recorrelate_x86(
         }
 
         if has_avx2() {
-            avx2::transform_with_recorrelate(
+            avx2::transform_with_decorrelate(
                 input_ptr,
                 colors_ptr,
                 indices_ptr,
@@ -91,7 +91,7 @@ unsafe fn transform_with_recorrelate_x86(
         }
 
         if has_sse2() {
-            sse2::transform_with_recorrelate(
+            sse2::transform_with_decorrelate(
                 input_ptr,
                 colors_ptr,
                 indices_ptr,
@@ -106,7 +106,7 @@ unsafe fn transform_with_recorrelate_x86(
     {
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512bw") {
-            avx512::transform_with_recorrelate(
+            avx512::transform_with_decorrelate(
                 input_ptr,
                 colors_ptr,
                 indices_ptr,
@@ -118,7 +118,7 @@ unsafe fn transform_with_recorrelate_x86(
 
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         if cfg!(target_feature = "avx2") {
-            avx2::transform_with_recorrelate(
+            avx2::transform_with_decorrelate(
                 input_ptr,
                 colors_ptr,
                 indices_ptr,
@@ -130,7 +130,7 @@ unsafe fn transform_with_recorrelate_x86(
 
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
         if cfg!(target_feature = "sse2") {
-            sse2::transform_with_recorrelate(
+            sse2::transform_with_decorrelate(
                 input_ptr,
                 colors_ptr,
                 indices_ptr,
@@ -142,7 +142,7 @@ unsafe fn transform_with_recorrelate_x86(
     }
 
     // Fallback to generic implementation
-    generic::transform_with_recorrelate_generic(
+    generic::transform_with_decorrelate_generic(
         input_ptr,
         colors_ptr,
         indices_ptr,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
@@ -1,21 +1,198 @@
 use crate::transforms::with_recorrelate::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::hint::unreachable_unchecked;
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
+use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::sse2::{
+    decorrelate_ycocg_r_var1_sse2, decorrelate_ycocg_r_var2_sse2, decorrelate_ycocg_r_var3_sse2,
+};
 
-/// SSE2 stub for transform with YCoCg-R decorrelation.
-/// Falls back to generic implementation.
+// Const-generic worker
+#[allow(dead_code)]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "sse2")]
+unsafe fn transform_decorr<const VARIANT: u8>(
+    input_ptr: *const u8,
+    mut colours_ptr: *mut u32,
+    mut indices_ptr: *mut u32,
+    num_blocks: usize,
+) {
+    let mut in_ptr = input_ptr;
+    let blocks8 = num_blocks / 8;
+    for _ in 0..blocks8 {
+        // Load four 16-byte chunks = 8 blocks
+        let data0 = _mm_loadu_si128(in_ptr as *const __m128i);
+        let data1 = _mm_loadu_si128(in_ptr.add(16) as *const __m128i);
+        let data2 = _mm_loadu_si128(in_ptr.add(32) as *const __m128i);
+        let data3 = _mm_loadu_si128(in_ptr.add(48) as *const __m128i);
+        in_ptr = in_ptr.add(64);
+
+        // Split colors and indices using shufps patterns
+        let col0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data0),
+            _mm_castsi128_ps(data1),
+            0x88,
+        ));
+        let col1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data2),
+            _mm_castsi128_ps(data3),
+            0x88,
+        ));
+        let idx0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data0),
+            _mm_castsi128_ps(data1),
+            0xDD,
+        ));
+        let idx1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data2),
+            _mm_castsi128_ps(data3),
+            0xDD,
+        ));
+
+        // Apply decorrelation
+        let rec_lo = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_sse2(col0),
+            2 => decorrelate_ycocg_r_var2_sse2(col0),
+            3 => decorrelate_ycocg_r_var3_sse2(col0),
+            _ => unreachable_unchecked(),
+        };
+        let rec_hi = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_sse2(col1),
+            2 => decorrelate_ycocg_r_var2_sse2(col1),
+            3 => decorrelate_ycocg_r_var3_sse2(col1),
+            _ => unreachable_unchecked(),
+        };
+
+        // Store results
+        _mm_storeu_si128(colours_ptr as *mut __m128i, rec_lo);
+        _mm_storeu_si128((colours_ptr as *mut __m128i).add(1), rec_hi);
+        _mm_storeu_si128(indices_ptr as *mut __m128i, idx0);
+        _mm_storeu_si128((indices_ptr as *mut __m128i).add(1), idx1);
+
+        colours_ptr = colours_ptr.add(8); // 32 bytes
+        indices_ptr = indices_ptr.add(8); // 32 bytes
+    }
+    // Handle any remaining blocks
+    let rem = num_blocks % 8;
+    if rem > 0 {
+        // Map const generic variant to enum for generic fallback
+        let variant_enum = match VARIANT {
+            1 => YCoCgVariant::Variant1,
+            2 => YCoCgVariant::Variant2,
+            3 => YCoCgVariant::Variant3,
+            _ => unreachable_unchecked(),
+        };
+        generic::transform_with_decorrelate_generic(
+            in_ptr,
+            colours_ptr,
+            indices_ptr,
+            rem,
+            variant_enum,
+        );
+    }
+}
+
+// Wrappers for asm inspection
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "sse2")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var1(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<1>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "sse2")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var2(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<2>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "sse2")]
+#[allow(dead_code)]
+pub(crate) unsafe fn transform_decorr_var3(
+    input_ptr: *const u8,
+    colours_out: *mut u32,
+    indices_out: *mut u32,
+    num_blocks: usize,
+) {
+    transform_decorr::<3>(input_ptr, colours_out, indices_out, num_blocks)
+}
+
+// Runtime dispatcher
+#[allow(dead_code)]
 #[inline(always)]
-pub(crate) unsafe fn transform_with_recorrelate(
+pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,
     colours_ptr: *mut u32,
     indices_ptr: *mut u32,
     num_blocks: usize,
-    decorrelation_mode: YCoCgVariant,
+    variant: YCoCgVariant,
 ) {
-    generic::transform_with_recorrelate_generic(
-        input_ptr,
-        colours_ptr,
-        indices_ptr,
-        num_blocks,
-        decorrelation_mode,
-    );
+    match variant {
+        YCoCgVariant::Variant1 => {
+            transform_decorr_var1(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_decorr_var2(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_decorr_var3(input_ptr, colours_ptr, indices_ptr, num_blocks)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_recorrelate::untransform::untransform_with_recorrelate;
+
+    #[rstest]
+    #[case(transform_decorr_var1, YCoCgVariant::Variant1)]
+    #[case(transform_decorr_var2, YCoCgVariant::Variant2)]
+    #[case(transform_decorr_var3, YCoCgVariant::Variant3)]
+    fn sse2_transform_roundtrip(
+        #[case] func: unsafe fn(*const u8, *mut u32, *mut u32, usize),
+        #[case] variant: YCoCgVariant,
+    ) {
+        for num_blocks in 1..=128 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut transformed = vec![0u8; len];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                func(
+                    input.as_ptr(),
+                    transformed.as_mut_ptr() as *mut u32,
+                    transformed.as_mut_ptr().add(len / 2) as *mut u32,
+                    num_blocks,
+                );
+                untransform_with_recorrelate(
+                    transformed.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks * 8,
+                    variant,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "Mismatch SSE2 roundtrip variant {variant:?}"
+            );
+        }
+    }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
@@ -20,7 +20,8 @@ unsafe fn transform_decorr<const VARIANT: u8>(
 ) {
     let mut in_ptr = input_ptr;
     let blocks8 = num_blocks / 8;
-    for _ in 0..blocks8 {
+    let input_end = input_ptr.add(blocks8 * 8 * 8); // blocks8 * 8 blocks per iteration * 8 bytes per block
+    while in_ptr < input_end {
         // Load four 16-byte chunks = 8 blocks
         let data0 = _mm_loadu_si128(in_ptr as *const __m128i);
         let data1 = _mm_loadu_si128(in_ptr.add(16) as *const __m128i);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
@@ -10,7 +10,6 @@ use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::sse2::{
 };
 
 // Const-generic worker
-#[allow(dead_code)]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "sse2")]
 unsafe fn transform_decorr<const VARIANT: u8>(
@@ -97,7 +96,6 @@ unsafe fn transform_decorr<const VARIANT: u8>(
 // Wrappers for asm inspection
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "sse2")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var1(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -109,7 +107,6 @@ pub(crate) unsafe fn transform_decorr_var1(
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "sse2")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var2(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -121,7 +118,6 @@ pub(crate) unsafe fn transform_decorr_var2(
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "sse2")]
-#[allow(dead_code)]
 pub(crate) unsafe fn transform_decorr_var3(
     input_ptr: *const u8,
     colours_out: *mut u32,
@@ -132,7 +128,6 @@ pub(crate) unsafe fn transform_decorr_var3(
 }
 
 // Runtime dispatcher
-#[allow(dead_code)]
 #[inline(always)]
 pub(crate) unsafe fn transform_with_decorrelate(
     input_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
@@ -19,7 +19,7 @@ unsafe fn transform_decorr<const VARIANT: u8>(
     num_blocks: usize,
 ) {
     let mut in_ptr = input_ptr;
-    let blocks8 = num_blocks / 8;
+    let blocks8 = num_blocks / 8; // round down via division
     let input_end = input_ptr.add(blocks8 * 8 * 8); // blocks8 * 8 blocks per iteration * 8 bytes per block
     while in_ptr < input_end {
         // Load four 16-byte chunks = 8 blocks

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
@@ -30,68 +30,65 @@ unsafe fn transform_decorr<const VARIANT: u8>(
         in_ptr = in_ptr.add(64);
 
         // Split colors and indices using shufps patterns
-        let col0 = _mm_castps_si128(_mm_shuffle_ps(
+        let colors0 = _mm_castps_si128(_mm_shuffle_ps(
             _mm_castsi128_ps(data0),
             _mm_castsi128_ps(data1),
             0x88,
         ));
-        let col1 = _mm_castps_si128(_mm_shuffle_ps(
+        let colors1 = _mm_castps_si128(_mm_shuffle_ps(
             _mm_castsi128_ps(data2),
             _mm_castsi128_ps(data3),
             0x88,
         ));
-        let idx0 = _mm_castps_si128(_mm_shuffle_ps(
+        let indices0 = _mm_castps_si128(_mm_shuffle_ps(
             _mm_castsi128_ps(data0),
             _mm_castsi128_ps(data1),
             0xDD,
         ));
-        let idx1 = _mm_castps_si128(_mm_shuffle_ps(
+        let indices1 = _mm_castps_si128(_mm_shuffle_ps(
             _mm_castsi128_ps(data2),
             _mm_castsi128_ps(data3),
             0xDD,
         ));
 
         // Apply decorrelation
-        let rec_lo = match VARIANT {
-            1 => decorrelate_ycocg_r_var1_sse2(col0),
-            2 => decorrelate_ycocg_r_var2_sse2(col0),
-            3 => decorrelate_ycocg_r_var3_sse2(col0),
+        let colors0 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_sse2(colors0),
+            2 => decorrelate_ycocg_r_var2_sse2(colors0),
+            3 => decorrelate_ycocg_r_var3_sse2(colors0),
             _ => unreachable_unchecked(),
         };
-        let rec_hi = match VARIANT {
-            1 => decorrelate_ycocg_r_var1_sse2(col1),
-            2 => decorrelate_ycocg_r_var2_sse2(col1),
-            3 => decorrelate_ycocg_r_var3_sse2(col1),
+        let colors1 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_sse2(colors1),
+            2 => decorrelate_ycocg_r_var2_sse2(colors1),
+            3 => decorrelate_ycocg_r_var3_sse2(colors1),
             _ => unreachable_unchecked(),
         };
 
         // Store results
-        _mm_storeu_si128(colours_ptr as *mut __m128i, rec_lo);
-        _mm_storeu_si128((colours_ptr as *mut __m128i).add(1), rec_hi);
-        _mm_storeu_si128(indices_ptr as *mut __m128i, idx0);
-        _mm_storeu_si128((indices_ptr as *mut __m128i).add(1), idx1);
+        _mm_storeu_si128(colours_ptr as *mut __m128i, colors0);
+        _mm_storeu_si128((colours_ptr as *mut __m128i).add(1), colors1);
+        _mm_storeu_si128(indices_ptr as *mut __m128i, indices0);
+        _mm_storeu_si128((indices_ptr as *mut __m128i).add(1), indices1);
 
         colours_ptr = colours_ptr.add(8); // 32 bytes
         indices_ptr = indices_ptr.add(8); // 32 bytes
     }
     // Handle any remaining blocks
-    let rem = num_blocks % 8;
-    if rem > 0 {
-        // Map const generic variant to enum for generic fallback
-        let variant_enum = match VARIANT {
-            1 => YCoCgVariant::Variant1,
-            2 => YCoCgVariant::Variant2,
-            3 => YCoCgVariant::Variant3,
-            _ => unreachable_unchecked(),
-        };
-        generic::transform_with_decorrelate_generic(
-            in_ptr,
-            colours_ptr,
-            indices_ptr,
-            rem,
-            variant_enum,
-        );
-    }
+    let remaining_blocks = num_blocks % 8;
+    let variant_enum = match VARIANT {
+        1 => YCoCgVariant::Variant1,
+        2 => YCoCgVariant::Variant2,
+        3 => YCoCgVariant::Variant3,
+        _ => unreachable_unchecked(),
+    };
+    generic::transform_with_decorrelate_generic(
+        in_ptr,
+        colours_ptr,
+        indices_ptr,
+        remaining_blocks,
+        variant_enum,
+    );
 }
 
 // Wrappers for asm inspection

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/sse2.rs
@@ -1,0 +1,21 @@
+use crate::transforms::with_recorrelate::transform::generic;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+
+/// SSE2 stub for transform with YCoCg-R decorrelation.
+/// Falls back to generic implementation.
+#[inline(always)]
+pub(crate) unsafe fn transform_with_recorrelate(
+    input_ptr: *const u8,
+    colours_ptr: *mut u32,
+    indices_ptr: *mut u32,
+    num_blocks: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    generic::transform_with_recorrelate_generic(
+        input_ptr,
+        colours_ptr,
+        indices_ptr,
+        num_blocks,
+        decorrelation_mode,
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/avx2.rs
@@ -170,12 +170,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/avx512.rs
@@ -171,12 +171,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/avx512.rs
@@ -10,21 +10,21 @@ use dxt_lossless_transform_common::intrinsics::color_565::recorrelate::avx512::{
 };
 
 pub(crate) unsafe fn untransform_with_recorrelate(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
     match decorrelation_mode {
         YCoCgVariant::Variant1 => {
-            untransform_recorr_var1(colors_ptr, indices_ptr, output_ptr, num_blocks);
+            untransform_recorr_var1(colors_in, indices_in, output_ptr, num_blocks);
         }
         YCoCgVariant::Variant2 => {
-            untransform_recorr_var2(colors_ptr, indices_ptr, output_ptr, num_blocks);
+            untransform_recorr_var2(colors_in, indices_in, output_ptr, num_blocks);
         }
         YCoCgVariant::Variant3 => {
-            untransform_recorr_var3(colors_ptr, indices_ptr, output_ptr, num_blocks);
+            untransform_recorr_var3(colors_in, indices_in, output_ptr, num_blocks);
         }
         YCoCgVariant::None => {
             // This should be unreachable based on the calling context
@@ -36,37 +36,37 @@ pub(crate) unsafe fn untransform_with_recorrelate(
 // Wrapper functions for assembly inspection using `cargo asm`
 
 unsafe fn untransform_recorr_var1(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    untransform_recorr::<1>(colors_ptr, indices_ptr, output_ptr, num_blocks)
+    untransform_recorr::<1>(colors_in, indices_in, output_ptr, num_blocks)
 }
 
 unsafe fn untransform_recorr_var2(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    untransform_recorr::<2>(colors_ptr, indices_ptr, output_ptr, num_blocks)
+    untransform_recorr::<2>(colors_in, indices_in, output_ptr, num_blocks)
 }
 
 unsafe fn untransform_recorr_var3(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    untransform_recorr::<3>(colors_ptr, indices_ptr, output_ptr, num_blocks)
+    untransform_recorr::<3>(colors_in, indices_in, output_ptr, num_blocks)
 }
 
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512bw")]
 unsafe fn untransform_recorr<const VARIANT: u8>(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
@@ -75,59 +75,57 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
     // Calculate number of blocks that can be processed in vectorized chunks
     let vectorized_blocks = num_blocks & !31; // Round down to multiple of 32
 
-    if vectorized_blocks > 0 {
-        // Set up permutation patterns for interleaving colors and indices (moved outside loop)
-        const PERM_LOW_BYTES: [i8; 16] = [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23];
-        const PERM_HIGH_BYTES: [i8; 16] =
-            [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31];
+    // Set up permutation patterns for interleaving colors and indices (moved outside loop)
+    const PERM_LOW_BYTES: [i8; 16] = [0, 16, 1, 17, 2, 18, 3, 19, 4, 20, 5, 21, 6, 22, 7, 23];
+    const PERM_HIGH_BYTES: [i8; 16] =
+        [8, 24, 9, 25, 10, 26, 11, 27, 12, 28, 13, 29, 14, 30, 15, 31];
 
-        let perm_low = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_LOW_BYTES.as_ptr() as *const _));
-        let perm_high = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_HIGH_BYTES.as_ptr() as *const _));
+    let perm_low = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_LOW_BYTES.as_ptr() as *const _));
+    let perm_high = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_HIGH_BYTES.as_ptr() as *const _));
 
-        let colors_end = colors_ptr.add(vectorized_blocks);
-        let mut current_colors_ptr = colors_ptr;
-        let mut current_indices_ptr = indices_ptr;
-        let mut current_output_ptr = output_ptr;
+    let colors_end = colors_in.add(vectorized_blocks);
+    let mut current_colors_ptr = colors_in;
+    let mut current_indices_ptr = indices_in;
+    let mut current_output_ptr = output_ptr;
 
-        // Main SIMD processing loop - handles 32 blocks per iteration (unroll 2)
-        while current_colors_ptr < colors_end {
-            // Load first set of colors and indices (64 bytes each)
-            let colors_0 = _mm512_loadu_si512(current_colors_ptr as *const __m512i);
-            let colors_1 = _mm512_loadu_si512(current_colors_ptr.add(16) as *const __m512i);
+    // Main SIMD processing loop - handles 32 blocks per iteration (unroll 2)
+    while current_colors_ptr < colors_end {
+        // Load first set of colors and indices (64 bytes each)
+        let colors_0 = _mm512_loadu_si512(current_colors_ptr as *const __m512i);
+        let colors_1 = _mm512_loadu_si512(current_colors_ptr.add(16) as *const __m512i);
 
-            let indices_0 = _mm512_loadu_si512(current_indices_ptr as *const __m512i);
-            let indices_1 = _mm512_loadu_si512(current_indices_ptr.add(16) as *const __m512i);
+        let indices_0 = _mm512_loadu_si512(current_indices_ptr as *const __m512i);
+        let indices_1 = _mm512_loadu_si512(current_indices_ptr.add(16) as *const __m512i);
 
-            // Apply recorrelation to the colors based on the variant
-            let recorrelated_colors_0 = match VARIANT {
-                1 => recorrelate_ycocg_r_var1_avx512(colors_0),
-                2 => recorrelate_ycocg_r_var2_avx512(colors_0),
-                3 => recorrelate_ycocg_r_var3_avx512(colors_0),
-                _ => unreachable_unchecked(),
-            };
-            let recorrelated_colors_1 = match VARIANT {
-                1 => recorrelate_ycocg_r_var1_avx512(colors_1),
-                2 => recorrelate_ycocg_r_var2_avx512(colors_1),
-                3 => recorrelate_ycocg_r_var3_avx512(colors_1),
-                _ => unreachable_unchecked(),
-            };
+        // Apply recorrelation to the colors based on the variant
+        let recorrelated_colors_0 = match VARIANT {
+            1 => recorrelate_ycocg_r_var1_avx512(colors_0),
+            2 => recorrelate_ycocg_r_var2_avx512(colors_0),
+            3 => recorrelate_ycocg_r_var3_avx512(colors_0),
+            _ => unreachable_unchecked(),
+        };
+        let recorrelated_colors_1 = match VARIANT {
+            1 => recorrelate_ycocg_r_var1_avx512(colors_1),
+            2 => recorrelate_ycocg_r_var2_avx512(colors_1),
+            3 => recorrelate_ycocg_r_var3_avx512(colors_1),
+            _ => unreachable_unchecked(),
+        };
 
-            // Apply permutations to interleave colors and indices (equivalent to vpermt2d instructions)
-            let output_0 = _mm512_permutex2var_epi32(recorrelated_colors_0, perm_low, indices_0);
-            let output_1 = _mm512_permutex2var_epi32(recorrelated_colors_0, perm_high, indices_0);
-            let output_2 = _mm512_permutex2var_epi32(recorrelated_colors_1, perm_low, indices_1);
-            let output_3 = _mm512_permutex2var_epi32(recorrelated_colors_1, perm_high, indices_1);
+        // Apply permutations to interleave colors and indices (equivalent to vpermt2d instructions)
+        let output_0 = _mm512_permutex2var_epi32(recorrelated_colors_0, perm_low, indices_0);
+        let output_1 = _mm512_permutex2var_epi32(recorrelated_colors_0, perm_high, indices_0);
+        let output_2 = _mm512_permutex2var_epi32(recorrelated_colors_1, perm_low, indices_1);
+        let output_3 = _mm512_permutex2var_epi32(recorrelated_colors_1, perm_high, indices_1);
 
-            // Store results (equivalent to vmovdqu64 instructions)
-            _mm512_storeu_si512(current_output_ptr as *mut __m512i, output_0);
-            _mm512_storeu_si512(current_output_ptr.add(64) as *mut __m512i, output_1);
-            _mm512_storeu_si512(current_output_ptr.add(128) as *mut __m512i, output_2);
-            _mm512_storeu_si512(current_output_ptr.add(192) as *mut __m512i, output_3);
+        // Store results (equivalent to vmovdqu64 instructions)
+        _mm512_storeu_si512(current_output_ptr as *mut __m512i, output_0);
+        _mm512_storeu_si512(current_output_ptr.add(64) as *mut __m512i, output_1);
+        _mm512_storeu_si512(current_output_ptr.add(128) as *mut __m512i, output_2);
+        _mm512_storeu_si512(current_output_ptr.add(192) as *mut __m512i, output_3);
 
-            current_colors_ptr = current_colors_ptr.add(32);
-            current_indices_ptr = current_indices_ptr.add(32);
-            current_output_ptr = current_output_ptr.add(256);
-        }
+        current_colors_ptr = current_colors_ptr.add(32);
+        current_indices_ptr = current_indices_ptr.add(32);
+        current_output_ptr = current_output_ptr.add(256);
     }
 
     // === Scalar Fallback for Remaining Blocks ===
@@ -141,8 +139,8 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
         _ => unreachable_unchecked(),
     };
     super::generic::untransform_with_recorrelate_generic(
-        colors_ptr.add(vectorized_blocks),
-        indices_ptr.add(vectorized_blocks),
+        colors_in.add(vectorized_blocks),
+        indices_in.add(vectorized_blocks),
         output_ptr.add(vectorized_blocks * 8),
         remaining_count,
         variant,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/generic.rs
@@ -59,7 +59,8 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
     mut output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    for _ in 0..num_blocks {
+    let colors_end = colors_ptr.add(num_blocks);
+    while colors_ptr < colors_end {
         // Read both values first (better instruction scheduling)
         let color_raw = read_unaligned(colors_ptr);
         let index_value = read_unaligned(indices_ptr);
@@ -102,8 +103,8 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::*;
+    use crate::test_prelude::*;
 
     #[rstest]
     #[case(untransform_recorr_var1, YCoCgVariant::Variant1)]

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/generic.rs
@@ -119,12 +119,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/sse2.rs
@@ -11,21 +11,21 @@ use dxt_lossless_transform_common::intrinsics::color_565::recorrelate::sse2::{
 use crate::transforms::with_recorrelate::untransform::generic::untransform_with_recorrelate_generic;
 
 pub(crate) unsafe fn untransform_with_recorrelate(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
     match decorrelation_mode {
         YCoCgVariant::Variant1 => {
-            untransform_recorr_var1(colors_ptr, indices_ptr, output_ptr, num_blocks);
+            untransform_recorr_var1(colors_in, indices_in, output_ptr, num_blocks);
         }
         YCoCgVariant::Variant2 => {
-            untransform_recorr_var2(colors_ptr, indices_ptr, output_ptr, num_blocks);
+            untransform_recorr_var2(colors_in, indices_in, output_ptr, num_blocks);
         }
         YCoCgVariant::Variant3 => {
-            untransform_recorr_var3(colors_ptr, indices_ptr, output_ptr, num_blocks);
+            untransform_recorr_var3(colors_in, indices_in, output_ptr, num_blocks);
         }
         YCoCgVariant::None => {
             // This should be unreachable based on the calling context
@@ -37,36 +37,36 @@ pub(crate) unsafe fn untransform_with_recorrelate(
 // Wrapper functions for assembly inspection using `cargo asm`
 
 unsafe fn untransform_recorr_var1(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    untransform_recorr::<1>(colors_ptr, indices_ptr, output_ptr, num_blocks)
+    untransform_recorr::<1>(colors_in, indices_in, output_ptr, num_blocks)
 }
 
 unsafe fn untransform_recorr_var2(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    untransform_recorr::<2>(colors_ptr, indices_ptr, output_ptr, num_blocks)
+    untransform_recorr::<2>(colors_in, indices_in, output_ptr, num_blocks)
 }
 
 unsafe fn untransform_recorr_var3(
-    colors_ptr: *const u32,
-    indices_ptr: *const u32,
+    colors_in: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     num_blocks: usize,
 ) {
-    untransform_recorr::<3>(colors_ptr, indices_ptr, output_ptr, num_blocks)
+    untransform_recorr::<3>(colors_in, indices_in, output_ptr, num_blocks)
 }
 
 #[target_feature(enable = "sse2")]
 unsafe fn untransform_recorr<const VARIANT: u8>(
-    mut colors_ptr: *const u32,
-    mut indices_ptr: *const u32,
+    mut colors_in: *const u32,
+    mut indices_in: *const u32,
     mut output_ptr: *mut u8,
     num_blocks: usize,
 ) {
@@ -74,65 +74,63 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
     // Process 8 blocks at a time using SSE2 SIMD instructions (unroll 2)
     // Calculate number of blocks that can be processed in vectorized chunks
     let vectorized_blocks = num_blocks & !7; // Round down to multiple of 8
-    if vectorized_blocks > 0 {
-        let colors_end = colors_ptr.add(vectorized_blocks);
+    let colors_end = colors_in.add(vectorized_blocks);
 
-        // Main SIMD processing loop - handles 8 blocks per iteration (unroll 2)
-        while colors_ptr < colors_end {
-            // Load colors and indices (16 bytes each)
-            // This corresponds to 8 blocks worth of data
-            let colors_0 = _mm_loadu_si128(colors_ptr as *const __m128i);
-            let colors_1 = _mm_loadu_si128(colors_ptr.add(4) as *const __m128i);
+    // Main SIMD processing loop - handles 8 blocks per iteration (unroll 2)
+    while colors_in < colors_end {
+        // Load colors and indices (16 bytes each)
+        // This corresponds to 8 blocks worth of data
+        let colors_0 = _mm_loadu_si128(colors_in as *const __m128i);
+        let colors_1 = _mm_loadu_si128(colors_in.add(4) as *const __m128i);
 
-            let indices_0 = _mm_loadu_si128(indices_ptr as *const __m128i);
-            let indices_1 = _mm_loadu_si128(indices_ptr.add(4) as *const __m128i);
+        let indices_0 = _mm_loadu_si128(indices_in as *const __m128i);
+        let indices_1 = _mm_loadu_si128(indices_in.add(4) as *const __m128i);
 
-            // Apply recorrelation to the colors based on the variant
-            let recorrelated_colors_0 = match VARIANT {
-                1 => recorrelate_ycocg_r_var1_sse2(colors_0),
-                2 => recorrelate_ycocg_r_var2_sse2(colors_0),
-                3 => recorrelate_ycocg_r_var3_sse2(colors_0),
-                _ => unreachable_unchecked(),
-            };
+        // Apply recorrelation to the colors based on the variant
+        let recorrelated_colors_0 = match VARIANT {
+            1 => recorrelate_ycocg_r_var1_sse2(colors_0),
+            2 => recorrelate_ycocg_r_var2_sse2(colors_0),
+            3 => recorrelate_ycocg_r_var3_sse2(colors_0),
+            _ => unreachable_unchecked(),
+        };
 
-            let recorrelated_colors_1 = match VARIANT {
-                1 => recorrelate_ycocg_r_var1_sse2(colors_1),
-                2 => recorrelate_ycocg_r_var2_sse2(colors_1),
-                3 => recorrelate_ycocg_r_var3_sse2(colors_1),
-                _ => unreachable_unchecked(),
-            };
+        let recorrelated_colors_1 = match VARIANT {
+            1 => recorrelate_ycocg_r_var1_sse2(colors_1),
+            2 => recorrelate_ycocg_r_var2_sse2(colors_1),
+            3 => recorrelate_ycocg_r_var3_sse2(colors_1),
+            _ => unreachable_unchecked(),
+        };
 
-            // Save copies for high parts (equivalent to movaps in assembly)
-            let colors_0_copy = recorrelated_colors_0;
-            let colors_1_copy = recorrelated_colors_1;
+        // Save copies for high parts (equivalent to movaps in assembly)
+        let colors_0_copy = recorrelated_colors_0;
+        let colors_1_copy = recorrelated_colors_1;
 
-            // Unpack all blocks - interleave colors and indices
-            // punpckldq: interleave low 32-bit values
-            let interleaved_0 = _mm_unpacklo_epi32(recorrelated_colors_0, indices_0); // color0,index0,color1,index1
-            let interleaved_1 = _mm_unpacklo_epi32(recorrelated_colors_1, indices_1); // color4,index4,color5,index5
+        // Unpack all blocks - interleave colors and indices
+        // punpckldq: interleave low 32-bit values
+        let interleaved_0 = _mm_unpacklo_epi32(recorrelated_colors_0, indices_0); // color0,index0,color1,index1
+        let interleaved_1 = _mm_unpacklo_epi32(recorrelated_colors_1, indices_1); // color4,index4,color5,index5
 
-            // punpckhdq: interleave high 32-bit values
-            let interleaved_2 = _mm_unpackhi_epi32(colors_0_copy, indices_0); // color2,index2,color3,index3
-            let interleaved_3 = _mm_unpackhi_epi32(colors_1_copy, indices_1); // color6,index6,color7,index7
+        // punpckhdq: interleave high 32-bit values
+        let interleaved_2 = _mm_unpackhi_epi32(colors_0_copy, indices_0); // color2,index2,color3,index3
+        let interleaved_3 = _mm_unpackhi_epi32(colors_1_copy, indices_1); // color6,index6,color7,index7
 
-            // Store all results (64 bytes total)
-            _mm_storeu_si128(output_ptr as *mut __m128i, interleaved_0);
-            _mm_storeu_si128(output_ptr.add(16) as *mut __m128i, interleaved_2);
-            _mm_storeu_si128(output_ptr.add(32) as *mut __m128i, interleaved_1);
-            _mm_storeu_si128(output_ptr.add(48) as *mut __m128i, interleaved_3);
+        // Store all results (64 bytes total)
+        _mm_storeu_si128(output_ptr as *mut __m128i, interleaved_0);
+        _mm_storeu_si128(output_ptr.add(16) as *mut __m128i, interleaved_2);
+        _mm_storeu_si128(output_ptr.add(32) as *mut __m128i, interleaved_1);
+        _mm_storeu_si128(output_ptr.add(48) as *mut __m128i, interleaved_3);
 
-            colors_ptr = colors_ptr.add(8);
-            indices_ptr = indices_ptr.add(8);
-            output_ptr = output_ptr.add(64);
-        }
+        colors_in = colors_in.add(8);
+        indices_in = indices_in.add(8);
+        output_ptr = output_ptr.add(64);
     }
 
     // === Fallback for Remaining Blocks ===
     // Process any remaining blocks using generic implementation
     let remaining_blocks = num_blocks - vectorized_blocks;
     untransform_with_recorrelate_generic(
-        colors_ptr,
-        indices_ptr,
+        colors_in,
+        indices_in,
         output_ptr,
         remaining_blocks,
         match VARIANT {

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/sse2.rs
@@ -175,12 +175,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/mod.rs
@@ -50,7 +50,7 @@ pub mod untransform;
 /// - indices_ptr must be valid for writes of block_count * 4 bytes
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn transform_with_split_colour(
+pub(crate) unsafe fn transform_with_split_colour(
     input_ptr: *const u8,
     color0_ptr: *mut u16,
     color1_ptr: *mut u16,
@@ -77,7 +77,7 @@ pub unsafe fn transform_with_split_colour(
 /// - output_ptr must be valid for writes of block_count * 8 bytes
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn untransform_with_split_colour(
+pub(crate) unsafe fn untransform_with_split_colour(
     color0_ptr: *const u16,
     color1_ptr: *const u16,
     indices_ptr: *const u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/mod.rs
@@ -39,6 +39,33 @@
 pub mod transform;
 pub mod untransform;
 
+/// Transform BC1 data from standard interleaved format to three separate arrays
+/// (color0, color1, indices) using best known implementation for current CPU.
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of block_count * 8 bytes
+/// - color0_ptr must be valid for writes of block_count * 2 bytes
+/// - color1_ptr must be valid for writes of block_count * 2 bytes
+/// - indices_ptr must be valid for writes of block_count * 4 bytes
+/// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
+#[inline]
+pub unsafe fn transform_with_split_colour(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    transform::transform_with_split_colour(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+    );
+}
+
 /// Transform BC1 data from three separate arrays (color0, color1, indices) back to
 /// standard interleaved format using best known implementation for current CPU.
 ///

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx2.rs
@@ -8,23 +8,111 @@ use core::arch::x86_64::*;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx2")]
 pub(crate) unsafe fn transform_with_split_colour(
-    input_ptr: *const u8,
-    color0_ptr: *mut u16,
-    color1_ptr: *mut u16,
-    indices_ptr: *mut u32,
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
     block_count: usize,
 ) {
-    // TODO: implement AVX2 optimized transform
+    let len = block_count * 8; // BC1 block size is 8 bytes
+    debug_assert!(len % 8 == 0);
+
+    // Process as many 128-byte blocks as possible (16 BC1 blocks)
+    let aligned_len = len - (len % 128);
+
+    // Process aligned blocks using intrinsics
+    let aligned_end = input_ptr.add(aligned_len);
+    let permute_idx = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+
+    while input_ptr < aligned_end {
+        // Load all 128 bytes first to utilize memory pipeline
+        let input_0 = _mm256_loadu_si256(input_ptr as *const __m256i);
+        let input_1 = _mm256_loadu_si256(input_ptr.add(32) as *const __m256i);
+        let input_2 = _mm256_loadu_si256(input_ptr.add(64) as *const __m256i);
+        let input_3 = _mm256_loadu_si256(input_ptr.add(96) as *const __m256i);
+        input_ptr = input_ptr.add(128);
+
+        // Do all shuffles together to utilize shuffle units
+        // Colors: vshufps with 0b10001000 (136) extracts elements 0,2 from each 128-bit lane
+        // We separate only the color components from the input blocks.
+        let colors_only_0 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_0),
+            _mm256_castsi256_ps(input_1),
+            0b10001000,
+        );
+
+        let colors_only_1 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_2),
+            _mm256_castsi256_ps(input_3),
+            0b10001000,
+        );
+
+        // Indices: vshufps with 0b11011101 (221) extracts elements 1,3 from each 128-bit lane
+        let indices_shuffled_0 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_0),
+            _mm256_castsi256_ps(input_1),
+            0b11011101,
+        );
+        let indices_blocks_0 =
+            _mm256_permute4x64_epi64(_mm256_castps_si256(indices_shuffled_0), 0b11011000); // arrange indices (216)
+
+        let indices_shuffled_1 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_2),
+            _mm256_castsi256_ps(input_3),
+            0b11011101,
+        );
+        let indices_blocks_1 =
+            _mm256_permute4x64_epi64(_mm256_castps_si256(indices_shuffled_1), 0b11011000); // arrange indices (216)
+
+        // We now group the colours into u32s of color0 and color1 components.
+        let colours_u32_grouped_0_lo =
+            _mm256_shufflelo_epi16(_mm256_castps_si256(colors_only_0), 0b11_01_10_00);
+        let colours_u32_grouped_0 = _mm256_shufflehi_epi16(colours_u32_grouped_0_lo, 0b11_01_10_00);
+
+        let colours_u32_grouped_1_lo =
+            _mm256_shufflelo_epi16(_mm256_castps_si256(colors_only_1), 0b11_01_10_00);
+        let colours_u32_grouped_1 = _mm256_shufflehi_epi16(colours_u32_grouped_1_lo, 0b11_01_10_00);
+
+        let colors_grouped_0 = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(colours_u32_grouped_0),
+            _mm256_castsi256_ps(colours_u32_grouped_1),
+            0b10_00_10_00,
+        ));
+        let colors_grouped_1 = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(colours_u32_grouped_0),
+            _mm256_castsi256_ps(colours_u32_grouped_1),
+            0b11_01_11_01,
+        ));
+
+        // We now have the correct output, but the data is interleaved across lanes.
+        // i.e. First u32 in first lane, then first u32 in second lane, etc.
+        // We need to merge these u32s across lanes. Permute + unpack seems to be the fastest way.
+        // Re-order the 32-bit words to `[0,4,1,5,2,6,3,7]` so the two 128-bit lanes are interleaved.
+        let colors_blocks_0 = _mm256_permutevar8x32_epi32(colors_grouped_0, permute_idx);
+        let colors_blocks_1 = _mm256_permutevar8x32_epi32(colors_grouped_1, permute_idx);
+
+        // Store all results together to utilize store pipeline
+        _mm256_storeu_si256(color0_ptr as *mut __m256i, colors_blocks_0); // Store colors
+        _mm256_storeu_si256(color1_ptr as *mut __m256i, colors_blocks_1); // Store colors
+        color0_ptr = color0_ptr.add(16); // color0_ptr += 32 bytes / 2 = 16 u16s
+        color1_ptr = color1_ptr.add(16); // color1_ptr += 32 bytes / 2 = 16 u16s
+
+        _mm256_storeu_si256(indices_ptr as *mut __m256i, indices_blocks_0); // Store indices
+        _mm256_storeu_si256(indices_ptr.add(8) as *mut __m256i, indices_blocks_1); // Store indices (@ +32 bytes)
+        indices_ptr = indices_ptr.add(16); // indices_ptr += 64 bytes / 4 = 16 u32s
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining_blocks = (len - aligned_len) / 8;
     generic::transform_with_split_colour(
         input_ptr,
         color0_ptr,
         color1_ptr,
         indices_ptr,
-        block_count,
+        remaining_blocks,
     );
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,4 +152,3 @@ mod tests {
         }
     }
 }
-*/

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx2.rs
@@ -1,0 +1,67 @@
+use crate::transforms::with_split_colour::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// AVX2 implementation for split-colour transform.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn transform_with_split_colour(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    // TODO: implement AVX2 optimized transform
+    generic::transform_with_split_colour(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+    );
+}
+
+/*
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour::untransform::untransform_with_split_colour;
+
+    #[rstest]
+    fn avx2_transform_roundtrip() {
+        for num_blocks in 1..=128 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut colour0 = vec![0u16; num_blocks];
+            let mut colour1 = vec![0u16; num_blocks];
+            let mut indices = vec![0u32; num_blocks];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                transform_with_split_colour(
+                    input.as_ptr(),
+                    colour0.as_mut_ptr(),
+                    colour1.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    num_blocks,
+                );
+                untransform_with_split_colour(
+                    colour0.as_ptr(),
+                    colour1.as_ptr(),
+                    indices.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "Mismatch AVX2 roundtrip split-colour",
+            );
+        }
+    }
+}
+*/

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx2.rs
@@ -121,6 +121,10 @@ mod tests {
 
     #[rstest]
     fn avx2_transform_roundtrip() {
+        if !has_avx2() {
+            return;
+        }
+
         for num_blocks in 1..=128 {
             let input = generate_bc1_test_data(num_blocks);
             let len = input.len();

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx512.rs
@@ -4,28 +4,165 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-/// AVX512 implementation for split-colour transform.
+/// AVX512 implementation for split‐colour transform.
+///
+/// This uses the same permutation approach as [`permute_512_with_separate_pointers`]
+/// but additionally splits the joined colour dword into separate `color0` and
+/// `color1` arrays.
+///
+/// Safety invariants are identical to the generic implementation.
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+#[allow(clippy::identity_op)]
+#[no_mangle]
 pub(crate) unsafe fn transform_with_split_colour(
-    input_ptr: *const u8,
-    color0_ptr: *mut u16,
-    color1_ptr: *mut u16,
-    indices_ptr: *mut u32,
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
     block_count: usize,
 ) {
-    // TODO: implement AVX512 optimized transform
+    debug_assert!(block_count > 0);
+
+    // Number of blocks that can be processed per 256-byte iteration (32 BC1 blocks).
+    const BLOCKS_PER_ITER: usize = 32;
+
+    // Byte permutation indices for vpermt2d to gather colour and index dwords.
+    // Same values as the standard AVX512 split implementation.
+    const PERM_COLORS_BYTES: [i8; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+    const PERM_INDICES_BYTES: [i8; 16] =
+        [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31];
+
+    // Pre-compute permutation vectors for dword gathers (extend i8 -> i32 as required by vpermt2d).
+    let perm_colors = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_COLORS_BYTES.as_ptr() as *const _));
+    let perm_indices =
+        _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+    // Pre-compute epi16 permutation vectors that directly extract colour0/colour1 words.
+    // Each entry selects a 16-bit lane from either `colors_0` (0-31) or `colors_1` (32-63).
+    // colour0 = low 16-bits  (even lanes), colour1 = high 16-bits (odd lanes).
+    const PERM_COLOR0_EPI16: [i16; 32] = [
+        0,
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        24,
+        26,
+        28,
+        30,
+        0 + 32,
+        2 + 32,
+        4 + 32,
+        6 + 32,
+        8 + 32,
+        10 + 32,
+        12 + 32,
+        14 + 32,
+        16 + 32,
+        18 + 32,
+        20 + 32,
+        22 + 32,
+        24 + 32,
+        26 + 32,
+        28 + 32,
+        30 + 32,
+    ];
+    const PERM_COLOR1_EPI16: [i16; 32] = [
+        1,
+        3,
+        5,
+        7,
+        9,
+        11,
+        13,
+        15,
+        17,
+        19,
+        21,
+        23,
+        25,
+        27,
+        29,
+        31,
+        1 + 32,
+        3 + 32,
+        5 + 32,
+        7 + 32,
+        9 + 32,
+        11 + 32,
+        13 + 32,
+        15 + 32,
+        17 + 32,
+        19 + 32,
+        21 + 32,
+        23 + 32,
+        25 + 32,
+        27 + 32,
+        29 + 32,
+        31 + 32,
+    ];
+
+    let perm_color0_epi16 = _mm512_loadu_si512(PERM_COLOR0_EPI16.as_ptr() as *const __m512i);
+    let perm_color1_epi16 = _mm512_loadu_si512(PERM_COLOR1_EPI16.as_ptr() as *const __m512i);
+
+    // Aligned block count that fits full iterations.
+    let aligned_blocks = block_count - (block_count % BLOCKS_PER_ITER);
+    let aligned_end_input = input_ptr.add(aligned_blocks * 8); // 8 bytes per BC1 block
+
+    while input_ptr < aligned_end_input {
+        // Load 256 bytes (4 × 64-byte ZMM registers) = 32 BC1 blocks.
+        let in0 = _mm512_loadu_si512(input_ptr as *const __m512i);
+        let in1 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+        let in2 = _mm512_loadu_si512(input_ptr.add(128) as *const __m512i);
+        let in3 = _mm512_loadu_si512(input_ptr.add(192) as *const __m512i);
+        input_ptr = input_ptr.add(256);
+
+        // Note: LLVM optimizes this away to intrinsics like vpermt2w + vpermt2w.
+        // And it is correct. I'm glad I wrote it with intrinsics this time, not inline asm.
+        // Gather colour and index dwords using vpermt2d equivalent.
+        let colors_0 = _mm512_permutex2var_epi32(in0, perm_colors, in1);
+        let colors_1 = _mm512_permutex2var_epi32(in2, perm_colors, in3);
+
+        let indices_0 = _mm512_permutex2var_epi32(in0, perm_indices, in1);
+        let indices_1 = _mm512_permutex2var_epi32(in2, perm_indices, in3);
+
+        // Extract colour0 and colour1 words directly with epi16 permutation.
+        let color0_packed = _mm512_permutex2var_epi16(colors_0, perm_color0_epi16, colors_1);
+        let color1_packed = _mm512_permutex2var_epi16(colors_0, perm_color1_epi16, colors_1);
+
+        // Store colour0 and colour1 (64 bytes each).
+        _mm512_storeu_si512(color0_ptr as *mut __m512i, color0_packed);
+        _mm512_storeu_si512(color1_ptr as *mut __m512i, color1_packed);
+        color0_ptr = color0_ptr.add(BLOCKS_PER_ITER);
+        color1_ptr = color1_ptr.add(BLOCKS_PER_ITER);
+
+        // Store indices (two 64-byte stores = 32 u32 values).
+        _mm512_storeu_si512(indices_ptr as *mut __m512i, indices_0);
+        _mm512_storeu_si512(indices_ptr.add(16) as *mut __m512i, indices_1);
+        indices_ptr = indices_ptr.add(BLOCKS_PER_ITER);
+    }
+
+    // Process any remaining blocks via the portable fallback.
+    let remaining_blocks = block_count - aligned_blocks;
     generic::transform_with_split_colour(
         input_ptr,
         color0_ptr,
         color1_ptr,
         indices_ptr,
-        block_count,
+        remaining_blocks,
     );
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -65,4 +202,3 @@ mod tests {
         }
     }
 }
-*/

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx512.rs
@@ -169,6 +169,10 @@ mod tests {
 
     #[rstest]
     fn avx512_transform_roundtrip() {
+        if !has_avx512f() || !has_avx512bw() {
+            return;
+        }
+
         for num_blocks in 1..=128 {
             let input = generate_bc1_test_data(num_blocks);
             let len = input.len();

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/avx512.rs
@@ -1,0 +1,68 @@
+use crate::transforms::with_split_colour::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// AVX512 implementation for split-colour transform.
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx512f")]
+pub(crate) unsafe fn transform_with_split_colour(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    // TODO: implement AVX512 optimized transform
+    generic::transform_with_split_colour(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+    );
+}
+
+/*
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour::untransform::untransform_with_split_colour;
+
+    #[rstest]
+    fn avx512_transform_roundtrip() {
+        for num_blocks in 1..=128 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut colour0 = vec![0u16; num_blocks];
+            let mut colour1 = vec![0u16; num_blocks];
+            let mut indices = vec![0u32; num_blocks];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                transform_with_split_colour(
+                    input.as_ptr(),
+                    colour0.as_mut_ptr(),
+                    colour1.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    num_blocks,
+                );
+                untransform_with_split_colour(
+                    colour0.as_ptr(),
+                    colour1.as_ptr(),
+                    indices.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "Mismatch AVX512 roundtrip split-colour",
+            );
+        }
+    }
+}
+*/

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
@@ -1,0 +1,85 @@
+/// Generic fallback implementation of split-colour transform.
+/// Splits standard interleaved BC1 blocks into separate arrays of colour0, colour1 and indices.
+///
+/// # Safety
+///
+/// - `input_ptr` must be valid for reads of `block_count * 8` bytes
+/// - `color0_ptr` must be valid for writes of `block_count * 2` bytes
+/// - `color1_ptr` must be valid for writes of `block_count * 2` bytes
+/// - `indices_ptr` must be valid for writes of `block_count * 4` bytes
+pub(crate) unsafe fn transform_with_split_colour(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    // Fallback implementation
+    unsafe {
+        // Initialize pointers
+        let mut input_ptr = input_ptr;
+        let mut color0_ptr = color0_ptr;
+        let mut color1_ptr = color1_ptr;
+        let mut indices_ptr = indices_ptr;
+
+        // Process each block
+        for _ in 0..block_count {
+            // Read BC1 block format: [color0: u16, color1: u16, indices: u32]
+            let color0 = (input_ptr as *const u16).read_unaligned();
+            let color1 = (input_ptr.add(2) as *const u16).read_unaligned();
+            let indices = (input_ptr.add(4) as *const u32).read_unaligned();
+
+            // Write to separate arrays
+            color0_ptr.write_unaligned(color0);
+            color1_ptr.write_unaligned(color1);
+            indices_ptr.write_unaligned(indices);
+
+            // Advance all pointers
+            input_ptr = input_ptr.add(8);
+            color0_ptr = color0_ptr.add(1);
+            color1_ptr = color1_ptr.add(1);
+            indices_ptr = indices_ptr.add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour::untransform::untransform_with_split_colour;
+
+    #[rstest]
+    fn generic_transform_roundtrip() {
+        for num_blocks in 1..=128 {
+            let original = generate_bc1_test_data(num_blocks);
+            let mut colour0 = vec![0u16; num_blocks];
+            let mut colour1 = vec![0u16; num_blocks];
+            let mut indices = vec![0u32; num_blocks];
+            let mut reconstructed = vec![0u8; original.len()];
+
+            unsafe {
+                transform_with_split_colour(
+                    original.as_ptr(),
+                    colour0.as_mut_ptr(),
+                    colour1.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    num_blocks,
+                );
+                untransform_with_split_colour(
+                    colour0.as_ptr(),
+                    colour1.as_ptr(),
+                    indices.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks,
+                );
+            }
+
+            assert_eq!(
+                reconstructed.as_slice(),
+                original.as_slice(),
+                "generic transform split-colour roundtrip"
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
@@ -7,18 +7,19 @@
 /// - `color0_ptr` must be valid for writes of `block_count * 2` bytes
 /// - `color1_ptr` must be valid for writes of `block_count * 2` bytes
 /// - `indices_ptr` must be valid for writes of `block_count * 4` bytes
+#[inline]
 pub(crate) unsafe fn transform_with_split_colour(
     input_ptr: *const u8,
-    color0_ptr: *mut u16,
-    color1_ptr: *mut u16,
-    indices_ptr: *mut u32,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
     block_count: usize,
 ) {
     // Initialize pointers
     let mut input_ptr = input_ptr;
-    let mut color0_ptr = color0_ptr;
-    let mut color1_ptr = color1_ptr;
-    let mut indices_ptr = indices_ptr;
+    let mut color0_ptr = color0_out;
+    let mut color1_ptr = color1_out;
+    let mut indices_ptr = indices_out;
 
     // Process each block
     let input_end = input_ptr.add(block_count * 8);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
@@ -14,33 +14,30 @@ pub(crate) unsafe fn transform_with_split_colour(
     indices_ptr: *mut u32,
     block_count: usize,
 ) {
-    // Fallback implementation
-    unsafe {
-        // Initialize pointers
-        let mut input_ptr = input_ptr;
-        let mut color0_ptr = color0_ptr;
-        let mut color1_ptr = color1_ptr;
-        let mut indices_ptr = indices_ptr;
+    // Initialize pointers
+    let mut input_ptr = input_ptr;
+    let mut color0_ptr = color0_ptr;
+    let mut color1_ptr = color1_ptr;
+    let mut indices_ptr = indices_ptr;
 
-        // Process each block
-        let input_end = input_ptr.add(block_count * 8);
-        while input_ptr < input_end {
-            // Read BC1 block format: [color0: u16, color1: u16, indices: u32]
-            let color0 = (input_ptr as *const u16).read_unaligned();
-            let color1 = (input_ptr.add(2) as *const u16).read_unaligned();
-            let indices = (input_ptr.add(4) as *const u32).read_unaligned();
+    // Process each block
+    let input_end = input_ptr.add(block_count * 8);
+    while input_ptr < input_end {
+        // Read BC1 block format: [color0: u16, color1: u16, indices: u32]
+        let color0 = (input_ptr as *const u16).read_unaligned();
+        let color1 = (input_ptr.add(2) as *const u16).read_unaligned();
+        let indices = (input_ptr.add(4) as *const u32).read_unaligned();
 
-            // Write to separate arrays
-            color0_ptr.write_unaligned(color0);
-            color1_ptr.write_unaligned(color1);
-            indices_ptr.write_unaligned(indices);
+        // Write to separate arrays
+        color0_ptr.write_unaligned(color0);
+        color1_ptr.write_unaligned(color1);
+        indices_ptr.write_unaligned(indices);
 
-            // Advance all pointers
-            input_ptr = input_ptr.add(8);
-            color0_ptr = color0_ptr.add(1);
-            color1_ptr = color1_ptr.add(1);
-            indices_ptr = indices_ptr.add(1);
-        }
+        // Advance all pointers
+        input_ptr = input_ptr.add(8);
+        color0_ptr = color0_ptr.add(1);
+        color1_ptr = color1_ptr.add(1);
+        indices_ptr = indices_ptr.add(1);
     }
 }
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/generic.rs
@@ -23,7 +23,8 @@ pub(crate) unsafe fn transform_with_split_colour(
         let mut indices_ptr = indices_ptr;
 
         // Process each block
-        for _ in 0..block_count {
+        let input_end = input_ptr.add(block_count * 8);
+        while input_ptr < input_end {
             // Read BC1 block format: [color0: u16, color1: u16, indices: u32]
             let color0 = (input_ptr as *const u16).read_unaligned();
             let color1 = (input_ptr.add(2) as *const u16).read_unaligned();

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
@@ -66,7 +66,7 @@ unsafe fn transform_with_split_colour_x86(
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
-        if has_avx512f() {
+        if has_avx512f() && has_avx512bw() {
             avx512::transform_with_split_colour(
                 input_ptr,
                 color0_ptr,
@@ -103,7 +103,7 @@ unsafe fn transform_with_split_colour_x86(
     #[cfg(feature = "no-runtime-cpu-detection")]
     {
         #[cfg(feature = "nightly")]
-        if cfg!(target_feature = "avx512f") {
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512bw") {
             avx512::transform_with_split_colour(
                 input_ptr,
                 color0_ptr,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
@@ -20,6 +20,8 @@ pub mod generic;
 /// - `color0_ptr` must be valid for writes of `block_count * 2` bytes
 /// - `color1_ptr` must be valid for writes of `block_count * 2` bytes
 /// - `indices_ptr` must be valid for writes of `block_count * 4` bytes
+///
+/// The buffers must not overlap.
 #[inline]
 pub(crate) unsafe fn transform_with_split_colour(
     input_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
@@ -1,0 +1,147 @@
+//! Split and separate BC1 blocks into color0, color1, and indices arrays using the best known implementation for the current CPU.
+//!
+//! For the inverse of `untransform_with_split_colour`, see the corresponding untransform module.
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub mod avx2;
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub mod avx512;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+pub mod sse2;
+
+pub mod generic;
+
+/// Split standard interleaved BC1 blocks into separate color0, color1, and index buffers.
+///
+/// # Safety
+///
+/// - `input_ptr` must be valid for reads of `block_count * 8` bytes
+/// - `color0_ptr` must be valid for writes of `block_count * 2` bytes
+/// - `color1_ptr` must be valid for writes of `block_count * 2` bytes
+/// - `indices_ptr` must be valid for writes of `block_count * 4` bytes
+#[inline]
+pub(crate) unsafe fn transform_with_split_colour(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        transform_with_split_colour_x86(
+            input_ptr,
+            color0_ptr,
+            color1_ptr,
+            indices_ptr,
+            block_count,
+        );
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        generic::transform_with_split_colour(
+            input_ptr,
+            color0_ptr,
+            color1_ptr,
+            indices_ptr,
+            block_count,
+        );
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline(always)]
+unsafe fn transform_with_split_colour_x86(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    use dxt_lossless_transform_common::cpu_detect::*;
+
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    {
+        #[cfg(feature = "nightly")]
+        if has_avx512f() {
+            avx512::transform_with_split_colour(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+            );
+            return;
+        }
+
+        if has_avx2() {
+            avx2::transform_with_split_colour(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+            );
+            return;
+        }
+
+        if has_sse2() {
+            sse2::transform_with_split_colour(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+            );
+            return;
+        }
+    }
+
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") {
+            avx512::transform_with_split_colour(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+            );
+            return;
+        }
+
+        if cfg!(target_feature = "avx2") {
+            avx2::transform_with_split_colour(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+            );
+            return;
+        }
+
+        if cfg!(target_feature = "sse2") {
+            sse2::transform_with_split_colour(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+            );
+            return;
+        }
+    }
+
+    generic::transform_with_split_colour(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
@@ -14,7 +14,7 @@ pub(crate) unsafe fn transform_with_split_colour(
     mut indices_ptr: *mut u32,
     block_count: usize,
 ) {
-    let blocks8 = block_count / 8;
+    let blocks8 = block_count / 8; // round down via division
     let input_end = input_ptr.add(blocks8 * 8 * 8); // blocks8 * 8 blocks per iteration * 8 bytes per block
     while input_ptr < input_end {
         // Load four 16-byte chunks = 8 blocks

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
@@ -1,0 +1,67 @@
+use crate::transforms::with_split_colour::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// SSE2 implementation for split-colour transform.
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "sse2")]
+pub(crate) unsafe fn transform_with_split_colour(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    // TODO: implement SSE2 optimized transform
+    generic::transform_with_split_colour(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+    );
+}
+
+/*
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour::untransform::untransform_with_split_colour;
+
+    #[rstest]
+    fn sse2_transform_roundtrip() {
+        for num_blocks in 1..=128 {
+            let input = generate_bc1_test_data(num_blocks);
+            let len = input.len();
+            let mut colour0 = vec![0u16; num_blocks];
+            let mut colour1 = vec![0u16; num_blocks];
+            let mut indices = vec![0u32; num_blocks];
+            let mut reconstructed = vec![0u8; len];
+            unsafe {
+                transform_with_split_colour(
+                    input.as_ptr(),
+                    colour0.as_mut_ptr(),
+                    colour1.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    num_blocks,
+                );
+                untransform_with_split_colour(
+                    colour0.as_ptr(),
+                    colour1.as_ptr(),
+                    indices.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    num_blocks,
+                );
+            }
+            assert_eq!(
+                reconstructed.as_slice(),
+                input.as_slice(),
+                "Mismatch SSE2 roundtrip split-colour",
+            );
+        }
+    }
+}
+*/

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
@@ -8,23 +8,81 @@ use core::arch::x86_64::*;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[target_feature(enable = "sse2")]
 pub(crate) unsafe fn transform_with_split_colour(
-    input_ptr: *const u8,
-    color0_ptr: *mut u16,
-    color1_ptr: *mut u16,
-    indices_ptr: *mut u32,
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
     block_count: usize,
 ) {
-    // TODO: implement SSE2 optimized transform
-    generic::transform_with_split_colour(
-        input_ptr,
-        color0_ptr,
-        color1_ptr,
-        indices_ptr,
-        block_count,
-    );
+    let blocks8 = block_count / 8;
+    let input_end = input_ptr.add(blocks8 * 8 * 8); // blocks8 * 8 blocks per iteration * 8 bytes per block
+    while input_ptr < input_end {
+        // Load four 16-byte chunks = 8 blocks
+        let data0 = _mm_loadu_si128(input_ptr as *const __m128i);
+        let data1 = _mm_loadu_si128(input_ptr.add(16) as *const __m128i);
+        let data2 = _mm_loadu_si128(input_ptr.add(32) as *const __m128i);
+        let data3 = _mm_loadu_si128(input_ptr.add(48) as *const __m128i);
+        input_ptr = input_ptr.add(64);
+
+        // Split colors and indices using shufps patterns
+        let colours_0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data0),
+            _mm_castsi128_ps(data1),
+            0x88,
+        ));
+        let colours_1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data2),
+            _mm_castsi128_ps(data3),
+            0x88,
+        ));
+        let idx0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data0),
+            _mm_castsi128_ps(data1),
+            0xDD,
+        ));
+        let idx1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data2),
+            _mm_castsi128_ps(data3),
+            0xDD,
+        ));
+
+        // Now we need to split the colours into their color0 and color1 components.
+        // SSE2 is a bit limited here, so we'll use what we can to get by.
+
+        // Shuffle so the first 8 bytes have their color0 and color1 components chunked into u32s
+        let col0_grouped_lo = _mm_shufflelo_epi16(colours_0, 0b11_01_10_00);
+        let col0_grouped = _mm_shufflehi_epi16(col0_grouped_lo, 0b11_01_10_00);
+
+        let col1_grouped_lo = _mm_shufflelo_epi16(colours_1, 0b11_01_10_00);
+        let col1_grouped = _mm_shufflehi_epi16(col1_grouped_lo, 0b11_01_10_00);
+
+        // Now combine back into single colour registers by shuffling the u32s into their respective positions.
+        let colours_0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(col0_grouped),
+            _mm_castsi128_ps(col1_grouped),
+            0b10_00_10_00,
+        ));
+        let colours_1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(col0_grouped),
+            _mm_castsi128_ps(col1_grouped),
+            0b11_01_11_01,
+        ));
+
+        // Store results
+        _mm_storeu_si128(color0_ptr as *mut __m128i, colours_0);
+        _mm_storeu_si128(color1_ptr as *mut __m128i, colours_1);
+        _mm_storeu_si128(indices_ptr as *mut __m128i, idx0);
+        _mm_storeu_si128((indices_ptr as *mut __m128i).add(1), idx1);
+
+        color0_ptr = color0_ptr.add(8); // 16 bytes
+        color1_ptr = color1_ptr.add(8); // 16 bytes
+        indices_ptr = indices_ptr.add(8); // 32 bytes
+    }
+    // Handle any remaining blocks using generic fallback
+    let rem = block_count % 8;
+    generic::transform_with_split_colour(input_ptr, color0_ptr, color1_ptr, indices_ptr, rem);
 }
 
-/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,4 +122,3 @@ mod tests {
         }
     }
 }
-*/

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
@@ -50,21 +50,21 @@ pub(crate) unsafe fn transform_with_split_colour(
         // SSE2 is a bit limited here, so we'll use what we can to get by.
 
         // Shuffle so the first 8 bytes have their color0 and color1 components chunked into u32s
-        let col0_grouped_lo = _mm_shufflelo_epi16(colours_0, 0b11_01_10_00);
-        let col0_grouped = _mm_shufflehi_epi16(col0_grouped_lo, 0b11_01_10_00);
+        let colours_u32_grouped_0_lo = _mm_shufflelo_epi16(colours_0, 0b11_01_10_00);
+        let colours_u32_grouped_0 = _mm_shufflehi_epi16(colours_u32_grouped_0_lo, 0b11_01_10_00);
 
-        let col1_grouped_lo = _mm_shufflelo_epi16(colours_1, 0b11_01_10_00);
-        let col1_grouped = _mm_shufflehi_epi16(col1_grouped_lo, 0b11_01_10_00);
+        let colours_u32_grouped_1_lo = _mm_shufflelo_epi16(colours_1, 0b11_01_10_00);
+        let colours_u32_grouped_1 = _mm_shufflehi_epi16(colours_u32_grouped_1_lo, 0b11_01_10_00);
 
         // Now combine back into single colour registers by shuffling the u32s into their respective positions.
         let colours_0 = _mm_castps_si128(_mm_shuffle_ps(
-            _mm_castsi128_ps(col0_grouped),
-            _mm_castsi128_ps(col1_grouped),
+            _mm_castsi128_ps(colours_u32_grouped_0),
+            _mm_castsi128_ps(colours_u32_grouped_1),
             0b10_00_10_00,
         ));
         let colours_1 = _mm_castps_si128(_mm_shuffle_ps(
-            _mm_castsi128_ps(col0_grouped),
-            _mm_castsi128_ps(col1_grouped),
+            _mm_castsi128_ps(colours_u32_grouped_0),
+            _mm_castsi128_ps(colours_u32_grouped_1),
             0b11_01_11_01,
         ));
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/sse2.rs
@@ -9,9 +9,9 @@ use core::arch::x86_64::*;
 #[target_feature(enable = "sse2")]
 pub(crate) unsafe fn transform_with_split_colour(
     mut input_ptr: *const u8,
-    mut color0_ptr: *mut u16,
-    mut color1_ptr: *mut u16,
-    mut indices_ptr: *mut u32,
+    mut color0_out: *mut u16,
+    mut color1_out: *mut u16,
+    mut indices_out: *mut u32,
     block_count: usize,
 ) {
     let blocks8 = block_count / 8; // round down via division
@@ -69,18 +69,18 @@ pub(crate) unsafe fn transform_with_split_colour(
         ));
 
         // Store results
-        _mm_storeu_si128(color0_ptr as *mut __m128i, colours_0);
-        _mm_storeu_si128(color1_ptr as *mut __m128i, colours_1);
-        _mm_storeu_si128(indices_ptr as *mut __m128i, idx0);
-        _mm_storeu_si128((indices_ptr as *mut __m128i).add(1), idx1);
+        _mm_storeu_si128(color0_out as *mut __m128i, colours_0);
+        _mm_storeu_si128(color1_out as *mut __m128i, colours_1);
+        _mm_storeu_si128(indices_out as *mut __m128i, idx0);
+        _mm_storeu_si128((indices_out as *mut __m128i).add(1), idx1);
 
-        color0_ptr = color0_ptr.add(8); // 16 bytes
-        color1_ptr = color1_ptr.add(8); // 16 bytes
-        indices_ptr = indices_ptr.add(8); // 32 bytes
+        color0_out = color0_out.add(8); // 16 bytes
+        color1_out = color1_out.add(8); // 16 bytes
+        indices_out = indices_out.add(8); // 32 bytes
     }
     // Handle any remaining blocks using generic fallback
     let rem = block_count % 8;
-    generic::transform_with_split_colour(input_ptr, color0_ptr, color1_ptr, indices_ptr, rem);
+    generic::transform_with_split_colour(input_ptr, color0_out, color1_out, indices_out, rem);
 }
 
 #[cfg(test)]

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx2.rs
@@ -7,9 +7,9 @@ use core::arch::x86::*;
 #[target_feature(enable = "avx2")]
 #[allow(clippy::identity_op)]
 pub unsafe fn untransform_with_split_colour(
-    mut color0_ptr: *const u16,
-    mut color1_ptr: *const u16,
-    mut indices_ptr: *const u32,
+    mut color0_in: *const u16,
+    mut color1_in: *const u16,
+    mut indices_in: *const u32,
     mut output_ptr: *mut u8,
     block_count: usize,
 ) {
@@ -17,56 +17,53 @@ pub unsafe fn untransform_with_split_colour(
 
     // Process 16 blocks (128 bytes) at a time with AVX2
     let aligned_count = block_count - (block_count % 16);
-    let color0_ptr_aligned_end = color0_ptr.add(aligned_count);
+    let color0_ptr_aligned_end = color0_in.add(aligned_count);
+    while color0_in < color0_ptr_aligned_end {
+        let color0s = _mm256_loadu_si256(color0_in as *const __m256i);
+        color0_in = color0_in.add(16);
 
-    if aligned_count > 0 {
-        while color0_ptr < color0_ptr_aligned_end {
-            let color0s = _mm256_loadu_si256(color0_ptr as *const __m256i);
-            color0_ptr = color0_ptr.add(16);
+        let color1s = _mm256_loadu_si256(color1_in as *const __m256i);
+        color1_in = color1_in.add(16);
 
-            let color1s = _mm256_loadu_si256(color1_ptr as *const __m256i);
-            color1_ptr = color1_ptr.add(16);
+        let indices_0 = _mm256_loadu_si256(indices_in as *const __m256i);
+        let indices_1 = _mm256_loadu_si256(indices_in.add(8) as *const __m256i);
+        indices_in = indices_in.add(16);
 
-            let indices_0 = _mm256_loadu_si256(indices_ptr as *const __m256i);
-            let indices_1 = _mm256_loadu_si256(indices_ptr.add(8) as *const __m256i);
-            indices_ptr = indices_ptr.add(16);
+        // Mix the colours back into their c0+c1 pairs
+        let colors_0_0 = _mm256_unpacklo_epi16(color0s, color1s);
+        let colors_1_0 = _mm256_unpackhi_epi16(color0s, color1s);
 
-            // Mix the colours back into their c0+c1 pairs
-            let colors_0_0 = _mm256_unpacklo_epi16(color0s, color1s);
-            let colors_1_0 = _mm256_unpackhi_epi16(color0s, color1s);
+        // Because of AVX 'lanes', we meed to permute the upper and lower halves
+        let colors_0 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0010_0000);
+        let colors_1 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0011_0001);
 
-            // Because of AVX 'lanes', we meed to permute the upper and lower halves
-            let colors_0 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0010_0000);
-            let colors_1 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0011_0001);
+        // Re-combine the colors and indices into the BC1 block format
+        let blocks_0 = _mm256_unpacklo_epi32(colors_0, indices_0);
+        let blocks_1 = _mm256_unpackhi_epi32(colors_0, indices_0);
+        let blocks_2 = _mm256_unpacklo_epi32(colors_1, indices_1);
+        let blocks_3 = _mm256_unpackhi_epi32(colors_1, indices_1);
 
-            // Re-combine the colors and indices into the BC1 block format
-            let blocks_0 = _mm256_unpacklo_epi32(colors_0, indices_0);
-            let blocks_1 = _mm256_unpackhi_epi32(colors_0, indices_0);
-            let blocks_2 = _mm256_unpacklo_epi32(colors_1, indices_1);
-            let blocks_3 = _mm256_unpackhi_epi32(colors_1, indices_1);
+        // We need to combine the lanes to form the final output blocks.
+        let output_0 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0010_0000);
+        let output_1 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0011_0001);
+        let output_2 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0010_0000);
+        let output_3 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0011_0001);
 
-            // We need to combine the lanes to form the final output blocks.
-            let output_0 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0010_0000);
-            let output_1 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0011_0001);
-            let output_2 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0010_0000);
-            let output_3 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0011_0001);
+        _mm256_storeu_si256(output_ptr as *mut __m256i, output_0);
+        _mm256_storeu_si256(output_ptr.add(32) as *mut __m256i, output_1);
+        _mm256_storeu_si256(output_ptr.add(64) as *mut __m256i, output_2);
+        _mm256_storeu_si256(output_ptr.add(96) as *mut __m256i, output_3);
 
-            _mm256_storeu_si256(output_ptr as *mut __m256i, output_0);
-            _mm256_storeu_si256(output_ptr.add(32) as *mut __m256i, output_1);
-            _mm256_storeu_si256(output_ptr.add(64) as *mut __m256i, output_2);
-            _mm256_storeu_si256(output_ptr.add(96) as *mut __m256i, output_3);
-
-            // Advance output pointer
-            output_ptr = output_ptr.add(128);
-        }
+        // Advance output pointer
+        output_ptr = output_ptr.add(128);
     }
 
     // Process any remaining blocks (less than 16) using generic implementation
     let remaining_count = block_count - aligned_count;
     super::generic::untransform_with_split_colour(
-        color0_ptr,
-        color1_ptr,
-        indices_ptr,
+        color0_in,
+        color1_in,
+        indices_in,
         output_ptr,
         remaining_count,
     );

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx2.rs
@@ -74,8 +74,8 @@ pub unsafe fn untransform_with_split_colour(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::untransform_with_split_colour;
+    use crate::test_prelude::*;
 
     #[test]
     fn can_untransform_unaligned() {
@@ -88,12 +88,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx512.rs
@@ -8,9 +8,9 @@ use core::arch::x86::*;
 #[target_feature(enable = "avx512bw")]
 #[allow(clippy::identity_op)]
 pub unsafe fn untransform_with_split_colour(
-    mut color0_ptr: *const u16,
-    mut color1_ptr: *const u16,
-    mut indices_ptr: *const u32,
+    mut color0_in: *const u16,
+    mut color1_in: *const u16,
+    mut indices_in: *const u32,
     mut output_ptr: *mut u8,
     block_count: usize,
 ) {
@@ -18,198 +18,196 @@ pub unsafe fn untransform_with_split_colour(
 
     // Process 32 blocks (256 bytes) at a time
     let aligned_count = block_count - (block_count % 32);
-    let color0_ptr_aligned_end = color0_ptr.add(aligned_count);
+    let color0_ptr_aligned_end = color0_in.add(aligned_count);
 
-    if aligned_count > 0 {
-        // Mask for interleaving color0 and color1 into alternating pattern (lower half)
-        // This takes 16 u16 color0 values and 16 u16 color1 values and interleaves them
+    // Mask for interleaving color0 and color1 into alternating pattern (lower half)
+    // This takes 16 u16 color0 values and 16 u16 color1 values and interleaves them
 
-        // Inputs:  color0=[C0_0, C0_1, ..., C0_15], color1=[C1_0, C1_1, ..., C1_15]
-        // Output: [C0_0, C1_0, C0_1, C1_1, ..., C0_15, C1_15]
-        let perm_color_interleave_low = _mm512_set_epi16(
-            15 + 32, // C1_15
-            15 + 0,  // C0_15,
-            14 + 32, // C1_14
-            14 + 0,  // C0_14,
-            13 + 32, // C1_13
-            13 + 0,  // C0_13,
-            12 + 32, // C1_12
-            12 + 0,  // C0_12,
-            11 + 32, // C1_11
-            11 + 0,  // C0_11,
-            10 + 32, // C1_10
-            10 + 0,  // C0_10,
-            9 + 32,  // C1_9
-            9 + 0,   // C0_9,
-            8 + 32,  // C1_8
-            8 + 0,   // C0_8,
-            7 + 32,  // C1_7,
-            7 + 0,   // C0_7,
-            6 + 32,  // C1_6
-            6 + 0,   // C0_6,
-            5 + 32,  // C1_5
-            5 + 0,   // C0_5,
-            4 + 32,  // C1_4
-            4 + 0,   // C0_4,
-            3 + 32,  // C1_3
-            3 + 0,   // C0_3,
-            2 + 32,  // C1_2
-            2 + 0,   // C0_2,
-            1 + 32,  // C1_1
-            1 + 0,   // C0_1,
-            0 + 32,  // C1_0
-            0 + 0,   // C0_0,
-        );
+    // Inputs:  color0=[C0_0, C0_1, ..., C0_15], color1=[C1_0, C1_1, ..., C1_15]
+    // Output: [C0_0, C1_0, C0_1, C1_1, ..., C0_15, C1_15]
+    let perm_color_interleave_low = _mm512_set_epi16(
+        15 + 32, // C1_15
+        15 + 0,  // C0_15,
+        14 + 32, // C1_14
+        14 + 0,  // C0_14,
+        13 + 32, // C1_13
+        13 + 0,  // C0_13,
+        12 + 32, // C1_12
+        12 + 0,  // C0_12,
+        11 + 32, // C1_11
+        11 + 0,  // C0_11,
+        10 + 32, // C1_10
+        10 + 0,  // C0_10,
+        9 + 32,  // C1_9
+        9 + 0,   // C0_9,
+        8 + 32,  // C1_8
+        8 + 0,   // C0_8,
+        7 + 32,  // C1_7,
+        7 + 0,   // C0_7,
+        6 + 32,  // C1_6
+        6 + 0,   // C0_6,
+        5 + 32,  // C1_5
+        5 + 0,   // C0_5,
+        4 + 32,  // C1_4
+        4 + 0,   // C0_4,
+        3 + 32,  // C1_3
+        3 + 0,   // C0_3,
+        2 + 32,  // C1_2
+        2 + 0,   // C0_2,
+        1 + 32,  // C1_1
+        1 + 0,   // C0_1,
+        0 + 32,  // C1_0
+        0 + 0,   // C0_0,
+    );
 
-        let perm_color_interleave_high = _mm512_set_epi16(
-            (15 + 32) + 16, // C1_31
-            (15 + 0) + 16,  // C0_31,
-            (14 + 32) + 16, // C1_30
-            (14 + 0) + 16,  // C0_30,
-            (13 + 32) + 16, // C1_29
-            (13 + 0) + 16,  // C0_29,
-            (12 + 32) + 16, // C1_28
-            (12 + 0) + 16,  // C0_28,
-            (11 + 32) + 16, // C1_27
-            (11 + 0) + 16,  // C0_27,
-            (10 + 32) + 16, // C1_26
-            (10 + 0) + 16,  // C0_26,
-            (9 + 32) + 16,  // C1_25
-            (9 + 0) + 16,   // C0_25,
-            (8 + 32) + 16,  // C1_24
-            (8 + 0) + 16,   // C0_24,
-            (7 + 32) + 16,  // C1_23,
-            (7 + 0) + 16,   // C0_23,
-            (6 + 32) + 16,  // C1_22
-            (6 + 0) + 16,   // C0_22,
-            (5 + 32) + 16,  // C1_21
-            (5 + 0) + 16,   // C0_21,
-            (4 + 32) + 16,  // C1_20
-            (4 + 0) + 16,   // C0_20,
-            (3 + 32) + 16,  // C1_19
-            (3 + 0) + 16,   // C0_19,
-            (2 + 32) + 16,  // C1_18
-            (2 + 0) + 16,   // C0_18,
-            (1 + 32) + 16,  // C1_17
-            (1 + 0) + 16,   // C0_17,
-            (0 + 32) + 16,  // C1_16
-            (0 + 0) + 16,   // C0_16,
-        );
+    let perm_color_interleave_high = _mm512_set_epi16(
+        (15 + 32) + 16, // C1_31
+        (15 + 0) + 16,  // C0_31,
+        (14 + 32) + 16, // C1_30
+        (14 + 0) + 16,  // C0_30,
+        (13 + 32) + 16, // C1_29
+        (13 + 0) + 16,  // C0_29,
+        (12 + 32) + 16, // C1_28
+        (12 + 0) + 16,  // C0_28,
+        (11 + 32) + 16, // C1_27
+        (11 + 0) + 16,  // C0_27,
+        (10 + 32) + 16, // C1_26
+        (10 + 0) + 16,  // C0_26,
+        (9 + 32) + 16,  // C1_25
+        (9 + 0) + 16,   // C0_25,
+        (8 + 32) + 16,  // C1_24
+        (8 + 0) + 16,   // C0_24,
+        (7 + 32) + 16,  // C1_23,
+        (7 + 0) + 16,   // C0_23,
+        (6 + 32) + 16,  // C1_22
+        (6 + 0) + 16,   // C0_22,
+        (5 + 32) + 16,  // C1_21
+        (5 + 0) + 16,   // C0_21,
+        (4 + 32) + 16,  // C1_20
+        (4 + 0) + 16,   // C0_20,
+        (3 + 32) + 16,  // C1_19
+        (3 + 0) + 16,   // C0_19,
+        (2 + 32) + 16,  // C1_18
+        (2 + 0) + 16,   // C0_18,
+        (1 + 32) + 16,  // C1_17
+        (1 + 0) + 16,   // C0_17,
+        (0 + 32) + 16,  // C1_16
+        (0 + 0) + 16,   // C0_16,
+    );
 
-        // Inputs:  colors_0=[C0_0, C1_0, ..., C0_8, C1_8] | indices_0=[I0_0, I0_1 ..., I16_0, I16_1]
-        // Output: [C0_0, C1_0, I0_0, I0_1 ..., C0_8, C1_8, I8_0, I8_1]
-        let perm_output_0 = _mm512_set_epi16(
-            15 + 32, // I7_1
-            14 + 32, // I7_0,
-            15 + 0,  // C1_7
-            14 + 0,  // C0_7,
-            13 + 32, // I6_1
-            12 + 32, // I6_0,
-            13 + 0,  // C1_6
-            12 + 0,  // C0_6,
-            11 + 32, // I5_1
-            10 + 32, // I5_0,
-            11 + 0,  // C1_5
-            10 + 0,  // C0_5,
-            9 + 32,  // I4_1
-            8 + 32,  // I4_0,
-            9 + 0,   // C1_4
-            8 + 0,   // C0_4,
-            7 + 32,  // I3_1
-            6 + 32,  // I3_0,
-            7 + 0,   // C1_3
-            6 + 0,   // C0_3,
-            5 + 32,  // I2_1
-            4 + 32,  // I2_0,
-            5 + 0,   // C1_2
-            4 + 0,   // C0_2,
-            3 + 32,  // I1_1
-            2 + 32,  // I1_0,
-            3 + 0,   // C1_1
-            2 + 0,   // C0_1,
-            1 + 32,  // I0_0
-            0 + 32,  // I0_0,
-            1 + 0,   // C1_0
-            0 + 0,   // C0_0,
-        );
+    // Inputs:  colors_0=[C0_0, C1_0, ..., C0_8, C1_8] | indices_0=[I0_0, I0_1 ..., I16_0, I16_1]
+    // Output: [C0_0, C1_0, I0_0, I0_1 ..., C0_8, C1_8, I8_0, I8_1]
+    let perm_output_0 = _mm512_set_epi16(
+        15 + 32, // I7_1
+        14 + 32, // I7_0,
+        15 + 0,  // C1_7
+        14 + 0,  // C0_7,
+        13 + 32, // I6_1
+        12 + 32, // I6_0,
+        13 + 0,  // C1_6
+        12 + 0,  // C0_6,
+        11 + 32, // I5_1
+        10 + 32, // I5_0,
+        11 + 0,  // C1_5
+        10 + 0,  // C0_5,
+        9 + 32,  // I4_1
+        8 + 32,  // I4_0,
+        9 + 0,   // C1_4
+        8 + 0,   // C0_4,
+        7 + 32,  // I3_1
+        6 + 32,  // I3_0,
+        7 + 0,   // C1_3
+        6 + 0,   // C0_3,
+        5 + 32,  // I2_1
+        4 + 32,  // I2_0,
+        5 + 0,   // C1_2
+        4 + 0,   // C0_2,
+        3 + 32,  // I1_1
+        2 + 32,  // I1_0,
+        3 + 0,   // C1_1
+        2 + 0,   // C0_1,
+        1 + 32,  // I0_0
+        0 + 32,  // I0_0,
+        1 + 0,   // C1_0
+        0 + 0,   // C0_0,
+    );
 
-        let perm_output_1 = _mm512_set_epi16(
-            31 + 32, // I15_1
-            30 + 32, // I15_0,
-            31 + 0,  // C1_15
-            30 + 0,  // C0_15,
-            29 + 32, // I14_1
-            28 + 32, // I14_0,
-            29 + 0,  // C1_14
-            28 + 0,  // C0_14,
-            27 + 32, // I13_1
-            26 + 32, // I13_0,
-            27 + 0,  // C1_13
-            26 + 0,  // C0_13,
-            25 + 32, // I12_1
-            24 + 32, // I12_0,
-            25 + 0,  // C1_12
-            24 + 0,  // C0_12,
-            23 + 32, // I11_1
-            22 + 32, // I11_0,
-            23 + 0,  // C1_11
-            22 + 0,  // C0_11
-            21 + 32, // I10_1
-            20 + 32, // I10_0,
-            21 + 0,  // C1_10
-            20 + 0,  // C0_10,
-            19 + 32, // I9_1
-            18 + 32, // I9_0,
-            19 + 0,  // C1_9
-            18 + 0,  // C0_9,
-            17 + 32, // I8_1
-            16 + 32, // I8_0,
-            17 + 0,  // C1_8
-            16 + 0,  // C0_8,
-        );
+    let perm_output_1 = _mm512_set_epi16(
+        31 + 32, // I15_1
+        30 + 32, // I15_0,
+        31 + 0,  // C1_15
+        30 + 0,  // C0_15,
+        29 + 32, // I14_1
+        28 + 32, // I14_0,
+        29 + 0,  // C1_14
+        28 + 0,  // C0_14,
+        27 + 32, // I13_1
+        26 + 32, // I13_0,
+        27 + 0,  // C1_13
+        26 + 0,  // C0_13,
+        25 + 32, // I12_1
+        24 + 32, // I12_0,
+        25 + 0,  // C1_12
+        24 + 0,  // C0_12,
+        23 + 32, // I11_1
+        22 + 32, // I11_0,
+        23 + 0,  // C1_11
+        22 + 0,  // C0_11
+        21 + 32, // I10_1
+        20 + 32, // I10_0,
+        21 + 0,  // C1_10
+        20 + 0,  // C0_10,
+        19 + 32, // I9_1
+        18 + 32, // I9_0,
+        19 + 0,  // C1_9
+        18 + 0,  // C0_9,
+        17 + 32, // I8_1
+        16 + 32, // I8_0,
+        17 + 0,  // C1_8
+        16 + 0,  // C0_8,
+    );
 
-        while color0_ptr < color0_ptr_aligned_end {
-            // Load 32 blocks worth of data
-            // Load 64 bytes (32 u16 values) of color0 data - 1 read
-            let color0s = _mm512_loadu_si512(color0_ptr as *const __m512i);
-            color0_ptr = color0_ptr.add(32);
+    while color0_in < color0_ptr_aligned_end {
+        // Load 32 blocks worth of data
+        // Load 64 bytes (32 u16 values) of color0 data - 1 read
+        let color0s = _mm512_loadu_si512(color0_in as *const __m512i);
+        color0_in = color0_in.add(32);
 
-            // Load 64 bytes (32 u16 values) of color1 data - 1 read
-            let color1s = _mm512_loadu_si512(color1_ptr as *const __m512i);
-            color1_ptr = color1_ptr.add(32);
+        // Load 64 bytes (32 u16 values) of color1 data - 1 read
+        let color1s = _mm512_loadu_si512(color1_in as *const __m512i);
+        color1_in = color1_in.add(32);
 
-            // Load 128 bytes (32 u32 values) of indices data - 2 reads
-            let indices_0 = _mm512_loadu_si512(indices_ptr as *const __m512i);
-            let indices_1 = _mm512_loadu_si512(indices_ptr.add(16) as *const __m512i);
-            indices_ptr = indices_ptr.add(32);
+        // Load 128 bytes (32 u32 values) of indices data - 2 reads
+        let indices_0 = _mm512_loadu_si512(indices_in as *const __m512i);
+        let indices_1 = _mm512_loadu_si512(indices_in.add(16) as *const __m512i);
+        indices_in = indices_in.add(32);
 
-            // Interleave color0 and color1 into alternating pairs (first 16 blocks)
-            let colors_0 = _mm512_permutex2var_epi16(color0s, perm_color_interleave_low, color1s);
-            let colors_1 = _mm512_permutex2var_epi16(color0s, perm_color_interleave_high, color1s);
+        // Interleave color0 and color1 into alternating pairs (first 16 blocks)
+        let colors_0 = _mm512_permutex2var_epi16(color0s, perm_color_interleave_low, color1s);
+        let colors_1 = _mm512_permutex2var_epi16(color0s, perm_color_interleave_high, color1s);
 
-            // Now interleave the color pairs with indices to create final BC1 blocks
-            let output_0 = _mm512_permutex2var_epi16(colors_0, perm_output_0, indices_0);
-            let output_1 = _mm512_permutex2var_epi16(colors_0, perm_output_1, indices_0);
-            let output_2 = _mm512_permutex2var_epi16(colors_1, perm_output_0, indices_1);
-            let output_3 = _mm512_permutex2var_epi16(colors_1, perm_output_1, indices_1);
+        // Now interleave the color pairs with indices to create final BC1 blocks
+        let output_0 = _mm512_permutex2var_epi16(colors_0, perm_output_0, indices_0);
+        let output_1 = _mm512_permutex2var_epi16(colors_0, perm_output_1, indices_0);
+        let output_2 = _mm512_permutex2var_epi16(colors_1, perm_output_0, indices_1);
+        let output_3 = _mm512_permutex2var_epi16(colors_1, perm_output_1, indices_1);
 
-            // Write results - 32 blocks * 8 bytes = 256 bytes total
-            _mm512_storeu_si512(output_ptr as *mut __m512i, output_0);
-            _mm512_storeu_si512(output_ptr.add(64) as *mut __m512i, output_1);
-            _mm512_storeu_si512(output_ptr.add(128) as *mut __m512i, output_2);
-            _mm512_storeu_si512(output_ptr.add(192) as *mut __m512i, output_3);
+        // Write results - 32 blocks * 8 bytes = 256 bytes total
+        _mm512_storeu_si512(output_ptr as *mut __m512i, output_0);
+        _mm512_storeu_si512(output_ptr.add(64) as *mut __m512i, output_1);
+        _mm512_storeu_si512(output_ptr.add(128) as *mut __m512i, output_2);
+        _mm512_storeu_si512(output_ptr.add(192) as *mut __m512i, output_3);
 
-            // Advance output pointer
-            output_ptr = output_ptr.add(256);
-        }
+        // Advance output pointer
+        output_ptr = output_ptr.add(256);
     }
 
     // Process any remaining blocks (less than 32) using generic implementation
     let remaining_count = block_count - aligned_count;
     super::generic::untransform_with_split_colour(
-        color0_ptr,
-        color1_ptr,
-        indices_ptr,
+        color0_in,
+        color1_in,
+        indices_in,
         output_ptr,
         remaining_count,
     );

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx512.rs
@@ -231,12 +231,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/generic.rs
@@ -39,8 +39,8 @@ pub(crate) unsafe fn untransform_with_split_colour(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::untransform_with_split_colour;
+    use crate::test_prelude::*;
 
     #[test]
     fn can_untransform_unaligned() {
@@ -49,12 +49,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/generic.rs
@@ -1,39 +1,31 @@
+#[inline]
 pub(crate) unsafe fn untransform_with_split_colour(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
-    output_ptr: *mut u8,
+    mut color0_ptr: *const u16,
+    mut color1_ptr: *const u16,
+    mut indices_ptr: *const u32,
+    mut output_ptr: *mut u8,
     block_count: usize,
 ) {
-    // Fallback implementation
-    unsafe {
-        // Initialize pointers
-        let mut color0_ptr = color0_ptr;
-        let mut color1_ptr = color1_ptr;
-        let mut indices_ptr = indices_ptr;
-        let mut output_ptr = output_ptr;
+    // Calculate end pointer for color0
+    let color0_ptr_end = color0_ptr.add(block_count);
 
-        // Calculate end pointer for color0
-        let color0_ptr_end = color0_ptr.add(block_count);
+    while color0_ptr < color0_ptr_end {
+        // Read the split color values
+        let color0 = color0_ptr.read_unaligned();
+        let color1 = color1_ptr.read_unaligned();
+        let indices = indices_ptr.read_unaligned();
 
-        while color0_ptr < color0_ptr_end {
-            // Read the split color values
-            let color0 = color0_ptr.read_unaligned();
-            let color1 = color1_ptr.read_unaligned();
-            let indices = indices_ptr.read_unaligned();
+        // Write BC1 block format: [color0: u16, color1: u16, indices: u32]
+        // Convert to bytes and write directly
+        (output_ptr as *mut u16).write_unaligned(color0);
+        (output_ptr.add(2) as *mut u16).write_unaligned(color1);
+        (output_ptr.add(4) as *mut u32).write_unaligned(indices);
 
-            // Write BC1 block format: [color0: u16, color1: u16, indices: u32]
-            // Convert to bytes and write directly
-            (output_ptr as *mut u16).write_unaligned(color0);
-            (output_ptr.add(2) as *mut u16).write_unaligned(color1);
-            (output_ptr.add(4) as *mut u32).write_unaligned(indices);
-
-            // Advance all pointers
-            color0_ptr = color0_ptr.add(1);
-            color1_ptr = color1_ptr.add(1);
-            indices_ptr = indices_ptr.add(1);
-            output_ptr = output_ptr.add(8);
-        }
+        // Advance all pointers
+        color0_ptr = color0_ptr.add(1);
+        color1_ptr = color1_ptr.add(1);
+        indices_ptr = indices_ptr.add(1);
+        output_ptr = output_ptr.add(8);
     }
 }
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/sse2.rs
@@ -64,8 +64,8 @@ pub unsafe fn untransform_with_split_colour(
 
 #[cfg(test)]
 mod tests {
-    use crate::test_prelude::*;
     use super::untransform_with_split_colour;
+    use crate::test_prelude::*;
 
     #[test]
     fn can_untransform_unaligned() {
@@ -78,12 +78,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/sse2.rs
@@ -7,9 +7,9 @@ use core::arch::x86::*;
 #[target_feature(enable = "sse2")]
 #[allow(clippy::identity_op)]
 pub unsafe fn untransform_with_split_colour(
-    mut color0_ptr: *const u16,
-    mut color1_ptr: *const u16,
-    mut indices_ptr: *const u32,
+    mut color0_in: *const u16,
+    mut color1_in: *const u16,
+    mut indices_in: *const u32,
     mut output_ptr: *mut u8,
     block_count: usize,
 ) {
@@ -17,46 +17,44 @@ pub unsafe fn untransform_with_split_colour(
 
     // Process 8 blocks (64 bytes) at a time with SSE2
     let aligned_count = block_count - (block_count % 8);
-    let color0_ptr_aligned_end = color0_ptr.add(aligned_count);
+    let color0_ptr_aligned_end = color0_in.add(aligned_count);
 
-    if aligned_count > 0 {
-        while color0_ptr < color0_ptr_aligned_end {
-            let color0s = _mm_loadu_si128(color0_ptr as *const __m128i);
-            color0_ptr = color0_ptr.add(8);
+    while color0_in < color0_ptr_aligned_end {
+        let color0s = _mm_loadu_si128(color0_in as *const __m128i);
+        color0_in = color0_in.add(8);
 
-            let color1s = _mm_loadu_si128(color1_ptr as *const __m128i);
-            color1_ptr = color1_ptr.add(8);
+        let color1s = _mm_loadu_si128(color1_in as *const __m128i);
+        color1_in = color1_in.add(8);
 
-            let indices_0 = _mm_loadu_si128(indices_ptr as *const __m128i);
-            let indices_1 = _mm_loadu_si128(indices_ptr.add(4) as *const __m128i);
-            indices_ptr = indices_ptr.add(8);
+        let indices_0 = _mm_loadu_si128(indices_in as *const __m128i);
+        let indices_1 = _mm_loadu_si128(indices_in.add(4) as *const __m128i);
+        indices_in = indices_in.add(8);
 
-            // Mix the colours back into their c0+c1 pairs
-            let colors_0 = _mm_unpacklo_epi16(color0s, color1s);
-            let colors_1 = _mm_unpackhi_epi16(color0s, color1s);
+        // Mix the colours back into their c0+c1 pairs
+        let colors_0 = _mm_unpacklo_epi16(color0s, color1s);
+        let colors_1 = _mm_unpackhi_epi16(color0s, color1s);
 
-            // Re-combine the colors and indices into the BC1 block format
-            let blocks_0 = _mm_unpacklo_epi32(colors_0, indices_0);
-            let blocks_1 = _mm_unpackhi_epi32(colors_0, indices_0);
-            let blocks_2 = _mm_unpacklo_epi32(colors_1, indices_1);
-            let blocks_3 = _mm_unpackhi_epi32(colors_1, indices_1);
+        // Re-combine the colors and indices into the BC1 block format
+        let blocks_0 = _mm_unpacklo_epi32(colors_0, indices_0);
+        let blocks_1 = _mm_unpackhi_epi32(colors_0, indices_0);
+        let blocks_2 = _mm_unpacklo_epi32(colors_1, indices_1);
+        let blocks_3 = _mm_unpackhi_epi32(colors_1, indices_1);
 
-            _mm_storeu_si128(output_ptr as *mut __m128i, blocks_0);
-            _mm_storeu_si128(output_ptr.add(16) as *mut __m128i, blocks_1);
-            _mm_storeu_si128(output_ptr.add(32) as *mut __m128i, blocks_2);
-            _mm_storeu_si128(output_ptr.add(48) as *mut __m128i, blocks_3);
+        _mm_storeu_si128(output_ptr as *mut __m128i, blocks_0);
+        _mm_storeu_si128(output_ptr.add(16) as *mut __m128i, blocks_1);
+        _mm_storeu_si128(output_ptr.add(32) as *mut __m128i, blocks_2);
+        _mm_storeu_si128(output_ptr.add(48) as *mut __m128i, blocks_3);
 
-            // Advance output pointer
-            output_ptr = output_ptr.add(64);
-        }
+        // Advance output pointer
+        output_ptr = output_ptr.add(64);
     }
 
     // Process any remaining blocks (less than 8) using generic implementation
     let remaining_count = block_count - aligned_count;
     super::generic::untransform_with_split_colour(
-        color0_ptr,
-        color1_ptr,
-        indices_ptr,
+        color0_in,
+        color1_in,
+        indices_in,
         output_ptr,
         remaining_count,
     );

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
@@ -43,6 +43,36 @@ pub mod untransform;
 
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
+/// Transform BC1 data from standard interleaved format to three separate arrays
+/// (color0, color1, indices) while applying YCoCg decorrelation using best known
+/// implementation for current CPU.
+///
+/// # Safety
+///
+/// - input_ptr must be valid for reads of block_count * 8 bytes
+/// - color0_ptr must be valid for writes of block_count * 2 bytes
+/// - color1_ptr must be valid for writes of block_count * 2 bytes
+/// - indices_ptr must be valid for writes of block_count * 4 bytes
+/// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
+#[inline]
+pub unsafe fn transform_with_split_colour_and_recorr(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    transform::transform_with_split_colour_and_recorr(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+        decorrelation_mode,
+    );
+}
+
 /// Transform BC1 data from three separate arrays (color0, color1, indices) back to
 /// standard interleaved format while applying YCoCg decorrelation using best known
 /// implementation for current CPU.

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
@@ -55,7 +55,7 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 /// - indices_ptr must be valid for writes of block_count * 4 bytes
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn transform_with_split_colour_and_recorr(
+pub(crate) unsafe fn transform_with_split_colour_and_recorr(
     input_ptr: *const u8,
     color0_ptr: *mut u16,
     color1_ptr: *mut u16,
@@ -85,7 +85,7 @@ pub unsafe fn transform_with_split_colour_and_recorr(
 /// - output_ptr must be valid for writes of block_count * 8 bytes
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn untransform_with_split_colour_and_recorr(
+pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
     color0_ptr: *const u16,
     color1_ptr: *const u16,
     indices_ptr: *const u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
@@ -54,6 +54,8 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 /// - color1_ptr must be valid for writes of block_count * 2 bytes
 /// - indices_ptr must be valid for writes of block_count * 4 bytes
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
+///
+/// The buffers must not overlap.
 #[inline]
 pub(crate) unsafe fn transform_with_split_colour_and_recorr(
     input_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/avx2.rs
@@ -1,0 +1,243 @@
+use crate::transforms::with_split_colour_and_recorr::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::hint::unreachable_unchecked;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::avx2::{
+    decorrelate_ycocg_r_var1_avx2, decorrelate_ycocg_r_var2_avx2, decorrelate_ycocg_r_var3_avx2,
+};
+
+/// AVX2 implementation for split-colour transform with YCoCg-R decorrelation.
+#[target_feature(enable = "avx2")]
+unsafe fn transform_impl<const VARIANT: u8>(
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    let permute_idx = _mm256_setr_epi32(0, 4, 1, 5, 2, 6, 3, 7);
+    let blocks16 = block_count / 16;
+    let input_end = input_ptr.add(blocks16 * 16 * 8);
+
+    while input_ptr < input_end {
+        // Load all 128 bytes first to utilize memory pipeline
+        let input_0 = _mm256_loadu_si256(input_ptr as *const __m256i);
+        let input_1 = _mm256_loadu_si256(input_ptr.add(32) as *const __m256i);
+        let input_2 = _mm256_loadu_si256(input_ptr.add(64) as *const __m256i);
+        let input_3 = _mm256_loadu_si256(input_ptr.add(96) as *const __m256i);
+        input_ptr = input_ptr.add(128);
+
+        // Do all shuffles together to utilize shuffle units
+        // Colors: vshufps with 0b10001000 (136) extracts elements 0,2 from each 128-bit lane
+        // We separate only the color components from the input blocks.
+        let colors_only_0 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_0),
+            _mm256_castsi256_ps(input_1),
+            0b10001000,
+        );
+
+        let colors_only_1 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_2),
+            _mm256_castsi256_ps(input_3),
+            0b10001000,
+        );
+
+        // Indices: vshufps with 0b11011101 (221) extracts elements 1,3 from each 128-bit lane
+        let indices_shuffled_0 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_0),
+            _mm256_castsi256_ps(input_1),
+            0b11011101,
+        );
+        let indices_blocks_0 =
+            _mm256_permute4x64_epi64(_mm256_castps_si256(indices_shuffled_0), 0b11011000); // arrange indices (216)
+
+        let indices_shuffled_1 = _mm256_shuffle_ps(
+            _mm256_castsi256_ps(input_2),
+            _mm256_castsi256_ps(input_3),
+            0b11011101,
+        );
+        let indices_blocks_1 =
+            _mm256_permute4x64_epi64(_mm256_castps_si256(indices_shuffled_1), 0b11011000); // arrange indices (216)
+
+        // We now group the colours into u32s of color0 and color1 components.
+        let colours_u32_grouped_0_lo =
+            _mm256_shufflelo_epi16(_mm256_castps_si256(colors_only_0), 0b11_01_10_00);
+        let colours_u32_grouped_0 = _mm256_shufflehi_epi16(colours_u32_grouped_0_lo, 0b11_01_10_00);
+
+        let colours_u32_grouped_1_lo =
+            _mm256_shufflelo_epi16(_mm256_castps_si256(colors_only_1), 0b11_01_10_00);
+        let colours_u32_grouped_1 = _mm256_shufflehi_epi16(colours_u32_grouped_1_lo, 0b11_01_10_00);
+
+        let colors_grouped_0 = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(colours_u32_grouped_0),
+            _mm256_castsi256_ps(colours_u32_grouped_1),
+            0b10_00_10_00,
+        ));
+        let colors_grouped_1 = _mm256_castps_si256(_mm256_shuffle_ps(
+            _mm256_castsi256_ps(colours_u32_grouped_0),
+            _mm256_castsi256_ps(colours_u32_grouped_1),
+            0b11_01_11_01,
+        ));
+
+        // We now have the correct output, but the data is interleaved across lanes.
+        // i.e. First u32 in first lane, then first u32 in second lane, etc.
+        // We need to merge these u32s across lanes. Permute + unpack seems to be the fastest way.
+        // Re-order the 32-bit words to `[0,4,1,5,2,6,3,7]` so the two 128-bit lanes are interleaved.
+        let colors_blocks_0 = _mm256_permutevar8x32_epi32(colors_grouped_0, permute_idx);
+        let colors_blocks_1 = _mm256_permutevar8x32_epi32(colors_grouped_1, permute_idx);
+
+        let colors_blocks_0: __m256i = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx2(colors_blocks_0),
+            2 => decorrelate_ycocg_r_var2_avx2(colors_blocks_0),
+            3 => decorrelate_ycocg_r_var3_avx2(colors_blocks_0),
+            _ => unreachable_unchecked(),
+        };
+
+        let colors_blocks_1: __m256i = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx2(colors_blocks_1),
+            2 => decorrelate_ycocg_r_var2_avx2(colors_blocks_1),
+            3 => decorrelate_ycocg_r_var3_avx2(colors_blocks_1),
+            _ => unreachable_unchecked(),
+        };
+
+        // Store all results together to utilize store pipeline
+        _mm256_storeu_si256(color0_ptr as *mut __m256i, colors_blocks_0); // Store colors
+        _mm256_storeu_si256(color1_ptr as *mut __m256i, colors_blocks_1); // Store colors
+        color0_ptr = color0_ptr.add(16); // color0_ptr += 32 bytes / 2 = 16 u16s
+        color1_ptr = color1_ptr.add(16); // color1_ptr += 32 bytes / 2 = 16 u16s
+
+        _mm256_storeu_si256(indices_ptr as *mut __m256i, indices_blocks_0); // Store indices
+        _mm256_storeu_si256(indices_ptr.add(8) as *mut __m256i, indices_blocks_1); // Store indices (@ +32 bytes)
+        indices_ptr = indices_ptr.add(16); // indices_ptr += 64 bytes / 4 = 16 u32s
+    }
+
+    // Remainder blocks handled by generic implementation
+    let rem = block_count % 16;
+    if rem > 0 {
+        let variant_enum = match VARIANT {
+            1 => YCoCgVariant::Variant1,
+            2 => YCoCgVariant::Variant2,
+            3 => YCoCgVariant::Variant3,
+            _ => unreachable_unchecked(),
+        };
+        generic::transform_with_split_colour_and_decorr_generic(
+            input_ptr,
+            color0_ptr,
+            color1_ptr,
+            indices_ptr,
+            rem,
+            variant_enum,
+        );
+    }
+}
+
+// Wrappers for asm inspection
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn transform_var1(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<1>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn transform_var2(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<2>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[target_feature(enable = "avx2")]
+pub(crate) unsafe fn transform_var3(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<3>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+// Runtime dispatcher for AVX2 path
+#[inline(always)]
+pub(crate) unsafe fn transform_with_split_colour_and_decorr(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+    variant: YCoCgVariant,
+) {
+    match variant {
+        YCoCgVariant::Variant1 => {
+            transform_var1(input_ptr, color0_ptr, color1_ptr, indices_ptr, block_count)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_var2(input_ptr, color0_ptr, color1_ptr, indices_ptr, block_count)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_var3(input_ptr, color0_ptr, color1_ptr, indices_ptr, block_count)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour_and_recorr::untransform::untransform_with_split_colour_and_recorr;
+
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn avx2_transform_roundtrip(#[case] variant: YCoCgVariant) {
+        if !has_avx2() {
+            return;
+        }
+        for blocks in 1..=128 {
+            let input = generate_bc1_test_data(blocks);
+            let mut colour0 = vec![0u16; blocks];
+            let mut colour1 = vec![0u16; blocks];
+            let mut indices = vec![0u32; blocks];
+            let mut reconstructed = vec![0u8; input.len()];
+            unsafe {
+                transform_with_split_colour_and_decorr(
+                    input.as_ptr(),
+                    colour0.as_mut_ptr(),
+                    colour1.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+                untransform_with_split_colour_and_recorr(
+                    colour0.as_ptr(),
+                    colour1.as_ptr(),
+                    indices.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+            }
+            assert_eq!(
+                input.as_slice(),
+                reconstructed.as_slice(),
+                "AVX2 roundtrip mismatch {variant:?}"
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/avx512.rs
@@ -1,0 +1,294 @@
+use crate::transforms::with_split_colour_and_recorr::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::hint::unreachable_unchecked;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::avx512::{
+    decorrelate_ycocg_r_var1_avx512, decorrelate_ycocg_r_var2_avx512,
+    decorrelate_ycocg_r_var3_avx512,
+};
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+unsafe fn transform_impl<const VARIANT: u8>(
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    debug_assert!(block_count > 0);
+
+    // Number of blocks that can be processed per 256-byte iteration (32 BC1 blocks).
+    const BLOCKS_PER_ITER: usize = 32;
+
+    // Byte permutation indices for vpermt2d to gather colour and index dwords.
+    // Same values as the standard AVX512 split implementation.
+    const PERM_COLORS_BYTES: [i8; 16] = [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30];
+    const PERM_INDICES_BYTES: [i8; 16] =
+        [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31];
+
+    // Pre-compute permutation vectors for dword gathers (extend i8 -> i32 as required by vpermt2d).
+    let perm_colors = _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_COLORS_BYTES.as_ptr() as *const _));
+    let perm_indices =
+        _mm512_cvtepi8_epi32(_mm_loadu_si128(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+    // Pre-compute epi16 permutation vectors that directly extract colour0/colour1 words.
+    // Each entry selects a 16-bit lane from either `colors_0` (0-31) or `colors_1` (32-63).
+    // colour0 = low 16-bits  (even lanes), colour1 = high 16-bits (odd lanes).
+    const PERM_COLOR0_EPI16: [i16; 32] = [
+        0,
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        24,
+        26,
+        28,
+        30,
+        32,
+        2 + 32,
+        4 + 32,
+        6 + 32,
+        8 + 32,
+        10 + 32,
+        12 + 32,
+        14 + 32,
+        16 + 32,
+        18 + 32,
+        20 + 32,
+        22 + 32,
+        24 + 32,
+        26 + 32,
+        28 + 32,
+        30 + 32,
+    ];
+    const PERM_COLOR1_EPI16: [i16; 32] = [
+        1,
+        3,
+        5,
+        7,
+        9,
+        11,
+        13,
+        15,
+        17,
+        19,
+        21,
+        23,
+        25,
+        27,
+        29,
+        31,
+        1 + 32,
+        3 + 32,
+        5 + 32,
+        7 + 32,
+        9 + 32,
+        11 + 32,
+        13 + 32,
+        15 + 32,
+        17 + 32,
+        19 + 32,
+        21 + 32,
+        23 + 32,
+        25 + 32,
+        27 + 32,
+        29 + 32,
+        31 + 32,
+    ];
+
+    let perm_color0_epi16 = _mm512_loadu_si512(PERM_COLOR0_EPI16.as_ptr() as *const __m512i);
+    let perm_color1_epi16 = _mm512_loadu_si512(PERM_COLOR1_EPI16.as_ptr() as *const __m512i);
+
+    // Aligned block count that fits full iterations.
+    let aligned_blocks = block_count - (block_count % BLOCKS_PER_ITER);
+    let aligned_end_input = input_ptr.add(aligned_blocks * 8); // 8 bytes per BC1 block
+
+    while input_ptr < aligned_end_input {
+        // Load 256 bytes (32 blocks)
+        let in0 = _mm512_loadu_si512(input_ptr as *const __m512i);
+        let in1 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+        let in2 = _mm512_loadu_si512(input_ptr.add(128) as *const __m512i);
+        let in3 = _mm512_loadu_si512(input_ptr.add(192) as *const __m512i);
+        input_ptr = input_ptr.add(256);
+
+        // Extract colours and indices into separate registers.
+        let colors_0 = _mm512_permutex2var_epi32(in0, perm_colors, in1);
+        let colors_1 = _mm512_permutex2var_epi32(in2, perm_colors, in3);
+
+        let indices_0 = _mm512_permutex2var_epi32(in0, perm_indices, in1);
+        let indices_1 = _mm512_permutex2var_epi32(in2, perm_indices, in3);
+
+        // Group extracted colours into color0 and color1 components.
+        let color0_only = _mm512_permutex2var_epi16(colors_0, perm_color0_epi16, colors_1);
+        let color1_only = _mm512_permutex2var_epi16(colors_0, perm_color1_epi16, colors_1);
+
+        // Decorrelate
+        let decorr_c0 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx512(color0_only),
+            2 => decorrelate_ycocg_r_var2_avx512(color0_only),
+            3 => decorrelate_ycocg_r_var3_avx512(color0_only),
+            _ => unreachable_unchecked(),
+        };
+        let decorr_c1 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_avx512(color1_only),
+            2 => decorrelate_ycocg_r_var2_avx512(color1_only),
+            3 => decorrelate_ycocg_r_var3_avx512(color1_only),
+            _ => unreachable_unchecked(),
+        };
+
+        // Store color0 and color1 (64 bytes each).
+        _mm512_storeu_si512(color0_ptr as *mut __m512i, decorr_c0);
+        _mm512_storeu_si512(color1_ptr as *mut __m512i, decorr_c1);
+        color0_ptr = color0_ptr.add(BLOCKS_PER_ITER);
+        color1_ptr = color1_ptr.add(BLOCKS_PER_ITER);
+
+        // Store indices (two 64-byte stores = 32 u32 values).
+        _mm512_storeu_si512(indices_ptr as *mut __m512i, indices_0);
+        _mm512_storeu_si512(indices_ptr.add(16) as *mut __m512i, indices_1);
+        indices_ptr = indices_ptr.add(BLOCKS_PER_ITER);
+    }
+
+    // Remainder via scalar path
+    let remaining_blocks = block_count - aligned_blocks;
+    let variant_enum = match VARIANT {
+        1 => YCoCgVariant::Variant1,
+        2 => YCoCgVariant::Variant2,
+        3 => YCoCgVariant::Variant3,
+        _ => unreachable_unchecked(),
+    };
+    generic::transform_with_split_colour_and_decorr_generic(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        remaining_blocks,
+        variant_enum,
+    );
+}
+
+// Variant wrappers for asm inspection
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+pub(crate) unsafe fn transform_decorr_var1(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<1>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+pub(crate) unsafe fn transform_decorr_var2(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<2>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+pub(crate) unsafe fn transform_decorr_var3(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<3>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+// Runtime dispatch helper used by parent module
+#[inline(always)]
+pub(crate) unsafe fn transform_with_split_colour_and_decorr(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    blocks: usize,
+    variant: YCoCgVariant,
+) {
+    match variant {
+        YCoCgVariant::Variant1 => {
+            transform_decorr_var1(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_decorr_var2(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_decorr_var3(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour_and_recorr::untransform::untransform_with_split_colour_and_recorr;
+
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn avx512_transform_roundtrip(#[case] variant: YCoCgVariant) {
+        if !has_avx512f() || !has_avx512bw() {
+            return;
+        }
+        for blocks in 1..=64 {
+            let input = generate_bc1_test_data(blocks);
+            let mut c0 = vec![0u16; blocks];
+            let mut c1 = vec![0u16; blocks];
+            let mut idx = vec![0u32; blocks];
+            let mut recon = vec![0u8; input.len()];
+            unsafe {
+                transform_with_split_colour_and_decorr(
+                    input.as_ptr(),
+                    c0.as_mut_ptr(),
+                    c1.as_mut_ptr(),
+                    idx.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+                untransform_with_split_colour_and_recorr(
+                    c0.as_ptr(),
+                    c1.as_ptr(),
+                    idx.as_ptr(),
+                    recon.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+            }
+            assert_eq!(
+                input.as_slice(),
+                recon.as_slice(),
+                "AVX512 roundtrip mismatch {variant:?}"
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/avx512.rs
@@ -226,21 +226,21 @@ pub(crate) unsafe fn transform_decorr_var3(
 #[inline(always)]
 pub(crate) unsafe fn transform_with_split_colour_and_decorr(
     input_ptr: *const u8,
-    color0_ptr: *mut u16,
-    color1_ptr: *mut u16,
-    indices_ptr: *mut u32,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
     blocks: usize,
     variant: YCoCgVariant,
 ) {
     match variant {
         YCoCgVariant::Variant1 => {
-            transform_decorr_var1(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+            transform_decorr_var1(input_ptr, color0_out, color1_out, indices_out, blocks)
         }
         YCoCgVariant::Variant2 => {
-            transform_decorr_var2(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+            transform_decorr_var2(input_ptr, color0_out, color1_out, indices_out, blocks)
         }
         YCoCgVariant::Variant3 => {
-            transform_decorr_var3(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+            transform_decorr_var3(input_ptr, color0_out, color1_out, indices_out, blocks)
         }
         YCoCgVariant::None => unreachable_unchecked(),
     }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/generic.rs
@@ -1,0 +1,128 @@
+use core::hint::unreachable_unchecked;
+use core::ptr::{read_unaligned, write_unaligned};
+use dxt_lossless_transform_common::color_565::{Color565, YCoCgVariant};
+
+/// Generic fallback implementation of split-colour transform with YCoCg-R decorrelation.
+///
+/// Splits standard interleaved BC1 blocks into separate colour0, colour1 and indices buffers,
+/// applying the selected YCoCg-R decorrelation variant to each colour endpoint.
+///
+/// # Safety
+///
+/// - `input_ptr` must be valid for reads of `block_count * 8` bytes
+/// - `color0_ptr` must be valid for writes of `block_count * 2` bytes
+/// - `color1_ptr` must be valid for writes of `block_count * 2` bytes
+/// - `indices_ptr` must be valid for writes of `block_count * 4` bytes
+#[inline]
+pub(crate) unsafe fn transform_with_split_colour_and_decorr_generic(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    match decorrelation_mode {
+        YCoCgVariant::Variant1 => {
+            transform_split_decorr::<1>(input_ptr, color0_ptr, color1_ptr, indices_ptr, block_count)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_split_decorr::<2>(input_ptr, color0_ptr, color1_ptr, indices_ptr, block_count)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_split_decorr::<3>(input_ptr, color0_ptr, color1_ptr, indices_ptr, block_count)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+unsafe fn transform_split_decorr<const VARIANT: u8>(
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    let input_end = input_ptr.add(block_count * 8);
+    while input_ptr < input_end {
+        // Read BC1 block (colour0, colour1, indices)
+        let color0_raw = read_unaligned(input_ptr as *const u16);
+        let color1_raw = read_unaligned(input_ptr.add(2) as *const u16);
+        let indices = read_unaligned(input_ptr.add(4) as *const u32);
+        input_ptr = input_ptr.add(8);
+
+        // Convert raw values to Color565 and decorrelate
+        let color0 = Color565::from_raw(color0_raw);
+        let color1 = Color565::from_raw(color1_raw);
+
+        // Apply YCoCg-R decorrelation based on variant
+        let (decorr0, decorr1) = match VARIANT {
+            1 => (
+                color0.decorrelate_ycocg_r_var1(),
+                color1.decorrelate_ycocg_r_var1(),
+            ),
+            2 => (
+                color0.decorrelate_ycocg_r_var2(),
+                color1.decorrelate_ycocg_r_var2(),
+            ),
+            3 => (
+                color0.decorrelate_ycocg_r_var3(),
+                color1.decorrelate_ycocg_r_var3(),
+            ),
+            _ => unreachable_unchecked(),
+        };
+
+        // Write decorrelated endpoints and indices
+        write_unaligned(color0_ptr, decorr0.raw_value());
+        write_unaligned(color1_ptr, decorr1.raw_value());
+        write_unaligned(indices_ptr, indices);
+
+        color0_ptr = color0_ptr.add(1);
+        color1_ptr = color1_ptr.add(1);
+        indices_ptr = indices_ptr.add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour_and_recorr::untransform::untransform_with_split_colour_and_recorr;
+
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn generic_transform_roundtrip(#[case] variant: YCoCgVariant) {
+        for blocks in 1..=256 {
+            let input = generate_bc1_test_data(blocks);
+            let mut colour0 = vec![0u16; blocks];
+            let mut colour1 = vec![0u16; blocks];
+            let mut indices = vec![0u32; blocks];
+            let mut reconstructed = vec![0u8; input.len()];
+            unsafe {
+                transform_with_split_colour_and_decorr_generic(
+                    input.as_ptr(),
+                    colour0.as_mut_ptr(),
+                    colour1.as_mut_ptr(),
+                    indices.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+                untransform_with_split_colour_and_recorr(
+                    colour0.as_ptr(),
+                    colour1.as_ptr(),
+                    indices.as_ptr(),
+                    reconstructed.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+            }
+            assert_eq!(
+                input.as_slice(),
+                reconstructed.as_slice(),
+                "Generic roundtrip mismatch for {variant:?}"
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/mod.rs
@@ -1,0 +1,166 @@
+//! Split colour **and** decorrelate transform
+//!
+//! Takes standard interleaved BC1 blocks (`input_ptr`) and produces three separate
+//! arrays: `color0_ptr`, `color1_ptr` (decorrelated [`Color565`] endpoints) and
+//! `indices_ptr` (packed 2-bit indices).
+//!
+//! This module selects the best available implementation for the current CPU at
+//! runtime (unless `no-runtime-cpu-detection` feature is enabled).
+
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+mod generic;
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod avx2;
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod avx512;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+mod sse2;
+
+/// Split-colour transform with YCoCg-R decorrelation using the best known
+/// implementation for the current CPU.
+///
+/// # Safety
+/// Refer to individual backend implementations for exact requirements. In
+/// general:
+/// - `input_ptr` must be valid for `block_count*8` bytes of reads.
+/// - `color0_ptr`, `color1_ptr` must be valid for `block_count*2` bytes of writes.
+/// - `indices_ptr` must be valid for `block_count*4` bytes of writes.
+#[inline]
+pub unsafe fn transform_with_split_colour_and_recorr(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    debug_assert!(decorrelation_mode != YCoCgVariant::None);
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    {
+        transform_with_split_colour_and_recorr_x86(
+            input_ptr,
+            color0_ptr,
+            color1_ptr,
+            indices_ptr,
+            block_count,
+            decorrelation_mode,
+        );
+    }
+
+    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+    {
+        generic::transform_with_split_colour_and_decorr_generic(
+            input_ptr,
+            color0_ptr,
+            color1_ptr,
+            indices_ptr,
+            block_count,
+            decorrelation_mode,
+        );
+    }
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline(always)]
+unsafe fn transform_with_split_colour_and_recorr_x86(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    block_count: usize,
+    decorrelation_mode: YCoCgVariant,
+) {
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    use dxt_lossless_transform_common::cpu_detect::*;
+
+    #[cfg(not(feature = "no-runtime-cpu-detection"))]
+    {
+        #[cfg(feature = "nightly")]
+        if has_avx512f() && has_avx512bw() {
+            avx512::transform_with_split_colour_and_decorr(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+                decorrelation_mode,
+            );
+            return;
+        }
+
+        if has_avx2() {
+            avx2::transform_with_split_colour_and_decorr(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+                decorrelation_mode,
+            );
+            return;
+        }
+        if has_sse2() {
+            sse2::transform_with_split_colour_and_decorr(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+                decorrelation_mode,
+            );
+            return;
+        }
+    }
+
+    #[cfg(feature = "no-runtime-cpu-detection")]
+    {
+        #[cfg(feature = "nightly")]
+        if cfg!(target_feature = "avx512f") && cfg!(target_feature = "avx512bw") {
+            avx512::transform_with_split_colour_and_decorr(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+                decorrelation_mode,
+            );
+            return;
+        }
+
+        if cfg!(target_feature = "avx2") {
+            avx2::transform_with_split_colour_and_decorr(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+                decorrelation_mode,
+            );
+            return;
+        }
+        if cfg!(target_feature = "sse2") {
+            sse2::transform_with_split_colour_and_decorr(
+                input_ptr,
+                color0_ptr,
+                color1_ptr,
+                indices_ptr,
+                block_count,
+                decorrelation_mode,
+            );
+            return;
+        }
+    }
+
+    // Fallback
+    generic::transform_with_split_colour_and_decorr_generic(
+        input_ptr,
+        color0_ptr,
+        color1_ptr,
+        indices_ptr,
+        block_count,
+        decorrelation_mode,
+    );
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/mod.rs
@@ -25,14 +25,15 @@ mod sse2;
 /// Refer to individual backend implementations for exact requirements. In
 /// general:
 /// - `input_ptr` must be valid for `block_count*8` bytes of reads.
-/// - `color0_ptr`, `color1_ptr` must be valid for `block_count*2` bytes of writes.
-/// - `indices_ptr` must be valid for `block_count*4` bytes of writes.
+/// - `color0_out` must be valid for `block_count*2` bytes of writes.
+/// - `color1_out` must be valid for `block_count*2` bytes of writes.
+/// - `indices_out` must be valid for `block_count*4` bytes of writes.
 #[inline]
 pub unsafe fn transform_with_split_colour_and_recorr(
     input_ptr: *const u8,
-    color0_ptr: *mut u16,
-    color1_ptr: *mut u16,
-    indices_ptr: *mut u32,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
     block_count: usize,
     decorrelation_mode: YCoCgVariant,
 ) {
@@ -42,9 +43,9 @@ pub unsafe fn transform_with_split_colour_and_recorr(
     {
         transform_with_split_colour_and_recorr_x86(
             input_ptr,
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_out,
+            color1_out,
+            indices_out,
             block_count,
             decorrelation_mode,
         );
@@ -54,9 +55,9 @@ pub unsafe fn transform_with_split_colour_and_recorr(
     {
         generic::transform_with_split_colour_and_decorr_generic(
             input_ptr,
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_out,
+            color1_out,
+            indices_out,
             block_count,
             decorrelation_mode,
         );

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/sse2.rs
@@ -1,0 +1,221 @@
+use crate::transforms::with_split_colour_and_recorr::transform::generic;
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::hint::unreachable_unchecked;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
+use dxt_lossless_transform_common::intrinsics::color_565::decorrelate::sse2::{
+    decorrelate_ycocg_r_var1_sse2, decorrelate_ycocg_r_var2_sse2, decorrelate_ycocg_r_var3_sse2,
+};
+
+/// SSE2 implementation for split-colour transform with YCoCg-R decorrelation.
+#[target_feature(enable = "sse2")]
+unsafe fn transform_impl<const VARIANT: u8>(
+    mut input_ptr: *const u8,
+    mut color0_ptr: *mut u16,
+    mut color1_ptr: *mut u16,
+    mut indices_ptr: *mut u32,
+    block_count: usize,
+) {
+    let blocks8 = block_count / 8; // round down via division
+    let input_end = input_ptr.add(blocks8 * 8 * 8);
+
+    while input_ptr < input_end {
+        // Load four 16-byte chunks = 8 blocks
+        let data0 = _mm_loadu_si128(input_ptr as *const __m128i);
+        let data1 = _mm_loadu_si128(input_ptr.add(16) as *const __m128i);
+        let data2 = _mm_loadu_si128(input_ptr.add(32) as *const __m128i);
+        let data3 = _mm_loadu_si128(input_ptr.add(48) as *const __m128i);
+        input_ptr = input_ptr.add(64);
+
+        // Split colors and indices using shufps patterns
+        let colours_0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data0),
+            _mm_castsi128_ps(data1),
+            0x88,
+        ));
+        let colours_1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data2),
+            _mm_castsi128_ps(data3),
+            0x88,
+        ));
+        let idx0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data0),
+            _mm_castsi128_ps(data1),
+            0xDD,
+        ));
+        let idx1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(data2),
+            _mm_castsi128_ps(data3),
+            0xDD,
+        ));
+
+        // Now we need to split the colours into their color0 and color1 components.
+        // SSE2 is a bit limited here, so we'll use what we can to get by.
+
+        // Shuffle so the first 8 bytes have their color0 and color1 components chunked into u32s
+        let colours_u32_grouped_0_lo = _mm_shufflelo_epi16(colours_0, 0b11_01_10_00);
+        let colours_u32_grouped_0 = _mm_shufflehi_epi16(colours_u32_grouped_0_lo, 0b11_01_10_00);
+
+        let colours_u32_grouped_1_lo = _mm_shufflelo_epi16(colours_1, 0b11_01_10_00);
+        let colours_u32_grouped_1 = _mm_shufflehi_epi16(colours_u32_grouped_1_lo, 0b11_01_10_00);
+
+        // Now combine back into single colour registers by shuffling the u32s into their respective positions.
+        let colours_0 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(colours_u32_grouped_0),
+            _mm_castsi128_ps(colours_u32_grouped_1),
+            0b10_00_10_00,
+        ));
+        let colours_1 = _mm_castps_si128(_mm_shuffle_ps(
+            _mm_castsi128_ps(colours_u32_grouped_0),
+            _mm_castsi128_ps(colours_u32_grouped_1),
+            0b11_01_11_01,
+        ));
+
+        let colours_0 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_sse2(colours_0),
+            2 => decorrelate_ycocg_r_var2_sse2(colours_0),
+            3 => decorrelate_ycocg_r_var3_sse2(colours_0),
+            _ => unreachable_unchecked(),
+        };
+
+        let colours_1 = match VARIANT {
+            1 => decorrelate_ycocg_r_var1_sse2(colours_1),
+            2 => decorrelate_ycocg_r_var2_sse2(colours_1),
+            3 => decorrelate_ycocg_r_var3_sse2(colours_1),
+            _ => unreachable_unchecked(),
+        };
+
+        // Store results
+        _mm_storeu_si128(color0_ptr as *mut __m128i, colours_0);
+        _mm_storeu_si128(color1_ptr as *mut __m128i, colours_1);
+        _mm_storeu_si128(indices_ptr as *mut __m128i, idx0);
+        _mm_storeu_si128((indices_ptr as *mut __m128i).add(1), idx1);
+
+        color0_ptr = color0_ptr.add(8); // 16 bytes
+        color1_ptr = color1_ptr.add(8); // 16 bytes
+        indices_ptr = indices_ptr.add(8); // 32 bytes
+    }
+
+    // Remainder
+    let remainder_blocks = block_count % 8;
+    if remainder_blocks > 0 {
+        let variant_enum = match VARIANT {
+            1 => YCoCgVariant::Variant1,
+            2 => YCoCgVariant::Variant2,
+            3 => YCoCgVariant::Variant3,
+            _ => unreachable_unchecked(),
+        };
+        generic::transform_with_split_colour_and_decorr_generic(
+            input_ptr,
+            color0_ptr,
+            color1_ptr,
+            indices_ptr,
+            remainder_blocks,
+            variant_enum,
+        );
+    }
+}
+
+// Wrappers for asm inspection
+#[target_feature(enable = "sse2")]
+unsafe fn transform_var1(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<1>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+#[target_feature(enable = "sse2")]
+unsafe fn transform_var2(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<2>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+#[target_feature(enable = "sse2")]
+unsafe fn transform_var3(
+    input_ptr: *const u8,
+    color0_out: *mut u16,
+    color1_out: *mut u16,
+    indices_out: *mut u32,
+    blocks: usize,
+) {
+    transform_impl::<3>(input_ptr, color0_out, color1_out, indices_out, blocks)
+}
+
+#[inline(always)]
+pub(crate) unsafe fn transform_with_split_colour_and_decorr(
+    input_ptr: *const u8,
+    color0_ptr: *mut u16,
+    color1_ptr: *mut u16,
+    indices_ptr: *mut u32,
+    blocks: usize,
+    variant: YCoCgVariant,
+) {
+    match variant {
+        YCoCgVariant::Variant1 => {
+            transform_var1(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+        }
+        YCoCgVariant::Variant2 => {
+            transform_var2(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+        }
+        YCoCgVariant::Variant3 => {
+            transform_var3(input_ptr, color0_ptr, color1_ptr, indices_ptr, blocks)
+        }
+        YCoCgVariant::None => unreachable_unchecked(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+    use crate::transforms::with_split_colour_and_recorr::untransform::untransform_with_split_colour_and_recorr;
+
+    #[rstest]
+    #[case(YCoCgVariant::Variant1)]
+    #[case(YCoCgVariant::Variant2)]
+    #[case(YCoCgVariant::Variant3)]
+    fn sse2_transform_roundtrip(#[case] variant: YCoCgVariant) {
+        if !has_sse2() {
+            return;
+        }
+        for blocks in 1..=128 {
+            let input = generate_bc1_test_data(blocks);
+            let mut c0_buf = vec![0u16; blocks];
+            let mut c1_buf = vec![0u16; blocks];
+            let mut idx_buf = vec![0u32; blocks];
+            let mut recon = vec![0u8; input.len()];
+            unsafe {
+                transform_with_split_colour_and_decorr(
+                    input.as_ptr(),
+                    c0_buf.as_mut_ptr(),
+                    c1_buf.as_mut_ptr(),
+                    idx_buf.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+                untransform_with_split_colour_and_recorr(
+                    c0_buf.as_ptr(),
+                    c1_buf.as_ptr(),
+                    idx_buf.as_ptr(),
+                    recon.as_mut_ptr(),
+                    blocks,
+                    variant,
+                );
+            }
+            assert_eq!(
+                input.as_slice(),
+                recon.as_slice(),
+                "SSE2 roundtrip mismatch {variant:?}"
+            );
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx2.rs
@@ -185,12 +185,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx2.rs
@@ -9,9 +9,9 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 use dxt_lossless_transform_common::intrinsics::color_565::recorrelate::avx2::*;
 
 pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
     recorrelation_mode: YCoCgVariant,
@@ -19,46 +19,46 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
     match recorrelation_mode {
         YCoCgVariant::None => unreachable_unchecked(),
         YCoCgVariant::Variant1 => {
-            untransform_recorr_var1(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var1(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant2 => {
-            untransform_recorr_var2(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var2(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant3 => {
-            untransform_recorr_var3(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var3(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
     }
 }
 
 // Wrapper functions for assembly inspection using `cargo asm`
 unsafe fn untransform_recorr_var1(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<1>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<1>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr_var2(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<2>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<2>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr_var3(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<3>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<3>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 #[target_feature(enable = "avx2")]
@@ -76,63 +76,61 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
     let aligned_count = block_count - (block_count % 16);
     let color0_ptr_aligned_end = color0_ptr.add(aligned_count);
 
-    if aligned_count > 0 {
-        while color0_ptr < color0_ptr_aligned_end {
-            let color0s = _mm256_loadu_si256(color0_ptr as *const __m256i);
-            color0_ptr = color0_ptr.add(16);
+    while color0_ptr < color0_ptr_aligned_end {
+        let color0s = _mm256_loadu_si256(color0_ptr as *const __m256i);
+        color0_ptr = color0_ptr.add(16);
 
-            let color1s = _mm256_loadu_si256(color1_ptr as *const __m256i);
-            color1_ptr = color1_ptr.add(16);
+        let color1s = _mm256_loadu_si256(color1_ptr as *const __m256i);
+        color1_ptr = color1_ptr.add(16);
 
-            let indices_0 = _mm256_loadu_si256(indices_ptr as *const __m256i);
-            let indices_1 = _mm256_loadu_si256(indices_ptr.add(8) as *const __m256i);
-            indices_ptr = indices_ptr.add(16);
+        let indices_0 = _mm256_loadu_si256(indices_ptr as *const __m256i);
+        let indices_1 = _mm256_loadu_si256(indices_ptr.add(8) as *const __m256i);
+        indices_ptr = indices_ptr.add(16);
 
-            // Apply YCoCg-R recorrelation to the colors using the specified variant
-            let (recorrelated_color0s, recorrelated_color1s) = match VARIANT {
-                1 => (
-                    recorrelate_ycocg_r_var1_avx2(color0s),
-                    recorrelate_ycocg_r_var1_avx2(color1s),
-                ),
-                2 => (
-                    recorrelate_ycocg_r_var2_avx2(color0s),
-                    recorrelate_ycocg_r_var2_avx2(color1s),
-                ),
-                3 => (
-                    recorrelate_ycocg_r_var3_avx2(color0s),
-                    recorrelate_ycocg_r_var3_avx2(color1s),
-                ),
-                _ => unreachable_unchecked(),
-            };
+        // Apply YCoCg-R recorrelation to the colors using the specified variant
+        let (recorrelated_color0s, recorrelated_color1s) = match VARIANT {
+            1 => (
+                recorrelate_ycocg_r_var1_avx2(color0s),
+                recorrelate_ycocg_r_var1_avx2(color1s),
+            ),
+            2 => (
+                recorrelate_ycocg_r_var2_avx2(color0s),
+                recorrelate_ycocg_r_var2_avx2(color1s),
+            ),
+            3 => (
+                recorrelate_ycocg_r_var3_avx2(color0s),
+                recorrelate_ycocg_r_var3_avx2(color1s),
+            ),
+            _ => unreachable_unchecked(),
+        };
 
-            // Mix the colours back into their c0+c1 pairs
-            let colors_0_0 = _mm256_unpacklo_epi16(recorrelated_color0s, recorrelated_color1s);
-            let colors_1_0 = _mm256_unpackhi_epi16(recorrelated_color0s, recorrelated_color1s);
+        // Mix the colours back into their c0+c1 pairs
+        let colors_0_0 = _mm256_unpacklo_epi16(recorrelated_color0s, recorrelated_color1s);
+        let colors_1_0 = _mm256_unpackhi_epi16(recorrelated_color0s, recorrelated_color1s);
 
-            // Because of AVX 'lanes', we need to permute the upper and lower halves
-            let colors_0 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0010_0000);
-            let colors_1 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0011_0001);
+        // Because of AVX 'lanes', we need to permute the upper and lower halves
+        let colors_0 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0010_0000);
+        let colors_1 = _mm256_permute2x128_si256(colors_0_0, colors_1_0, 0b0011_0001);
 
-            // Re-combine the colors and indices into the BC1 block format
-            let blocks_0 = _mm256_unpacklo_epi32(colors_0, indices_0);
-            let blocks_1 = _mm256_unpackhi_epi32(colors_0, indices_0);
-            let blocks_2 = _mm256_unpacklo_epi32(colors_1, indices_1);
-            let blocks_3 = _mm256_unpackhi_epi32(colors_1, indices_1);
+        // Re-combine the colors and indices into the BC1 block format
+        let blocks_0 = _mm256_unpacklo_epi32(colors_0, indices_0);
+        let blocks_1 = _mm256_unpackhi_epi32(colors_0, indices_0);
+        let blocks_2 = _mm256_unpacklo_epi32(colors_1, indices_1);
+        let blocks_3 = _mm256_unpackhi_epi32(colors_1, indices_1);
 
-            // We need to combine the lanes to form the final output blocks.
-            let output_0 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0010_0000);
-            let output_1 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0011_0001);
-            let output_2 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0010_0000);
-            let output_3 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0011_0001);
+        // We need to combine the lanes to form the final output blocks.
+        let output_0 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0010_0000);
+        let output_1 = _mm256_permute2x128_si256(blocks_0, blocks_1, 0b0011_0001);
+        let output_2 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0010_0000);
+        let output_3 = _mm256_permute2x128_si256(blocks_2, blocks_3, 0b0011_0001);
 
-            _mm256_storeu_si256(output_ptr as *mut __m256i, output_0);
-            _mm256_storeu_si256(output_ptr.add(32) as *mut __m256i, output_1);
-            _mm256_storeu_si256(output_ptr.add(64) as *mut __m256i, output_2);
-            _mm256_storeu_si256(output_ptr.add(96) as *mut __m256i, output_3);
+        _mm256_storeu_si256(output_ptr as *mut __m256i, output_0);
+        _mm256_storeu_si256(output_ptr.add(32) as *mut __m256i, output_1);
+        _mm256_storeu_si256(output_ptr.add(64) as *mut __m256i, output_2);
+        _mm256_storeu_si256(output_ptr.add(96) as *mut __m256i, output_3);
 
-            // Advance output pointer
-            output_ptr = output_ptr.add(128);
-        }
+        // Advance output pointer
+        output_ptr = output_ptr.add(128);
     }
 
     // Process any remaining blocks (less than 16) using generic implementation

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx512.rs
@@ -346,12 +346,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/avx512.rs
@@ -161,9 +161,9 @@ unsafe fn get_shared_constants() -> (__m512i, __m512i, __m512i, __m512i) {
 }
 
 pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
     recorrelation_mode: YCoCgVariant,
@@ -171,55 +171,55 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
     match recorrelation_mode {
         YCoCgVariant::None => unreachable_unchecked(),
         YCoCgVariant::Variant1 => {
-            untransform_recorr_var1(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var1(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant2 => {
-            untransform_recorr_var2(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var2(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant3 => {
-            untransform_recorr_var3(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var3(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
     }
 }
 
 // Wrapper functions for assembly inspection using `cargo asm`
 unsafe fn untransform_recorr_var1(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<1>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<1>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr_var2(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<2>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<2>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr_var3(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<3>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<3>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512bw")]
 #[allow(clippy::identity_op)]
 unsafe fn untransform_recorr<const VARIANT: u8>(
-    mut color0_ptr: *const u16,
-    mut color1_ptr: *const u16,
-    mut indices_ptr: *const u32,
+    mut color0_in: *const u16,
+    mut color1_in: *const u16,
+    mut indices_in: *const u32,
     mut output_ptr: *mut u8,
     block_count: usize,
 ) {
@@ -227,72 +227,70 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
 
     // Process 32 blocks (256 bytes) at a time
     let aligned_count = block_count - (block_count % 32);
-    let color0_ptr_aligned_end = color0_ptr.add(aligned_count);
+    let color0_ptr_aligned_end = color0_in.add(aligned_count);
 
-    if aligned_count > 0 {
-        // Get shared constants for permutation masks
-        let (perm_color_interleave_high, perm_color_interleave_low, perm_output_0, perm_output_1) =
-            get_shared_constants();
+    // Get shared constants for permutation masks
+    let (perm_color_interleave_high, perm_color_interleave_low, perm_output_0, perm_output_1) =
+        get_shared_constants();
 
-        while color0_ptr < color0_ptr_aligned_end {
-            // Load 32 blocks worth of data
-            // Load 64 bytes (32 u16 values) of color0 data - 1 read
-            let color0s = _mm512_loadu_si512(color0_ptr as *const __m512i);
-            color0_ptr = color0_ptr.add(32);
+    while color0_in < color0_ptr_aligned_end {
+        // Load 32 blocks worth of data
+        // Load 64 bytes (32 u16 values) of color0 data - 1 read
+        let color0s = _mm512_loadu_si512(color0_in as *const __m512i);
+        color0_in = color0_in.add(32);
 
-            // Load 64 bytes (32 u16 values) of color1 data - 1 read
-            let color1s = _mm512_loadu_si512(color1_ptr as *const __m512i);
-            color1_ptr = color1_ptr.add(32);
+        // Load 64 bytes (32 u16 values) of color1 data - 1 read
+        let color1s = _mm512_loadu_si512(color1_in as *const __m512i);
+        color1_in = color1_in.add(32);
 
-            // Load 128 bytes (32 u32 values) of indices data - 2 reads
-            let indices_0 = _mm512_loadu_si512(indices_ptr as *const __m512i);
-            let indices_1 = _mm512_loadu_si512(indices_ptr.add(16) as *const __m512i);
-            indices_ptr = indices_ptr.add(32);
+        // Load 128 bytes (32 u32 values) of indices data - 2 reads
+        let indices_0 = _mm512_loadu_si512(indices_in as *const __m512i);
+        let indices_1 = _mm512_loadu_si512(indices_in.add(16) as *const __m512i);
+        indices_in = indices_in.add(32);
 
-            // Apply YCoCg-R recorrelation using the specified variant
-            let (recorrelated_color0s, recorrelated_color1s) = match VARIANT {
-                1 => (
-                    recorrelate_ycocg_r_var1_avx512(color0s),
-                    recorrelate_ycocg_r_var1_avx512(color1s),
-                ),
-                2 => (
-                    recorrelate_ycocg_r_var2_avx512(color0s),
-                    recorrelate_ycocg_r_var2_avx512(color1s),
-                ),
-                3 => (
-                    recorrelate_ycocg_r_var3_avx512(color0s),
-                    recorrelate_ycocg_r_var3_avx512(color1s),
-                ),
-                _ => unreachable_unchecked(),
-            };
+        // Apply YCoCg-R recorrelation using the specified variant
+        let (recorrelated_color0s, recorrelated_color1s) = match VARIANT {
+            1 => (
+                recorrelate_ycocg_r_var1_avx512(color0s),
+                recorrelate_ycocg_r_var1_avx512(color1s),
+            ),
+            2 => (
+                recorrelate_ycocg_r_var2_avx512(color0s),
+                recorrelate_ycocg_r_var2_avx512(color1s),
+            ),
+            3 => (
+                recorrelate_ycocg_r_var3_avx512(color0s),
+                recorrelate_ycocg_r_var3_avx512(color1s),
+            ),
+            _ => unreachable_unchecked(),
+        };
 
-            // Interleave color0 and color1 into alternating pairs (first 16 blocks)
-            let colors_0 = _mm512_permutex2var_epi16(
-                recorrelated_color0s,
-                perm_color_interleave_low,
-                recorrelated_color1s,
-            );
-            let colors_1 = _mm512_permutex2var_epi16(
-                recorrelated_color0s,
-                perm_color_interleave_high,
-                recorrelated_color1s,
-            );
+        // Interleave color0 and color1 into alternating pairs (first 16 blocks)
+        let colors_0 = _mm512_permutex2var_epi16(
+            recorrelated_color0s,
+            perm_color_interleave_low,
+            recorrelated_color1s,
+        );
+        let colors_1 = _mm512_permutex2var_epi16(
+            recorrelated_color0s,
+            perm_color_interleave_high,
+            recorrelated_color1s,
+        );
 
-            // Now interleave the recorrelated color pairs with indices to create final BC1 blocks
-            let output_0 = _mm512_permutex2var_epi16(colors_0, perm_output_0, indices_0);
-            let output_1 = _mm512_permutex2var_epi16(colors_0, perm_output_1, indices_0);
-            let output_2 = _mm512_permutex2var_epi16(colors_1, perm_output_0, indices_1);
-            let output_3 = _mm512_permutex2var_epi16(colors_1, perm_output_1, indices_1);
+        // Now interleave the recorrelated color pairs with indices to create final BC1 blocks
+        let output_0 = _mm512_permutex2var_epi16(colors_0, perm_output_0, indices_0);
+        let output_1 = _mm512_permutex2var_epi16(colors_0, perm_output_1, indices_0);
+        let output_2 = _mm512_permutex2var_epi16(colors_1, perm_output_0, indices_1);
+        let output_3 = _mm512_permutex2var_epi16(colors_1, perm_output_1, indices_1);
 
-            // Write results - 32 blocks * 8 bytes = 256 bytes total
-            _mm512_storeu_si512(output_ptr as *mut __m512i, output_0);
-            _mm512_storeu_si512(output_ptr.add(64) as *mut __m512i, output_1);
-            _mm512_storeu_si512(output_ptr.add(128) as *mut __m512i, output_2);
-            _mm512_storeu_si512(output_ptr.add(192) as *mut __m512i, output_3);
+        // Write results - 32 blocks * 8 bytes = 256 bytes total
+        _mm512_storeu_si512(output_ptr as *mut __m512i, output_0);
+        _mm512_storeu_si512(output_ptr.add(64) as *mut __m512i, output_1);
+        _mm512_storeu_si512(output_ptr.add(128) as *mut __m512i, output_2);
+        _mm512_storeu_si512(output_ptr.add(192) as *mut __m512i, output_3);
 
-            // Advance output pointer
-            output_ptr = output_ptr.add(256);
-        }
+        // Advance output pointer
+        output_ptr = output_ptr.add(256);
     }
 
     // Process any remaining blocks (less than 32) using scalar code
@@ -300,23 +298,23 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
     // Delegate to the generic implementation for remaining blocks
     match VARIANT {
         1 => super::generic::untransform_recorr_var1(
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_in,
+            color1_in,
+            indices_in,
             output_ptr,
             remaining_count,
         ),
         2 => super::generic::untransform_recorr_var2(
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_in,
+            color1_in,
+            indices_in,
             output_ptr,
             remaining_count,
         ),
         3 => super::generic::untransform_recorr_var3(
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_in,
+            color1_in,
+            indices_in,
             output_ptr,
             remaining_count,
         ),

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/generic.rs
@@ -6,9 +6,9 @@ use dxt_lossless_transform_common::{
 };
 
 pub(crate) unsafe fn untransform_with_split_colour_and_recorr_generic(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
     recorrelation_mode: YCoCgVariant,
@@ -25,16 +25,16 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr_generic(
     //              For x86 at least, I got custom intrinsic functions, to overcome this.
 
     // Allocating here has some overhead, so we'll delegate to the slower solution if under 512 bytes.
-    // 64 blocks is 512 bytes
-    if block_count >= 64 {
+    // 128 blocks is 1024 bytes
+    if block_count >= 128 {
         let mut work_alloc =
             allocate_align_64(block_count * 8).expect("Failed to allocate work buffer");
         let work_ptr = work_alloc.as_mut_ptr();
 
         // Recorrelate colours into work area, doing the unsplit in the same process.
         Color565::recorrelate_ycocg_r_ptr_split(
-            color0_ptr as *mut Color565,
-            color1_ptr as *mut Color565,
+            color0_in as *mut Color565,
+            color1_in as *mut Color565,
             work_ptr as *mut Color565,
             block_count * 2, // 2 colour endpoints per block.
             recorrelation_mode,
@@ -43,7 +43,7 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr_generic(
         // Now unsplit the colours, placing them into the final buffer
         unsplit_block_with_separate_pointers(
             work_ptr as *const u32,
-            indices_ptr,
+            indices_in,
             output_ptr,
             block_count * 8,
         );
@@ -53,65 +53,60 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr_generic(
     match recorrelation_mode {
         YCoCgVariant::None => unreachable_unchecked(),
         YCoCgVariant::Variant1 => {
-            untransform_recorr_var1(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var1(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant2 => {
-            untransform_recorr_var2(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var2(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant3 => {
-            untransform_recorr_var3(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var3(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
     }
 }
 
 // Wrapper functions for assembly inspection using `cargo asm`
 pub(crate) unsafe fn untransform_recorr_var1(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<1>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<1>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 pub(crate) unsafe fn untransform_recorr_var2(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<2>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<2>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 pub(crate) unsafe fn untransform_recorr_var3(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<3>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<3>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr<const VARIANT: u8>(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
-    output_ptr: *mut u8,
+    mut color0_in: *const u16,
+    mut color1_in: *const u16,
+    mut indices_in: *const u32,
+    mut output_ptr: *mut u8,
     block_count: usize,
 ) {
-    // Initialize pointers for iteration
-    let mut color0_ptr = color0_ptr;
-    let mut color1_ptr = color1_ptr;
-    let mut indices_ptr = indices_ptr;
-    let mut output_ptr = output_ptr;
-
-    for _ in 0..block_count {
+    let color0_end = color0_in.add(block_count);
+    while color0_in < color0_end {
         // Read the correlated colors and apply recorrelation using the specified variant
-        let color0_obj = Color565::from_raw(color0_ptr.read_unaligned());
-        let color1_obj = Color565::from_raw(color1_ptr.read_unaligned());
+        let color0_obj = Color565::from_raw(color0_in.read_unaligned());
+        let color1_obj = Color565::from_raw(color1_in.read_unaligned());
         let (recorrelated_color0, recorrelated_color1) = match VARIANT {
             1 => (
                 color0_obj.recorrelate_ycocg_r_var1(),
@@ -129,7 +124,7 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
         };
 
         // Read the indices
-        let indices = indices_ptr.read_unaligned();
+        let indices = indices_in.read_unaligned();
 
         // Write the BC1 block directly: color0 (2 bytes) + color1 (2 bytes) + indices (4 bytes)
         // Colors are stored in little-endian format as u16 values
@@ -138,9 +133,9 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
         (output_ptr.add(4) as *mut u32).write_unaligned(indices);
 
         // Advance pointers
-        color0_ptr = color0_ptr.add(1);
-        color1_ptr = color1_ptr.add(1);
-        indices_ptr = indices_ptr.add(1);
+        color0_in = color0_in.add(1);
+        color1_in = color1_in.add(1);
+        indices_in = indices_in.add(1);
         output_ptr = output_ptr.add(8); // 8 bytes per BC1 block
     }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/generic.rs
@@ -160,12 +160,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/mod.rs
@@ -60,7 +60,7 @@ unsafe fn untransform_with_split_colour_and_recorr_x86(
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
-        if has_avx512f() {
+        if has_avx512f() && has_avx512bw() {
             avx512::untransform_with_split_colour_and_recorr(
                 color0_ptr,
                 color1_ptr,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/sse2.rs
@@ -171,12 +171,10 @@ mod tests {
 
             // Transform using standard implementation
             let mut transformed = vec![0u8; original.len()];
-            let mut work = vec![0u8; original.len()];
             unsafe {
                 transform_bc1(
                     original.as_ptr(),
                     transformed.as_mut_ptr(),
-                    work.as_mut_ptr(),
                     original.len(),
                     Bc1TransformDetails {
                         color_normalization_mode: ColorNormalizationMode::None,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/sse2.rs
@@ -9,9 +9,9 @@ use dxt_lossless_transform_common::color_565::YCoCgVariant;
 use dxt_lossless_transform_common::intrinsics::color_565::recorrelate::sse2::*;
 
 pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
     recorrelation_mode: YCoCgVariant,
@@ -19,54 +19,54 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr(
     match recorrelation_mode {
         YCoCgVariant::None => unreachable_unchecked(),
         YCoCgVariant::Variant1 => {
-            untransform_recorr_var1(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var1(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant2 => {
-            untransform_recorr_var2(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var2(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
         YCoCgVariant::Variant3 => {
-            untransform_recorr_var3(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+            untransform_recorr_var3(color0_in, color1_in, indices_in, output_ptr, block_count)
         }
     }
 }
 
 // Wrapper functions for assembly inspection using `cargo asm`
 unsafe fn untransform_recorr_var1(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<1>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<1>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr_var2(
-    color0_ptr: *const u16,
-    color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    color0_in: *const u16,
+    color1_in: *const u16,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<2>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<2>(color0_in, color1_in, indices_in, output_ptr, block_count)
 }
 
 unsafe fn untransform_recorr_var3(
-    color0_ptr: *const u16,
+    color0_in: *const u16,
     color1_ptr: *const u16,
-    indices_ptr: *const u32,
+    indices_in: *const u32,
     output_ptr: *mut u8,
     block_count: usize,
 ) {
-    untransform_recorr::<3>(color0_ptr, color1_ptr, indices_ptr, output_ptr, block_count)
+    untransform_recorr::<3>(color0_in, color1_ptr, indices_in, output_ptr, block_count)
 }
 
 #[target_feature(enable = "sse2")]
 #[allow(clippy::identity_op)]
 unsafe fn untransform_recorr<const VARIANT: u8>(
-    mut color0_ptr: *const u16,
-    mut color1_ptr: *const u16,
-    mut indices_ptr: *const u32,
+    mut color0_in: *const u16,
+    mut color1_in: *const u16,
+    mut indices_in: *const u32,
     mut output_ptr: *mut u8,
     block_count: usize,
 ) {
@@ -74,78 +74,76 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
 
     // Process 8 blocks (64 bytes) at a time with SSE2
     let aligned_count = block_count - (block_count % 8);
-    let color0_ptr_aligned_end = color0_ptr.add(aligned_count);
+    let color0_ptr_aligned_end = color0_in.add(aligned_count);
 
-    if aligned_count > 0 {
-        while color0_ptr < color0_ptr_aligned_end {
-            let color0s = _mm_loadu_si128(color0_ptr as *const __m128i);
-            color0_ptr = color0_ptr.add(8);
+    while color0_in < color0_ptr_aligned_end {
+        let color0s = _mm_loadu_si128(color0_in as *const __m128i);
+        color0_in = color0_in.add(8);
 
-            let color1s = _mm_loadu_si128(color1_ptr as *const __m128i);
-            color1_ptr = color1_ptr.add(8);
+        let color1s = _mm_loadu_si128(color1_in as *const __m128i);
+        color1_in = color1_in.add(8);
 
-            let indices_0 = _mm_loadu_si128(indices_ptr as *const __m128i);
-            let indices_1 = _mm_loadu_si128(indices_ptr.add(4) as *const __m128i);
-            indices_ptr = indices_ptr.add(8);
+        let indices_0 = _mm_loadu_si128(indices_in as *const __m128i);
+        let indices_1 = _mm_loadu_si128(indices_in.add(4) as *const __m128i);
+        indices_in = indices_in.add(8);
 
-            // Apply YCoCg-R recorrelation to the colors using the specified variant
-            let (recorr_color0s, recorr_color1s) = match VARIANT {
-                1 => (
-                    recorrelate_ycocg_r_var1_sse2(color0s),
-                    recorrelate_ycocg_r_var1_sse2(color1s),
-                ),
-                2 => (
-                    recorrelate_ycocg_r_var2_sse2(color0s),
-                    recorrelate_ycocg_r_var2_sse2(color1s),
-                ),
-                3 => (
-                    recorrelate_ycocg_r_var3_sse2(color0s),
-                    recorrelate_ycocg_r_var3_sse2(color1s),
-                ),
-                _ => unreachable_unchecked(),
-            };
+        // Apply YCoCg-R recorrelation to the colors using the specified variant
+        let (recorr_color0s, recorr_color1s) = match VARIANT {
+            1 => (
+                recorrelate_ycocg_r_var1_sse2(color0s),
+                recorrelate_ycocg_r_var1_sse2(color1s),
+            ),
+            2 => (
+                recorrelate_ycocg_r_var2_sse2(color0s),
+                recorrelate_ycocg_r_var2_sse2(color1s),
+            ),
+            3 => (
+                recorrelate_ycocg_r_var3_sse2(color0s),
+                recorrelate_ycocg_r_var3_sse2(color1s),
+            ),
+            _ => unreachable_unchecked(),
+        };
 
-            // Mix the colours back into their c0+c1 pairs
-            let colors_0 = _mm_unpacklo_epi16(recorr_color0s, recorr_color1s);
-            let colors_1 = _mm_unpackhi_epi16(recorr_color0s, recorr_color1s);
+        // Mix the colours back into their c0+c1 pairs
+        let colors_0 = _mm_unpacklo_epi16(recorr_color0s, recorr_color1s);
+        let colors_1 = _mm_unpackhi_epi16(recorr_color0s, recorr_color1s);
 
-            // Re-combine the colors and indices into the BC1 block format
-            let blocks_0 = _mm_unpacklo_epi32(colors_0, indices_0);
-            let blocks_1 = _mm_unpackhi_epi32(colors_0, indices_0);
-            let blocks_2 = _mm_unpacklo_epi32(colors_1, indices_1);
-            let blocks_3 = _mm_unpackhi_epi32(colors_1, indices_1);
+        // Re-combine the colors and indices into the BC1 block format
+        let blocks_0 = _mm_unpacklo_epi32(colors_0, indices_0);
+        let blocks_1 = _mm_unpackhi_epi32(colors_0, indices_0);
+        let blocks_2 = _mm_unpacklo_epi32(colors_1, indices_1);
+        let blocks_3 = _mm_unpackhi_epi32(colors_1, indices_1);
 
-            _mm_storeu_si128(output_ptr as *mut __m128i, blocks_0);
-            _mm_storeu_si128(output_ptr.add(16) as *mut __m128i, blocks_1);
-            _mm_storeu_si128(output_ptr.add(32) as *mut __m128i, blocks_2);
-            _mm_storeu_si128(output_ptr.add(48) as *mut __m128i, blocks_3);
+        _mm_storeu_si128(output_ptr as *mut __m128i, blocks_0);
+        _mm_storeu_si128(output_ptr.add(16) as *mut __m128i, blocks_1);
+        _mm_storeu_si128(output_ptr.add(32) as *mut __m128i, blocks_2);
+        _mm_storeu_si128(output_ptr.add(48) as *mut __m128i, blocks_3);
 
-            // Advance output pointer
-            output_ptr = output_ptr.add(64);
-        }
+        // Advance output pointer
+        output_ptr = output_ptr.add(64);
     }
 
     // Process any remaining blocks (less than 8) using generic implementation
     let remaining_count = block_count - aligned_count;
     match VARIANT {
         1 => super::generic::untransform_recorr_var1(
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_in,
+            color1_in,
+            indices_in,
             output_ptr,
             remaining_count,
         ),
         2 => super::generic::untransform_recorr_var2(
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_in,
+            color1_in,
+            indices_in,
             output_ptr,
             remaining_count,
         ),
         3 => super::generic::untransform_recorr_var3(
-            color0_ptr,
-            color1_ptr,
-            indices_ptr,
+            color0_in,
+            color1_in,
+            indices_in,
             output_ptr,
             remaining_count,
         ),

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/sse2.rs
@@ -156,6 +156,7 @@ unsafe fn untransform_recorr<const VARIANT: u8>(
 #[cfg(test)]
 mod tests {
     use crate::test_prelude::*;
+    use crate::transforms::with_split_colour_and_recorr::untransform::untransform_with_split_colour_and_recorr;
 
     #[rstest]
     #[case(YCoCgVariant::Variant1)]

--- a/projects/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc2/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+// Not yet in stable today, but will be in 1.89.0
+#![allow(stable_features)]
 #![cfg_attr(
     all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")),
     feature(stdarch_x86_avx512)

--- a/projects/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc3/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+// Not yet in stable today, but will be in 1.89.0
+#![allow(stable_features)]
 #![cfg_attr(
     all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")),
     feature(stdarch_x86_avx512)

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/benchmark.rs
@@ -322,13 +322,11 @@ unsafe fn process_scenario(
 ) -> Result<Option<BenchmarkScenarioResult>, TransformError> {
     // Allocate buffers
     let mut transformed_data = allocate_align_64(len_bytes)?;
-    let mut work_buffer = allocate_align_64(len_bytes)?;
 
     // Transform the original data
     transform_bc1(
         data_ptr,
         transformed_data.as_mut_ptr(),
-        work_buffer.as_mut_ptr(),
         len_bytes,
         transform_details,
     );

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/calc_compression_stats.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/calc_compression_stats.rs
@@ -212,6 +212,7 @@ fn analyze_bc1_compression_transforms(
     Ok(results)
 }
 
+#[allow(clippy::too_many_arguments)]
 unsafe fn analyze_bc1_api_recommendation(
     data_ptr: *const u8,
     len_bytes: usize,

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/calc_compression_stats.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/calc_compression_stats.rs
@@ -183,8 +183,6 @@ fn analyze_bc1_compression_transforms(
 ) -> Result<Vec<Bc1TransformResult>, TransformError> {
     // Allocate aligned buffers for transformations
     let mut transformed_data = allocate_align_64(len_bytes)?;
-    let mut work_buffer = allocate_align_64(len_bytes)?;
-
     let mut results = Vec::new();
     unsafe {
         // Test all transform combinations
@@ -193,7 +191,6 @@ fn analyze_bc1_compression_transforms(
             transform_bc1(
                 data_ptr,
                 transformed_data.as_mut_ptr(),
-                work_buffer.as_mut_ptr(),
                 len_bytes,
                 transform_options,
             );
@@ -254,12 +251,9 @@ unsafe fn analyze_bc1_api_recommendation(
 
     // Transform the data using the recommended details and measure the size
     let mut transformed_data = allocate_align_64(len_bytes)?;
-    let mut work_buffer = allocate_align_64(len_bytes)?;
-
     transform_bc1(
         data_ptr,
         transformed_data.as_mut_ptr(),
-        work_buffer.as_mut_ptr(),
         len_bytes,
         best_details,
     );

--- a/projects/dxt-lossless-transform-cli/src/debug_bc1/roundtrip.rs
+++ b/projects/dxt-lossless-transform-cli/src/debug_bc1/roundtrip.rs
@@ -58,7 +58,6 @@ pub(crate) fn handle_roundtrip_command(cmd: RoundtripCmd) -> Result<(), Transfor
 fn test_bc1_roundtrip(data_ptr: *const u8, len_bytes: usize) -> Result<(), TransformError> {
     // Allocate aligned buffers
     let mut transformed_data = allocate_align_64(len_bytes)?;
-    let mut work_buffer = allocate_align_64(len_bytes)?;
     let mut roundtrip_data = allocate_align_64(len_bytes)?;
 
     unsafe {
@@ -68,20 +67,17 @@ fn test_bc1_roundtrip(data_ptr: *const u8, len_bytes: usize) -> Result<(), Trans
             transform_bc1(
                 data_ptr,
                 transformed_data.as_mut_ptr(),
-                work_buffer.as_mut_ptr(),
                 len_bytes,
                 transform_options,
             );
 
             // Untransform the data back
-            work_buffer.as_mut_slice().fill(0x00); // reset work buffer
             untransform_bc1(
                 transformed_data.as_ptr(),
                 roundtrip_data.as_mut_ptr(),
                 len_bytes,
                 transform_options.into(),
             );
-            work_buffer.as_mut_slice().fill(0x00); // reset work buffer (again)
 
             // Compare all pixels by decoding each block
             let num_blocks = len_bytes / 8;

--- a/projects/dxt-lossless-transform-cli/src/main.rs
+++ b/projects/dxt-lossless-transform-cli/src/main.rs
@@ -13,7 +13,6 @@ mod util;
 use argh::FromArgs;
 use core::{error::Error, ops::Sub, ptr::copy_nonoverlapping};
 use dxt_lossless_transform_api::*;
-use dxt_lossless_transform_common::allocate::allocate_align_64;
 use error::TransformError;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use std::{
@@ -188,14 +187,7 @@ pub unsafe fn transform_format(
     len: usize,
     format: DdsFormat,
 ) {
-    let mut work_ptr = allocate_align_64(len).expect("Failed to allocate work buffer");
-    dxt_lossless_transform_api::transform_format(
-        input_ptr,
-        output_ptr,
-        work_ptr.as_mut_ptr(),
-        len,
-        format,
-    )
+    dxt_lossless_transform_api::transform_format(input_ptr, output_ptr, len, format)
 }
 
 /// # Safety

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx2.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx2.rs
@@ -37,6 +37,7 @@ use core::arch::x86_64::*;
 ///
 /// [`Color565`]: crate::color_565::Color565
 #[target_feature(enable = "avx2")]
+#[inline]
 pub unsafe fn decorrelate_ycocg_r_var1_avx2(colors_raw: __m256i) -> __m256i {
     // Constants
     let mask_5bit = _mm256_set1_epi16(0x1F); // 31 in decimal, 0b11111 in binary
@@ -91,6 +92,7 @@ pub unsafe fn decorrelate_ycocg_r_var1_avx2(colors_raw: __m256i) -> __m256i {
 ///
 /// [`Color565`]: crate::color_565::Color565
 #[target_feature(enable = "avx2")]
+#[inline]
 pub unsafe fn decorrelate_ycocg_r_var2_avx2(colors_raw: __m256i) -> __m256i {
     // Constants
     let mask_5bit = _mm256_set1_epi16(0x1F); // 31 in decimal, 0b11111 in binary
@@ -145,6 +147,7 @@ pub unsafe fn decorrelate_ycocg_r_var2_avx2(colors_raw: __m256i) -> __m256i {
 ///
 /// [`Color565`]: crate::color_565::Color565
 #[target_feature(enable = "avx2")]
+#[inline]
 pub unsafe fn decorrelate_ycocg_r_var3_avx2(colors_raw: __m256i) -> __m256i {
     // Constants
     let mask_5bit = _mm256_set1_epi16(0x1F); // 31 in decimal, 0b11111 in binary

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx2.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx2.rs
@@ -1,0 +1,264 @@
+//! AVX2 intrinsics for YCoCg-R decorrelation on [`Color565`] values.
+//!
+//! This module provides AVX2-optimized functions for performing YCoCg-R decorrelation
+//! transformations on packed [`Color565`] data in 256-bit registers.
+//!
+//! # Functions
+//!
+//! - [`decorrelate_ycocg_r_var1_avx2`] - Applies YCoCg-R variant 1 decorrelation (g_low at bit 5)
+//! - [`decorrelate_ycocg_r_var2_avx2`] - Applies YCoCg-R variant 2 decorrelation (g_low at bit 15)  
+//! - [`decorrelate_ycocg_r_var3_avx2`] - Applies YCoCg-R variant 3 decorrelation (g_low at bit 0)
+//!
+//! Each function processes 16 [`Color565`] values simultaneously using AVX2 instructions.
+//!
+//! [`Color565`]: crate::color_565::Color565
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// Applies YCoCg-R variant 1 decorrelation to 16 [`Color565`] values using AVX2.
+///
+/// This variant places the g_low bit at position 5 in the output format.
+/// Output format: `((y << 11) | (co << 6) | (g_low << 5) | cg)`
+///
+/// # Parameters
+///
+/// - `colors_raw`: A 256-bit register containing 16 packed [`Color565`] values
+///
+/// # Returns
+///
+/// A 256-bit register containing 16 decorrelated [`Color565`] values
+///
+/// # Safety
+///
+/// This function requires AVX2 support. Caller must ensure the target CPU supports AVX2.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[target_feature(enable = "avx2")]
+pub unsafe fn decorrelate_ycocg_r_var1_avx2(colors_raw: __m256i) -> __m256i {
+    // Constants
+    let mask_5bit = _mm256_set1_epi16(0x1F); // 31 in decimal, 0b11111 in binary
+    let mask_1bit = _mm256_set1_epi16(0x01); // 1 in decimal
+
+    // Extract RGB components
+    let r = _mm256_srli_epi16(colors_raw, 11); // Red: bits 15-11
+    let g = _mm256_srli_epi16(colors_raw, 6); // Green: bits 10-6 (upper 5 bits)
+    let g_low = _mm256_and_si256(_mm256_srli_epi16(colors_raw, 5), mask_1bit); // Green low bit
+    let b = _mm256_and_si256(colors_raw, mask_5bit); // Blue: bits 4-0
+
+    // Apply YCoCg-R forward transform
+    // Step 1: Co = (R - B) & 0x1F
+    let co = _mm256_and_si256(_mm256_sub_epi16(r, b), mask_5bit);
+
+    // Step 2: t = (B + (Co >> 1)) & 0x1F
+    let t = _mm256_and_si256(_mm256_add_epi16(b, _mm256_srli_epi16(co, 1)), mask_5bit);
+
+    // Step 3: Cg = (G - t) & 0x1F
+    let cg = _mm256_and_si256(_mm256_sub_epi16(g, t), mask_5bit);
+
+    // Step 4: Y = (t + (Cg >> 1)) & 0x1F
+    let y = _mm256_and_si256(_mm256_add_epi16(t, _mm256_srli_epi16(cg, 1)), mask_5bit);
+
+    // Pack into Color565 format: ((y << 11) | (co << 6) | (g_low << 5) | cg)
+    let y_shifted = _mm256_slli_epi16(y, 11);
+    let co_shifted = _mm256_slli_epi16(co, 6);
+    let g_low_shifted = _mm256_slli_epi16(g_low, 5);
+
+    _mm256_or_si256(
+        _mm256_or_si256(y_shifted, co_shifted),
+        _mm256_or_si256(g_low_shifted, cg),
+    )
+}
+
+/// Applies YCoCg-R variant 2 decorrelation to 16 [`Color565`] values using AVX2.
+///
+/// This variant places the g_low bit at position 15 (top bit) in the output format.
+/// Output format: `((g_low << 15) | (y << 10) | (co << 5) | cg)`
+///
+/// # Parameters
+///
+/// - `colors_raw`: A 256-bit register containing 16 packed [`Color565`] values
+///
+/// # Returns
+///
+/// A 256-bit register containing 16 decorrelated [`Color565`] values
+///
+/// # Safety
+///
+/// This function requires AVX2 support. Caller must ensure the target CPU supports AVX2.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[target_feature(enable = "avx2")]
+pub unsafe fn decorrelate_ycocg_r_var2_avx2(colors_raw: __m256i) -> __m256i {
+    // Constants
+    let mask_5bit = _mm256_set1_epi16(0x1F); // 31 in decimal, 0b11111 in binary
+    let mask_1bit = _mm256_set1_epi16(0x01); // 1 in decimal
+
+    // Extract RGB components
+    let r = _mm256_srli_epi16(colors_raw, 11); // Red: bits 15-11
+    let g = _mm256_srli_epi16(colors_raw, 6); // Green: bits 10-6 (upper 5 bits)
+    let g_low = _mm256_and_si256(_mm256_srli_epi16(colors_raw, 5), mask_1bit); // Green low bit
+    let b = _mm256_and_si256(colors_raw, mask_5bit); // Blue: bits 4-0
+
+    // Apply YCoCg-R forward transform
+    // Step 1: Co = (R - B) & 0x1F
+    let co = _mm256_and_si256(_mm256_sub_epi16(r, b), mask_5bit);
+
+    // Step 2: t = (B + (Co >> 1)) & 0x1F
+    let t = _mm256_and_si256(_mm256_add_epi16(b, _mm256_srli_epi16(co, 1)), mask_5bit);
+
+    // Step 3: Cg = (G - t) & 0x1F
+    let cg = _mm256_and_si256(_mm256_sub_epi16(g, t), mask_5bit);
+
+    // Step 4: Y = (t + (Cg >> 1)) & 0x1F
+    let y = _mm256_and_si256(_mm256_add_epi16(t, _mm256_srli_epi16(cg, 1)), mask_5bit);
+
+    // Pack into Color565 format: ((g_low << 15) | (y << 10) | (co << 5) | cg)
+    let g_low_shifted = _mm256_slli_epi16(g_low, 15);
+    let y_shifted = _mm256_slli_epi16(y, 10);
+    let co_shifted = _mm256_slli_epi16(co, 5);
+
+    _mm256_or_si256(
+        _mm256_or_si256(g_low_shifted, y_shifted),
+        _mm256_or_si256(co_shifted, cg),
+    )
+}
+
+/// Applies YCoCg-R variant 3 decorrelation to 16 [`Color565`] values using AVX2.
+///
+/// This variant places the g_low bit at position 0 (bottom bit) in the output format.
+/// Output format: `((y << 11) | (co << 6) | (cg << 1) | g_low)`
+///
+/// # Parameters
+///
+/// - `colors_raw`: A 256-bit register containing 16 packed [`Color565`] values
+///
+/// # Returns
+///
+/// A 256-bit register containing 16 decorrelated [`Color565`] values
+///
+/// # Safety
+///
+/// This function requires AVX2 support. Caller must ensure the target CPU supports AVX2.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[target_feature(enable = "avx2")]
+pub unsafe fn decorrelate_ycocg_r_var3_avx2(colors_raw: __m256i) -> __m256i {
+    // Constants
+    let mask_5bit = _mm256_set1_epi16(0x1F); // 31 in decimal, 0b11111 in binary
+    let mask_1bit = _mm256_set1_epi16(0x01); // 1 in decimal
+
+    // Extract RGB components
+    let r = _mm256_srli_epi16(colors_raw, 11); // Red: bits 15-11
+    let g = _mm256_srli_epi16(colors_raw, 6); // Green: bits 10-6 (upper 5 bits)
+    let g_low = _mm256_and_si256(_mm256_srli_epi16(colors_raw, 5), mask_1bit); // Green low bit
+    let b = _mm256_and_si256(colors_raw, mask_5bit); // Blue: bits 4-0
+
+    // Apply YCoCg-R forward transform
+    // Step 1: Co = (R - B) & 0x1F
+    let co = _mm256_and_si256(_mm256_sub_epi16(r, b), mask_5bit);
+
+    // Step 2: t = (B + (Co >> 1)) & 0x1F
+    let t = _mm256_and_si256(_mm256_add_epi16(b, _mm256_srli_epi16(co, 1)), mask_5bit);
+
+    // Step 3: Cg = (G - t) & 0x1F
+    let cg = _mm256_and_si256(_mm256_sub_epi16(g, t), mask_5bit);
+
+    // Step 4: Y = (t + (Cg >> 1)) & 0x1F
+    let y = _mm256_and_si256(_mm256_add_epi16(t, _mm256_srli_epi16(cg, 1)), mask_5bit);
+
+    // Pack into Color565 format: ((y << 11) | (co << 6) | (cg << 1) | g_low)
+    let y_shifted = _mm256_slli_epi16(y, 11);
+    let co_shifted = _mm256_slli_epi16(co, 6);
+    let cg_shifted = _mm256_slli_epi16(cg, 1);
+
+    _mm256_or_si256(
+        _mm256_or_si256(y_shifted, co_shifted),
+        _mm256_or_si256(cg_shifted, g_low),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color_565::Color565;
+    use rstest::rstest;
+
+    /// Test data for all decorrelation variants
+    fn get_test_colors() -> [Color565; 16] {
+        [
+            Color565::from_rgb(255, 128, 64),  // Orange
+            Color565::from_rgb(128, 255, 192), // Light green
+            Color565::from_rgb(64, 128, 255),  // Light blue
+            Color565::from_rgb(192, 64, 128),  // Pink
+            Color565::from_raw(0x1234),        // Random value 1
+            Color565::from_raw(0x5678),        // Random value 2
+            Color565::from_raw(0x9ABC),        // Random value 3
+            Color565::from_raw(0xDEF0),        // Random value 4
+            Color565::from_raw(0x2468),        // Even bits
+            Color565::from_raw(0x1357),        // Odd bits
+            Color565::from_raw(0xACE0),        // Mixed pattern 1
+            Color565::from_raw(0x1359),        // Mixed pattern 2
+            Color565::from_raw(0x7531),        // Mixed pattern 3
+            Color565::from_raw(0x9BDF),        // Mixed pattern 4
+            Color565::from_raw(0x4682),        // Mixed pattern 5
+            Color565::from_raw(0xCEA8),        // Mixed pattern 6
+        ]
+    }
+
+    #[rstest]
+    #[case(
+        decorrelate_ycocg_r_var1_avx2,
+        Color565::decorrelate_ycocg_r_var1_ptr,
+        "variant 1"
+    )]
+    #[case(
+        decorrelate_ycocg_r_var2_avx2,
+        Color565::decorrelate_ycocg_r_var2_ptr,
+        "variant 2"
+    )]
+    #[case(
+        decorrelate_ycocg_r_var3_avx2,
+        Color565::decorrelate_ycocg_r_var3_ptr,
+        "variant 3"
+    )]
+    fn test_avx2_vs_reference_implementation(
+        #[case] intrinsic_fn: unsafe fn(__m256i) -> __m256i,
+        #[case] reference_fn: unsafe fn(*const Color565, *mut Color565, usize),
+        #[case] variant_name: &str,
+    ) {
+        if !is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        let test_colors = get_test_colors();
+
+        unsafe {
+            let mut reference_results = [Color565::from_raw(0); 16];
+            reference_fn(
+                test_colors.as_ptr(),
+                reference_results.as_mut_ptr(),
+                test_colors.len(),
+            );
+
+            let input_reg = _mm256_loadu_si256(test_colors.as_ptr() as *const __m256i);
+            let result_reg = intrinsic_fn(input_reg);
+            let mut intrinsic_results = [Color565::from_raw(0); 16];
+            _mm256_storeu_si256(intrinsic_results.as_mut_ptr() as *mut __m256i, result_reg);
+
+            for (x, (&intrinsic_result, &reference_result)) in intrinsic_results
+                .iter()
+                .zip(reference_results.iter())
+                .take(test_colors.len())
+                .enumerate()
+            {
+                assert_eq!(
+                    intrinsic_result, reference_result,
+                    "AVX2 {variant_name} mismatch at index {x}: intrinsic={intrinsic_result:?}, reference={reference_result:?}"
+                );
+            }
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx512.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx512.rs
@@ -39,6 +39,7 @@ use core::arch::x86_64::*;
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512bw")]
+#[inline]
 pub unsafe fn decorrelate_ycocg_r_var1_avx512(colors_raw: __m512i) -> __m512i {
     // === Constants from assembly ===
     let mask_31 = _mm512_set1_epi32(0x001F001F); // .LCPI21_1: mask for 5-bit values (31,31)
@@ -116,6 +117,7 @@ pub unsafe fn decorrelate_ycocg_r_var1_avx512(colors_raw: __m512i) -> __m512i {
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512bw")]
+#[inline]
 pub unsafe fn decorrelate_ycocg_r_var2_avx512(colors_raw: __m512i) -> __m512i {
     // === Constants from assembly ===
     let mask_31 = _mm512_set1_epi32(0x001F001F); // .LCPI22_1: mask for 5-bit values (31,31)
@@ -199,6 +201,7 @@ pub unsafe fn decorrelate_ycocg_r_var2_avx512(colors_raw: __m512i) -> __m512i {
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512bw")]
+#[inline]
 pub unsafe fn decorrelate_ycocg_r_var3_avx512(colors_raw: __m512i) -> __m512i {
     // === Constants from assembly ===
     let mask_31 = _mm512_set1_epi16(31); // .LCPI24_2: mask for 5-bit values (0x001F)

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx512.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx512.rs
@@ -1,0 +1,361 @@
+//! AVX512 intrinsics for YCoCg-R decorrelation on [`Color565`] values.
+//!
+//! This module provides AVX512-optimized functions for performing YCoCg-R decorrelation
+//! transformations on packed [`Color565`] data in 512-bit registers.
+//!
+//! # Functions
+//!
+//! - [`decorrelate_ycocg_r_var1_avx512`] - Applies YCoCg-R variant 1 decorrelation (g_low at bit 5)
+//! - [`decorrelate_ycocg_r_var2_avx512`] - Applies YCoCg-R variant 2 decorrelation (g_low at bit 15)  
+//! - [`decorrelate_ycocg_r_var3_avx512`] - Applies YCoCg-R variant 3 decorrelation (g_low at bit 0)
+//!
+//! Each function processes 32 [`Color565`] values simultaneously using AVX512 instructions.
+//!
+//! [`Color565`]: crate::color_565::Color565
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// Applies YCoCg-R variant 1 decorrelation to 32 [`Color565`] values using AVX512.
+///
+/// This variant places the g_low bit at position 5 in the output format.
+/// Output format: `((y << 11) | (co << 6) | (g_low << 5) | cg)`
+///
+/// # Parameters
+///
+/// - `colors_raw`: A 512-bit register containing 32 packed [`Color565`] values
+///
+/// # Returns
+///
+/// A 512-bit register containing 32 decorrelated [`Color565`] values
+///
+/// # Safety
+///
+/// This function requires AVX512F and AVX512BW support. Caller must ensure the target CPU supports AVX512.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[cfg(feature = "nightly")]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+pub unsafe fn decorrelate_ycocg_r_var1_avx512(colors_raw: __m512i) -> __m512i {
+    // === Constants from assembly ===
+    let mask_31 = _mm512_set1_epi32(0x001F001F); // .LCPI21_1: mask for 5-bit values (31,31)
+    let mask_g_low = _mm512_set1_epi32(0x00200020); // .LCPI21_2: mask for g_low bit position 5 (32,32)
+
+    // Load input colors (zmm0 = colors_raw)
+    let colors = colors_raw;
+
+    // Extract components through bit manipulation (following assembly exactly)
+    // vpsrlw zmm1, zmm0, 11  (Red component)
+    let mut red = _mm512_srli_epi16(colors, 11);
+
+    // vpsrlw zmm2, zmm0, 6   (Green component)
+    let mut green = _mm512_srli_epi16(colors, 6);
+
+    // Apply YCoCg-R variant 1 decorrelation algorithm
+    // vpsubw zmm1, zmm1, zmm0  (Co = R - B, where B is from lower bits of zmm0)
+    red = _mm512_sub_epi16(red, colors);
+
+    // vpandd zmm1, zmm1, dword ptr [rip + .LCPI21_1]{1to16}  (Co &= 31)
+    red = _mm512_and_si512(red, mask_31);
+
+    // vpsrlw zmm3, zmm1, 1     (Co >> 1)
+    let co_half = _mm512_srli_epi16(red, 1);
+
+    // vpsllw zmm1, zmm1, 6     (Co << 6 for final packing)
+    let co_shifted = _mm512_slli_epi16(red, 6);
+
+    // vpaddw zmm3, zmm3, zmm0  (t = B + (Co >> 1))
+    let t = _mm512_add_epi16(co_half, colors);
+
+    // vpandd zmm0, zmm0, dword ptr [rip + .LCPI21_2]{1to16}  (extract g_low)
+    let g_low = _mm512_and_si512(colors, mask_g_low);
+
+    // vpsubw zmm2, zmm2, zmm3  (Cg = G - t)
+    green = _mm512_sub_epi16(green, t);
+
+    // vpandd zmm2, zmm2, dword ptr [rip + .LCPI21_1]{1to16}  (Cg &= 31)
+    green = _mm512_and_si512(green, mask_31);
+
+    // vpsrlw zmm4, zmm2, 1     (Cg >> 1)
+    let cg_half = _mm512_srli_epi16(green, 1);
+
+    // vpaddw zmm3, zmm4, zmm3  (Y = t + (Cg >> 1))
+    let y = _mm512_add_epi16(cg_half, t);
+
+    // vpsllw zmm3, zmm3, 11    (Y << 11 for final packing)
+    let y_shifted = _mm512_slli_epi16(y, 11);
+
+    // vporq zmm1, zmm3, zmm1   (combine y_shifted and co_shifted)
+    let partial_result = _mm512_or_si512(y_shifted, co_shifted);
+
+    // vpternlogd zmm0, zmm2, zmm1, 254  (combine g_low, green(cg), partial_result)
+    _mm512_ternarylogic_epi32(g_low, green, partial_result, 254)
+}
+
+/// Applies YCoCg-R variant 2 decorrelation to 32 [`Color565`] values using AVX512.
+///
+/// This variant places the g_low bit at position 15 (top bit) in the output format.
+/// Output format: `((g_low << 15) | (y << 10) | (co << 5) | cg)`
+///
+/// # Parameters
+///
+/// - `colors_raw`: A 512-bit register containing 32 packed [`Color565`] values
+///
+/// # Returns
+///
+/// A 512-bit register containing 32 decorrelated [`Color565`] values
+///
+/// # Safety
+///
+/// This function requires AVX512F and AVX512BW support. Caller must ensure the target CPU supports AVX512.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[cfg(feature = "nightly")]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+pub unsafe fn decorrelate_ycocg_r_var2_avx512(colors_raw: __m512i) -> __m512i {
+    // === Constants from assembly ===
+    let mask_31 = _mm512_set1_epi32(0x001F001F); // .LCPI22_1: mask for 5-bit values (31,31)
+    let mask_g_low = _mm512_set1_epi32(-2147450880i32); // .LCPI22_2: mask for g_low at bit 15 (0x80008000)
+    let mask_y_field = _mm512_set1_epi32(0x7C007C00); // .LCPI22_3: mask for Y field at bit 10
+
+    // Load input colors (zmm0 = colors_raw)
+    let colors = colors_raw;
+
+    // Extract components through bit manipulation (following assembly exactly)
+    // vpsrlw zmm1, zmm0, 11  (Red component)
+    let mut red = _mm512_srli_epi16(colors, 11);
+
+    // vpsrlw zmm2, zmm0, 6   (Green component)
+    let mut green = _mm512_srli_epi16(colors, 6);
+
+    // Apply YCoCg-R variant 2 decorrelation algorithm
+    // vpsubw zmm1, zmm1, zmm0  (Co = R - B, where B is from lower bits of zmm0)
+    red = _mm512_sub_epi16(red, colors);
+
+    // vpandd zmm1, zmm1, dword ptr [rip + .LCPI22_1]{1to16}  (Co &= 31)
+    red = _mm512_and_si512(red, mask_31);
+
+    // vpsrlw zmm3, zmm1, 1     (Co >> 1)
+    let co_half = _mm512_srli_epi16(red, 1);
+
+    // vpsllw zmm1, zmm1, 5     (Co << 5 for final packing)
+    let co_shifted = _mm512_slli_epi16(red, 5);
+
+    // vpaddw zmm3, zmm3, zmm0  (t = B + (Co >> 1))
+    let t = _mm512_add_epi16(co_half, colors);
+
+    // vpsllw zmm0, zmm0, 10    (colors << 10 for g_low extraction)
+    let colors_shifted = _mm512_slli_epi16(colors, 10);
+
+    // vpternlogd zmm0, zmm1, dword ptr [rip + .LCPI22_2]{1to16}, 236  (combine colors_shifted, co_shifted with g_low)
+    let co_with_g_low = _mm512_ternarylogic_epi32(colors_shifted, co_shifted, mask_g_low, 236);
+
+    // vpsubw zmm1, zmm2, zmm3  (Cg = G - t)
+    green = _mm512_sub_epi16(green, t);
+
+    // vpandd zmm1, zmm1, dword ptr [rip + .LCPI22_1]{1to16}  (Cg &= 31)
+    green = _mm512_and_si512(green, mask_31);
+
+    // vpsrlw zmm2, zmm1, 1     (Cg >> 1)
+    let cg_half = _mm512_srli_epi16(green, 1);
+
+    // vpaddw zmm2, zmm2, zmm3  (Y = t + (Cg >> 1))
+    let y = _mm512_add_epi16(cg_half, t);
+
+    // vpsllw zmm2, zmm2, 10    (Y << 10 for final packing)
+    let y_shifted = _mm512_slli_epi16(y, 10);
+
+    // vpandd zmm2, zmm2, dword ptr [rip + .LCPI22_3]{1to16}  (mask Y field)
+    let y_masked = _mm512_and_si512(y_shifted, mask_y_field);
+
+    // vpternlogd zmm2, zmm1, zmm0, 254  (combine y_masked, green(cg), co_with_g_low)
+    _mm512_ternarylogic_epi32(y_masked, green, co_with_g_low, 254)
+}
+
+/// Applies YCoCg-R variant 3 decorrelation to 32 [`Color565`] values using AVX512.
+///
+/// This variant places the g_low bit at position 0 (bottom bit) in the output format.
+/// Output format: `((y << 11) | (co << 6) | (cg << 1) | g_low)`
+///
+/// This function is translated from compiler-generated assembly for optimal performance.
+///
+/// # Parameters
+///
+/// - `colors_raw`: A 512-bit register containing 32 packed [`Color565`] values
+///
+/// # Returns
+///
+/// A 512-bit register containing 32 decorrelated [`Color565`] values
+///
+/// # Safety
+///
+/// This function requires AVX512F and AVX512BW support. Caller must ensure the target CPU supports AVX512.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[cfg(feature = "nightly")]
+#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512bw")]
+pub unsafe fn decorrelate_ycocg_r_var3_avx512(colors_raw: __m512i) -> __m512i {
+    // === Constants from assembly ===
+    let mask_31 = _mm512_set1_epi16(31); // .LCPI24_2: mask for 5-bit values (0x001F)
+    let mask_1 = _mm512_set1_epi32(0x00010001); // .LCPI24_3: pattern 1,1 for g_low
+
+    // Load input colors (zmm0 = colors_raw)
+    let mut colors = colors_raw;
+
+    // Extract components through bit manipulation (following assembly exactly)
+    // vpsrlw zmm1, zmm0, 11  (Red component)
+    let mut red = _mm512_srli_epi16(colors, 11);
+
+    // vpsrlw zmm2, zmm0, 6   (Green component)
+    let mut green = _mm512_srli_epi16(colors, 6);
+
+    // vpsrlw zmm3, zmm0, 5   (g_low component)
+    let g_low = _mm512_srli_epi16(colors, 5);
+
+    // Apply YCoCg-R variant 3 decorrelation algorithm
+    // vpsubw zmm1, zmm1, zmm0  (Co = R - B, where B is from lower bits of zmm0)
+    red = _mm512_sub_epi16(red, colors);
+
+    // vpandq zmm1, zmm1, zmm4  (Co &= 31)
+    red = _mm512_and_si512(red, mask_31);
+
+    // vpsrlw zmm5, zmm1, 1     (Co >> 1)
+    let co_half = _mm512_srli_epi16(red, 1);
+
+    // vpsllw zmm1, zmm1, 6     (Co << 6 for final packing)
+    let co_shifted = _mm512_slli_epi16(red, 6);
+
+    // vpaddw zmm0, zmm5, zmm0  (t = B + (Co >> 1))
+    colors = _mm512_add_epi16(co_half, colors);
+
+    // vpsubw zmm2, zmm2, zmm0  (Cg = G - t)
+    green = _mm512_sub_epi16(green, colors);
+
+    // vpandq zmm2, zmm2, zmm4  (Cg &= 31)
+    green = _mm512_and_si512(green, mask_31);
+
+    // vpsrlw zmm4, zmm2, 1     (Cg >> 1)
+    let cg_half = _mm512_srli_epi16(green, 1);
+
+    // vpaddw zmm2, zmm2, zmm2  (Cg << 1 for final packing)
+    let cg_shifted = _mm512_add_epi16(green, green);
+
+    // vpaddw zmm0, zmm4, zmm0  (Y = t + (Cg >> 1))
+    colors = _mm512_add_epi16(cg_half, colors);
+
+    // vpsllw zmm0, zmm0, 11    (Y << 11 for final packing)
+    let y_shifted = _mm512_slli_epi16(colors, 11);
+
+    // Pack final result using ternary logic operations (from assembly)
+    // vpternlogq zmm2, zmm0, zmm1, 254  (combine cg_shifted, y_shifted, co_shifted)
+    let mut result = _mm512_ternarylogic_epi32(cg_shifted, y_shifted, co_shifted, 254);
+
+    // vpternlogd zmm2, zmm3, dword ptr [rip + .LCPI24_3]{1to16}, 248  (add g_low)
+    result = _mm512_ternarylogic_epi32(result, g_low, mask_1, 248);
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color_565::Color565;
+    use rstest::rstest;
+
+    /// Test data for all decorrelation variants
+    fn get_test_colors() -> [Color565; 32] {
+        [
+            Color565::from_rgb(255, 128, 64),  // Orange
+            Color565::from_rgb(128, 255, 192), // Light green
+            Color565::from_rgb(64, 128, 255),  // Light blue
+            Color565::from_rgb(192, 64, 128),  // Pink
+            Color565::from_raw(0x1234),        // Random value 1
+            Color565::from_raw(0x5678),        // Random value 2
+            Color565::from_raw(0x9ABC),        // Random value 3
+            Color565::from_raw(0xDEF0),        // Random value 4
+            Color565::from_raw(0x2468),        // Even bits
+            Color565::from_raw(0x1357),        // Odd bits
+            Color565::from_raw(0xACE0),        // Mixed pattern 1
+            Color565::from_raw(0x1359),        // Mixed pattern 2
+            Color565::from_raw(0x7531),        // Mixed pattern 3
+            Color565::from_raw(0x9BDF),        // Mixed pattern 4
+            Color565::from_raw(0x4682),        // Mixed pattern 5
+            Color565::from_raw(0xCEA8),        // Mixed pattern 6
+            Color565::from_rgb(255, 255, 255), // White
+            Color565::from_rgb(0, 0, 0),       // Black
+            Color565::from_rgb(255, 0, 0),     // Red
+            Color565::from_rgb(0, 255, 0),     // Green
+            Color565::from_rgb(0, 0, 255),     // Blue
+            Color565::from_rgb(128, 128, 128), // Gray
+            Color565::from_raw(0x0000),        // All zeros
+            Color565::from_raw(0xFFFF),        // All ones
+            Color565::from_raw(0xF800),        // Max red
+            Color565::from_raw(0x07E0),        // Max green
+            Color565::from_raw(0x001F),        // Max blue
+            Color565::from_raw(0x8000),        // MSB only
+            Color565::from_raw(0x0001),        // LSB only
+            Color565::from_raw(0x5555),        // Alternating bits
+            Color565::from_raw(0xAAAA),        // Alternating bits 2
+            Color565::from_raw(0x3C78),        // Pattern
+        ]
+    }
+
+    #[rstest]
+    #[case(
+        decorrelate_ycocg_r_var1_avx512,
+        Color565::decorrelate_ycocg_r_var1_ptr,
+        "variant 1"
+    )]
+    #[case(
+        decorrelate_ycocg_r_var2_avx512,
+        Color565::decorrelate_ycocg_r_var2_ptr,
+        "variant 2"
+    )]
+    #[case(
+        decorrelate_ycocg_r_var3_avx512,
+        Color565::decorrelate_ycocg_r_var3_ptr,
+        "variant 3"
+    )]
+    fn test_avx512_vs_reference_implementation(
+        #[case] intrinsic_fn: unsafe fn(__m512i) -> __m512i,
+        #[case] reference_fn: unsafe fn(*const Color565, *mut Color565, usize),
+        #[case] variant_name: &str,
+    ) {
+        if !is_x86_feature_detected!("avx512f") || !is_x86_feature_detected!("avx512bw") {
+            return;
+        }
+
+        let test_colors = get_test_colors();
+
+        unsafe {
+            let mut reference_results = [Color565::from_raw(0); 32];
+            reference_fn(
+                test_colors.as_ptr(),
+                reference_results.as_mut_ptr(),
+                test_colors.len(),
+            );
+
+            let input_reg = _mm512_loadu_si512(test_colors.as_ptr() as *const __m512i);
+            let result_reg = intrinsic_fn(input_reg);
+            let mut intrinsic_results = [Color565::from_raw(0); 32];
+            _mm512_storeu_si512(intrinsic_results.as_mut_ptr() as *mut __m512i, result_reg);
+
+            for (x, (&intrinsic_result, &reference_result)) in intrinsic_results
+                .iter()
+                .zip(reference_results.iter())
+                .take(test_colors.len())
+                .enumerate()
+            {
+                assert_eq!(
+                    intrinsic_result, reference_result,
+                    "AVX512 {variant_name} mismatch at index {x}: intrinsic={intrinsic_result:?}, reference={reference_result:?}"
+                );
+            }
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/mod.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/mod.rs
@@ -1,0 +1,38 @@
+//! YCoCg-R decorrelation intrinsics for [`Color565`] values.
+//!
+//! This module provides SIMD-optimized intrinsic functions for performing YCoCg-R decorrelation
+//! transformations on packed [`Color565`] data. These functions are designed to work with
+//! registers containing multiple color values, offering high-performance batch processing.
+//!
+//! # Available Functions
+//!
+//! ## AVX512 Functions (requires `nightly` feature)
+//!
+//! - [`avx512::decorrelate_ycocg_r_var1_avx512`] - Applies YCoCg-R variant 1 decorrelation
+//! - [`avx512::decorrelate_ycocg_r_var2_avx512`] - Applies YCoCg-R variant 2 decorrelation  
+//! - [`avx512::decorrelate_ycocg_r_var3_avx512`] - Applies YCoCg-R variant 3 decorrelation
+//!
+//! ## AVX2 Functions
+//!
+//! - [`avx2::decorrelate_ycocg_r_var1_avx2`] - Applies YCoCg-R variant 1 decorrelation
+//! - [`avx2::decorrelate_ycocg_r_var2_avx2`] - Applies YCoCg-R variant 2 decorrelation
+//! - [`avx2::decorrelate_ycocg_r_var3_avx2`] - Applies YCoCg-R variant 3 decorrelation
+//!
+//! ## SSE2 Functions
+//!
+//! - [`sse2::decorrelate_ycocg_r_var1_sse2`] - Applies YCoCg-R variant 1 decorrelation
+//! - [`sse2::decorrelate_ycocg_r_var2_sse2`] - Applies YCoCg-R variant 2 decorrelation
+//! - [`sse2::decorrelate_ycocg_r_var3_sse2`] - Applies YCoCg-R variant 3 decorrelation
+//!
+//! [`Color565`]: crate::color_565::Color565
+//! [`__m512i`]: core::arch::x86_64::__m512i
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx512;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx2;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod sse2;

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/sse2.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/sse2.rs
@@ -1,0 +1,275 @@
+//! These functions are converted from compiler-generated assembly
+//! to be used as part of larger assembly routines.
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+/// Decorrelate a register of [`Color565`] values using YCoCg-R variant 1
+///
+/// Takes a `__m128i` register containing 8 [`Color565`] values and returns a register
+/// with the colors decorrelated using YCoCg-R variant 1 algorithm that operates
+/// directly on 16-bit color values.
+///
+/// # Safety
+///
+/// Requires `sse2` target feature to be enabled.
+/// The input register must contain valid [`Color565`] data.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[target_feature(enable = "sse2")]
+#[inline]
+pub unsafe fn decorrelate_ycocg_r_var1_sse2(colors_raw: __m128i) -> __m128i {
+    // Constants
+    let mask_32 = _mm_set1_epi16(32);
+    let mask_31 = _mm_set1_epi16(31);
+
+    // Load input colors
+    let xmm1 = colors_raw;
+
+    // Extract blue component (AND with mask 32)
+    let xmm2 = _mm_and_si128(xmm1, mask_32);
+
+    // Extract red component and start YCoCg-R algorithm
+    let mut xmm0 = _mm_srli_epi16(xmm1, 11); // Red component
+    xmm0 = _mm_sub_epi16(xmm0, xmm1); // R - input
+    xmm0 = _mm_and_si128(xmm0, mask_31); // AND with mask 31
+
+    // Calculate intermediate value
+    let mut xmm4 = _mm_srli_epi16(xmm0, 1); // Divide by 2
+    xmm4 = _mm_add_epi16(xmm4, xmm1); // Add input colors
+
+    // Process green component
+    let mut xmm1 = _mm_srli_epi16(xmm1, 6); // Green component
+    xmm1 = _mm_sub_epi16(xmm1, xmm4); // Subtract intermediate
+    xmm1 = _mm_and_si128(xmm1, mask_31); // AND with mask 31
+
+    // Combine first part of result
+    xmm0 = _mm_slli_epi16(xmm0, 6); // Shift left by 6
+    xmm0 = _mm_or_si128(xmm0, xmm2); // OR with blue component
+    xmm0 = _mm_or_si128(xmm0, xmm1); // OR with processed green
+
+    // Final calculation for Y component
+    xmm1 = _mm_srli_epi16(xmm1, 1); // Shift right by 1
+    xmm1 = _mm_add_epi16(xmm1, xmm4); // Add intermediate
+    xmm1 = _mm_slli_epi16(xmm1, 11); // Shift to Y position (red field)
+
+    // Final combination
+    _mm_or_si128(xmm0, xmm1)
+}
+
+/// Decorrelate a register of [`Color565`] values using YCoCg-R variant 2
+///
+/// Takes a `__m128i` register containing 8 [`Color565`] values and returns a register
+/// with the colors decorrelated using YCoCg-R variant 2 algorithm that operates
+/// directly on 16-bit color values.
+///
+/// # Safety
+///
+/// Requires `sse2` target feature to be enabled.
+/// The input register must contain valid [`Color565`] data.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[target_feature(enable = "sse2")]
+#[inline]
+pub unsafe fn decorrelate_ycocg_r_var2_sse2(colors_raw: __m128i) -> __m128i {
+    // Constants based on the scalar assembly analysis
+    let mask_31 = _mm_set1_epi16(31);
+    let mask_g_low = _mm_set1_epi16(-32768); // Mask for preserving g_low bit in position 15 (0x8000)
+
+    // Load input colors
+    let input = colors_raw;
+
+    // Extract red component (bits 15-11)
+    let red = _mm_srli_epi16(input, 11);
+
+    // Extract green component (bits 10-6, ignoring bit 5)
+    let green = _mm_srli_epi16(input, 6);
+
+    // Step 1: Co = R - input (modulo 32)
+    let mut co = _mm_sub_epi16(red, input);
+    co = _mm_and_si128(co, mask_31);
+
+    // Step 2: t = B + (Co >> 1)
+    // B is the lower 5 bits of input, Co >> 1 is the half of co
+    let co_half = _mm_srli_epi16(co, 1);
+    let t = _mm_add_epi16(input, co_half); // input contains B in lower bits
+
+    // Step 3: Cg = G - t (modulo 32)
+    let mut cg = _mm_sub_epi16(green, t);
+    cg = _mm_and_si128(cg, mask_31);
+
+    // Step 4: Y = t + (Cg >> 1)
+    let cg_half = _mm_srli_epi16(cg, 1);
+    let mut y = _mm_add_epi16(t, cg_half);
+    y = _mm_and_si128(y, mask_31);
+
+    // Packing based on variant 2 format:
+    // Bit 15: g_low (preserved from original green bit 5)
+    // Bits 14-10: Y (5 bits)
+    // Bits 9-5: Co (5 bits)
+    // Bits 4-0: Cg (5 bits)
+
+    // Extract and preserve g_low bit (bit 5 of original input)
+    // Based on assembly: shl input, 10 then and with 0x3FFE000 to preserve bit 5 -> bit 15
+    let mut g_low_preserved = _mm_slli_epi16(input, 10);
+    g_low_preserved = _mm_and_si128(g_low_preserved, mask_g_low);
+
+    // Shift Y to position 14-10 (red field)
+    let mut y_shifted = _mm_slli_epi16(y, 10);
+    let mask_y = _mm_set1_epi16(0x7C00); // Mask for bits 14-10
+    y_shifted = _mm_and_si128(y_shifted, mask_y);
+
+    // Shift Co to position 9-5 (green field)
+    let co_shifted = _mm_slli_epi16(co, 5);
+
+    // Combine all components
+    let mut result = _mm_or_si128(g_low_preserved, y_shifted);
+    result = _mm_or_si128(result, co_shifted);
+    result = _mm_or_si128(result, cg);
+
+    result
+}
+
+/// Decorrelate a register of [`Color565`] values using YCoCg-R variant 3
+///
+/// Takes a `__m128i` register containing 8 [`Color565`] values and returns a register
+/// with the colors decorrelated using YCoCg-R variant 3 algorithm that operates
+/// directly on 16-bit color values.
+///
+/// # Safety
+///
+/// Requires `sse2` target feature to be enabled.
+/// The input register must contain valid [`Color565`] data.
+///
+/// [`Color565`]: crate::color_565::Color565
+#[target_feature(enable = "sse2")]
+#[inline]
+pub unsafe fn decorrelate_ycocg_r_var3_sse2(colors_raw: __m128i) -> __m128i {
+    // Constants for variant 3
+    let mask_31 = _mm_set1_epi16(31);
+    let mask_1 = _mm_set1_epi16(1);
+
+    // Load input colors
+    let input = colors_raw;
+
+    // Extract RGB components
+    let r = _mm_srli_epi16(input, 11); // Red component (5 bits)
+    let g = _mm_srli_epi16(input, 6); // Green component (will be masked to 5 bits)
+    let g_low = _mm_and_si128(_mm_srli_epi16(input, 5), mask_1); // Extract g_low bit
+    let b = _mm_and_si128(input, mask_31); // Blue component (5 bits)
+
+    // Apply YCoCg-R variant 3 algorithm
+    // Step 1: Co = (R - B) & 0x1F
+    let co = _mm_and_si128(_mm_sub_epi16(r, b), mask_31);
+
+    // Step 2: t = B + (Co >> 1)
+    let t = _mm_add_epi16(b, _mm_srli_epi16(co, 1));
+
+    // Step 3: Cg = (G - t) & 0x1F
+    let cg = _mm_and_si128(_mm_sub_epi16(_mm_and_si128(g, mask_31), t), mask_31);
+
+    // Step 4: Y = t + (Cg >> 1)
+    let y = _mm_add_epi16(t, _mm_srli_epi16(cg, 1));
+
+    // Pack into Color565 variant 3 format:
+    // Y (5 bits) in bits 15-11: Y << 11
+    // Co (5 bits) in bits 10-6: Co << 6
+    // Cg (5 bits) in bits 5-1: Cg << 1
+    // g_low (1 bit) in bit 0: g_low
+    let y_shifted = _mm_slli_epi16(y, 11);
+    let co_shifted = _mm_slli_epi16(co, 6);
+    let cg_shifted = _mm_slli_epi16(cg, 1);
+
+    // Combine all components
+    let result = _mm_or_si128(y_shifted, co_shifted);
+    let result = _mm_or_si128(result, cg_shifted);
+    _mm_or_si128(result, g_low)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::color_565::Color565;
+    use rstest::rstest;
+
+    /// Test data for all decorrelation variants
+    fn get_test_colors() -> [Color565; 8] {
+        [
+            Color565::from_rgb(255, 128, 64),  // Orange
+            Color565::from_rgb(128, 255, 192), // Light green
+            Color565::from_rgb(64, 128, 255),  // Light blue
+            Color565::from_rgb(192, 64, 128),  // Pink
+            Color565::from_raw(0x1234),        // Random value 1
+            Color565::from_raw(0x5678),        // Random value 2
+            Color565::from_raw(0x9ABC),        // Random value 3
+            Color565::from_raw(0xDEF0),        // Random value 4
+        ]
+    }
+
+    #[rstest]
+    #[case(
+        decorrelate_ycocg_r_var1_sse2,
+        Color565::decorrelate_ycocg_r_var1_ptr,
+        "SSE2",
+        "variant 1"
+    )]
+    #[case(
+        decorrelate_ycocg_r_var2_sse2,
+        Color565::decorrelate_ycocg_r_var2_ptr,
+        "SSSE3",
+        "variant 2"
+    )]
+    #[case(
+        decorrelate_ycocg_r_var3_sse2,
+        Color565::decorrelate_ycocg_r_var3_ptr,
+        "SSE2",
+        "variant 3"
+    )]
+    fn test_sse_vs_reference_implementation(
+        #[case] intrinsic_fn: unsafe fn(__m128i) -> __m128i,
+        #[case] reference_fn: unsafe fn(*const Color565, *mut Color565, usize),
+        #[case] arch_name: &str,
+        #[case] variant_name: &str,
+    ) {
+        // Check feature availability based on the function being tested
+        let feature_available = match arch_name {
+            "SSE2" => is_x86_feature_detected!("sse2"),
+            "SSSE3" => is_x86_feature_detected!("ssse3"),
+            _ => false,
+        };
+
+        if !feature_available {
+            return;
+        }
+
+        let test_colors = get_test_colors();
+
+        unsafe {
+            let mut reference_results = [Color565::from_raw(0); 8];
+            reference_fn(
+                test_colors.as_ptr(),
+                reference_results.as_mut_ptr(),
+                test_colors.len(),
+            );
+
+            let input_reg = _mm_loadu_si128(test_colors.as_ptr() as *const __m128i);
+            let result_reg = intrinsic_fn(input_reg);
+            let mut intrinsic_results = [Color565::from_raw(0); 8];
+            _mm_storeu_si128(intrinsic_results.as_mut_ptr() as *mut __m128i, result_reg);
+
+            for (x, (&intrinsic_result, &reference_result)) in intrinsic_results
+                .iter()
+                .zip(reference_results.iter())
+                .take(test_colors.len())
+                .enumerate()
+            {
+                assert_eq!(
+                    intrinsic_result, reference_result,
+                    "{arch_name} {variant_name} mismatch at index {x}: intrinsic={intrinsic_result:?}, reference={reference_result:?}"
+                );
+            }
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/sse2.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/sse2.rs
@@ -212,38 +212,23 @@ mod tests {
     #[case(
         decorrelate_ycocg_r_var1_sse2,
         Color565::decorrelate_ycocg_r_var1_ptr,
-        "SSE2",
         "variant 1"
     )]
     #[case(
         decorrelate_ycocg_r_var2_sse2,
         Color565::decorrelate_ycocg_r_var2_ptr,
-        "SSSE3",
         "variant 2"
     )]
     #[case(
         decorrelate_ycocg_r_var3_sse2,
         Color565::decorrelate_ycocg_r_var3_ptr,
-        "SSE2",
         "variant 3"
     )]
     fn test_sse_vs_reference_implementation(
         #[case] intrinsic_fn: unsafe fn(__m128i) -> __m128i,
         #[case] reference_fn: unsafe fn(*const Color565, *mut Color565, usize),
-        #[case] arch_name: &str,
         #[case] variant_name: &str,
     ) {
-        // Check feature availability based on the function being tested
-        let feature_available = match arch_name {
-            "SSE2" => is_x86_feature_detected!("sse2"),
-            "SSSE3" => is_x86_feature_detected!("ssse3"),
-            _ => false,
-        };
-
-        if !feature_available {
-            return;
-        }
-
         let test_colors = get_test_colors();
 
         unsafe {
@@ -267,7 +252,7 @@ mod tests {
             {
                 assert_eq!(
                     intrinsic_result, reference_result,
-                    "{arch_name} {variant_name} mismatch at index {x}: intrinsic={intrinsic_result:?}, reference={reference_result:?}"
+                    "{variant_name} mismatch at index {x}: intrinsic={intrinsic_result:?}, reference={reference_result:?}"
                 );
             }
         }

--- a/projects/dxt-lossless-transform-common/src/intrinsics/color_565/mod.rs
+++ b/projects/dxt-lossless-transform-common/src/intrinsics/color_565/mod.rs
@@ -1,1 +1,2 @@
+pub mod decorrelate;
 pub mod recorrelate;

--- a/projects/dxt-lossless-transform-common/src/lib.rs
+++ b/projects/dxt-lossless-transform-common/src/lib.rs
@@ -1,5 +1,7 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
 #![cfg_attr(not(feature = "std"), no_std)]
+// Not yet in stable today, but will be in 1.89.0
+#![allow(stable_features)]
 #![cfg_attr(
     all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")),
     feature(stdarch_x86_avx512)
@@ -13,5 +15,5 @@ pub mod transforms {
     pub mod split_565_color_endpoints;
 }
 pub mod allocate;
-pub mod intrinsics;
 pub mod cpu_detect;
+pub mod intrinsics;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added SIMD-accelerated BC1 transforms with AVX512, AVX2, and SSE2 support, including split-color and YCoCg-R decorrelation variants.
  - Introduced split-color and decorrelate transforms with multiple YCoCg-R variants for BC1 blocks.
  - Added SIMD-optimized YCoCg-R decorrelation for Color565 color data across AVX512, AVX2, and SSE2.

- **Refactor**
  - Removed the need for separate work buffers in BC1 transform functions, simplifying APIs and internal logic.
  - Updated vectorized loops to use pointer arithmetic instead of index variables for clarity and efficiency.
  - Streamlined BC1 transform logic to use specialized transform functions without external normalization or work buffers.
  - Restricted visibility of several transform and untransform functions to crate-level for better encapsulation.
  - Enhanced runtime CPU feature detection to select optimal SIMD implementations (AVX512, AVX2, SSE2, or generic fallback).
  - Renamed pointer parameters for clarity and consistency across transform and untransform functions.

- **Bug Fixes**
  - Simplified test code by removing unused workspace buffers and adjusting import orders, improving clarity and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->