### PR TITLE
Improved: Hide Benchmark Only Functions in BC2, BC3 Module

### DIFF
--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -53,13 +53,11 @@ required-features = ["bench"]
 name = "block_decode"
 path = "benches/block_decode/main.rs"
 harness = false
-required-features = ["bench"]
 
 [[bench]]
 name = "normalize_blocks"
 path = "benches/normalize_blocks/main.rs"
 harness = false
-required-features = ["bench"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)"] }

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -17,6 +17,8 @@ pgo = []
 no-runtime-cpu-detection = []
 # Use nightly compiler features (AVX512)
 nightly = ["dxt-lossless-transform-common/nightly"]
+# Code only required for benchmarks.
+bench = []
 
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }
@@ -40,11 +42,13 @@ bench = false
 name = "transform_standard"
 path = "benches/transform_standard/main.rs"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "untransform_standard"
 path = "benches/untransform_standard/main.rs"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "block_decode"
@@ -55,3 +59,6 @@ harness = false
 name = "normalize_blocks"
 path = "benches/normalize_blocks/main.rs"
 harness = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)"] }

--- a/projects/dxt-lossless-transform-bc2/benches/transform_standard/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/transform_standard/avx2.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::transform::shuffle;
+use dxt_lossless_transform_bc2::transforms::standard::transform::bench::avx2_shuffle;
 use safe_allocator_api::RawAlloc;
 
 fn bench_shuffle(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        shuffle(
+        avx2_shuffle(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc2/benches/transform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/transform_standard/avx512.rs
@@ -1,5 +1,7 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::transform::{permute_512, permute_512_v2};
+use dxt_lossless_transform_bc2::transforms::standard::transform::bench::{
+    permute_512, permute_512_v2,
+};
 use safe_allocator_api::RawAlloc;
 
 fn bench_permute(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc2/benches/transform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/transform_standard/portable32.rs
@@ -1,5 +1,7 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::transform::*;
+use dxt_lossless_transform_bc2::transforms::standard::transform::bench::{
+    u32, u32_unroll_2, u32_unroll_4,
+};
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc2/benches/transform_standard/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/transform_standard/sse2.rs
@@ -1,5 +1,7 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::transform::*;
+use dxt_lossless_transform_bc2::transforms::standard::transform::bench::{
+    shuffle_v1, shuffle_v1_unroll_2, sse2_shuffle_v2, sse2_shuffle_v3,
+};
 use safe_allocator_api::RawAlloc;
 
 fn bench_shuffle_v1(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
@@ -24,7 +26,7 @@ fn bench_shuffle_v1_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, outpu
 
 fn bench_shuffle_v2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        shuffle_v2(
+        sse2_shuffle_v2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -35,7 +37,7 @@ fn bench_shuffle_v2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut R
 #[cfg(target_arch = "x86_64")]
 fn bench_shuffle_v3(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        shuffle_v3(
+        sse2_shuffle_v3(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc2/benches/untransform_standard/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/untransform_standard/avx2.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::untransform::avx2::avx2_shuffle;
+use dxt_lossless_transform_bc2::transforms::standard::untransform::bench_exports::avx2_shuffle;
 use safe_allocator_api::RawAlloc;
 
 fn bench_shuffle(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc2/benches/untransform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/untransform_standard/avx512.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::untransform::avx512::avx512_shuffle;
+use dxt_lossless_transform_bc2::transforms::standard::untransform::bench_exports::avx512_shuffle;
 use safe_allocator_api::RawAlloc;
 
 fn bench_shuffle(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc2/benches/untransform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/untransform_standard/portable32.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::untransform::*;
+use dxt_lossless_transform_bc2::transforms::standard::untransform::bench_exports::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc2/benches/untransform_standard/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/benches/untransform_standard/sse2.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc2::transforms::standard::untransform::sse2::shuffle;
+use dxt_lossless_transform_bc2::transforms::standard::untransform::bench_exports::sse2_shuffle;
 use safe_allocator_api::RawAlloc;
 
 fn bench_shuffle_v2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        shuffle(
+        sse2_shuffle(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/avx2.rs
@@ -19,7 +19,7 @@ const PERMUTE_MASK: [u32; 8] = [0, 4, 1, 5, 2, 6, 3, 7];
 /// - len must be divisible by 16
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
-pub unsafe fn shuffle_with_separate_pointers(
+pub(crate) unsafe fn shuffle_with_separate_pointers(
     mut input_ptr: *const u8,
     mut alphas_ptr: *mut u64,
     mut colors_ptr: *mut u32,
@@ -167,7 +167,7 @@ pub unsafe fn shuffle_with_separate_pointers(
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
-pub unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     let alphas_ptr = output_ptr as *mut u64;
     let colors_ptr = output_ptr.add(len / 2) as *mut u32;
     let indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/avx512.rs
@@ -12,205 +12,15 @@ const PERM_ALPHA_BYTES: [i8; 8] = [0, 2, 4, 6, 8, 10, 12, 14]; // For vpermt2q t
 /// # Safety
 ///
 /// - input_ptr must be valid for reads of len bytes
-/// - alphas_ptr must be valid for writes of len/2 bytes
-/// - colors_ptr must be valid for writes of len/4 bytes
-/// - indices_ptr must be valid for writes of len/4 bytes
-/// - len must be divisible by 16
+/// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
 #[allow(unused_assignments)]
-pub unsafe fn permute_512_with_separate_pointers(
+#[allow(dead_code)] // reference implementation
+pub(crate) unsafe fn permute_512_v2_intrinsics(
     mut input_ptr: *const u8,
-    mut alphas_ptr: *mut u64,
-    mut colors_ptr: *mut u32,
-    mut indices_ptr: *mut u32,
+    output_ptr: *mut u8,
     len: usize,
 ) {
-    debug_assert!(len % 16 == 0);
-
-    let mut aligned_len = len - (len % 128);
-
-    // Note(sewer): We need to subtract 32 (half register) as to not write beyond the end of the
-    // buffer. We write 64 bytes with vmovdqu64, so the final indices_ptr write goes 32 bytes beyond
-    // the limit. We need to guard against this. However, because the indices also represent 4 / 16
-    // of the blocks, we need to multiply the amount we subtract by 4 to account for split buffers.
-    aligned_len = aligned_len.saturating_sub(32 * 4);
-
-    if aligned_len > 0 {
-        let mut aligned_end = input_ptr.add(aligned_len);
-
-        const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
-        const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
-
-        // Load permutation patterns
-        let perm_alpha =
-            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
-        let perm_colors =
-            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_COLORS_BYTES.as_ptr() as *const _));
-        let perm_indices =
-            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_INDICES_BYTES.as_ptr() as *const _));
-
-        asm!(
-            ".p2align 5",
-            "2:",
-
-            // Load 128 bytes (eight blocks)
-            "vmovdqu64 {zmm4}, [{input_ptr}]",      // Load first 4 blocks
-            "vmovdqu64 {zmm5}, [{input_ptr} + 64]", // Load next 4 blocks
-            "vmovdqa64 {zmm3}, {zmm4}",             // Copy first 4 blocks to zmm3
-            "vpermt2q {zmm3}, {perm_alpha}, {zmm5}",// Filter out the alphas from zmm3 (zmm4) + zmm5
-            "add {input_ptr}, 128",
-
-            // Permute to separate colors and indices
-            "vmovdqa64 {zmm6}, {zmm4}",
-            "vpermt2d {zmm6}, {perm_colors}, {zmm5}",  // Gather colors from zmm4 + zmm5
-            "vpermt2d {zmm4}, {perm_indices}, {zmm5}", // Gather indices from zmm4 + zmm5
-
-            // Store results
-            "vmovdqu64 [{alphas_ptr}], {zmm3}",
-            "vmovdqu64 [{colors_ptr}], {zmm6}",
-            "vmovdqu64 [{indices_ptr}], {zmm4}",
-
-            // Update pointers
-            "add {alphas_ptr}, 64",
-            "add {colors_ptr}, 32",
-            "add {indices_ptr}, 32",
-
-            // Loop until done
-            "cmp {input_ptr}, {aligned_end}",
-            "jb 2b",
-
-            input_ptr = inout(reg) input_ptr,
-            alphas_ptr = inout(reg) alphas_ptr,
-            colors_ptr = inout(reg) colors_ptr,
-            indices_ptr = inout(reg) indices_ptr,
-            aligned_end = inout(reg) aligned_end,
-            perm_alpha = in(zmm_reg) perm_alpha,
-            perm_colors = in(zmm_reg) perm_colors,
-            perm_indices = in(zmm_reg) perm_indices,
-            zmm3 = out(zmm_reg) _,
-            zmm4 = out(zmm_reg) _,
-            zmm5 = out(zmm_reg) _,
-            zmm6 = out(zmm_reg) _,
-            options(nostack, preserves_flags)
-        );
-    }
-
-    // Process any remaining elements
-    let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_with_separate_pointers(input_ptr, alphas_ptr, colors_ptr, indices_ptr, remaining);
-    }
-}
-
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-#[target_feature(enable = "avx512f")]
-#[allow(unused_assignments)]
-pub unsafe fn permute_512(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let alphas_ptr = output_ptr as *mut u64;
-    let colors_ptr = output_ptr.add(len / 2);
-    let indices_ptr = colors_ptr.add(len / 4);
-
-    permute_512_with_separate_pointers(
-        input_ptr,
-        alphas_ptr,
-        colors_ptr as *mut u32,
-        indices_ptr as *mut u32,
-        len,
-    );
-}
-
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-#[target_feature(enable = "avx512f")]
-#[allow(unused_assignments)]
-pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let mut aligned_len = len - (len % 128);
-    let mut alpha_ptr = output_ptr;
-
-    // Note(sewer): We need to subtract 32 (half register) as to not write beyond the end of the
-    // buffer. We write 64 bytes with vmovdqu64, so the final indices_ptr write goes 32 bytes beyond
-    // the limit. We need to guard against this. However, because the indices also represent 4 / 16
-    // of the blocks, we need to multiply the amount we subtract by 4 to account for split buffers.
-    aligned_len = aligned_len.saturating_sub(32 * 4);
-
-    let mut colors_ptr = alpha_ptr.add(len / 2);
-    let mut indices_ptr = colors_ptr.add(len / 4);
-
-    if aligned_len > 0 {
-        let aligned_end = input_ptr.add(aligned_len);
-
-        // Constant data for permutation masks
-        const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
-        const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
-
-        // Load permutation patterns
-        let perm_alpha =
-            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
-        let perm_colors =
-            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_COLORS_BYTES.as_ptr() as *const _));
-        let perm_indices =
-            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_INDICES_BYTES.as_ptr() as *const _));
-
-        while input_ptr < aligned_end {
-            // Load 128 bytes (eight blocks)
-            let zmm4 = _mm512_loadu_si512(input_ptr as *const __m512i);
-            let zmm5 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
-
-            // Copy first 4 blocks to zmm3
-            let mut zmm3 = zmm4;
-
-            // Filter out the alphas using vpermt2q
-            zmm3 = _mm512_permutex2var_epi64(zmm3, perm_alpha, zmm5);
-
-            // Update input pointer
-            input_ptr = input_ptr.add(128);
-
-            // Permute to separate colors and indices
-            let mut zmm6 = zmm4;
-            zmm6 = _mm512_permutex2var_epi32(zmm6, perm_colors, zmm5); // colours
-            let zmm4_indices = _mm512_permutex2var_epi32(zmm4, perm_indices, zmm5); // indices
-
-            // Store results
-            _mm512_storeu_si512(alpha_ptr as *mut __m512i, zmm3); // alphas
-            _mm512_storeu_si512(colors_ptr as *mut __m512i, zmm6); // colours
-            _mm512_storeu_si512(indices_ptr as *mut __m512i, zmm4_indices); // indices
-
-            // Update pointers
-            alpha_ptr = alpha_ptr.add(64);
-            colors_ptr = colors_ptr.add(32);
-            indices_ptr = indices_ptr.add(32);
-        }
-    }
-
-    // Process any remaining elements
-    let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_with_separate_pointers(
-            input_ptr,
-            alpha_ptr as *mut u64,
-            colors_ptr as *mut u32,
-            indices_ptr as *mut u32,
-            remaining,
-        );
-    }
-}
-
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-#[target_feature(enable = "avx512f")]
-#[allow(unused_assignments)]
-pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     let aligned_len = len - (len % 256);
@@ -302,7 +112,7 @@ pub unsafe fn permute_512_v2_intrinsics(mut input_ptr: *const u8, output_ptr: *m
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
 #[allow(unused_assignments)]
-pub unsafe fn permute_512_v2_with_separate_pointers(
+pub(crate) unsafe fn permute_512_v2_with_separate_pointers(
     mut input_ptr: *const u8,
     mut alphas_ptr: *mut u64,
     mut colors_ptr: *mut u32,
@@ -401,7 +211,7 @@ pub unsafe fn permute_512_v2_with_separate_pointers(
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
 #[allow(unused_assignments)]
-pub unsafe fn permute_512_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permute_512_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     let alphas_ptr = output_ptr as *mut u64;
@@ -423,8 +233,6 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(permute_512, "avx512_permute")]
-    #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
     #[case(permute_512_v2_intrinsics, "avx512_permute_intrinsics_v2")]
     #[case(permute_512_v2, "avx512_permute_asm_v2")]
     fn test_avx512_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/avx512.rs
@@ -211,7 +211,7 @@ mod tests {
 
     #[rstest]
     #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
-    #[case(permute_512_intrinsics, "avx512_permute_asm")]
+    #[case(permute_512, "avx512_permute_asm")]
     fn test_avx512_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {
         if !has_avx512f() {
             return;

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/avx512.rs
@@ -1,0 +1,223 @@
+use crate::transforms::standard::transform::portable32::u32_with_separate_pointers;
+use core::arch::asm;
+
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+
+const PERM_ALPHA_BYTES: [i8; 8] = [0, 2, 4, 6, 8, 10, 12, 14]; // For vpermt2q to gather alpha values
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - alphas_ptr must be valid for writes of len/2 bytes
+/// - colors_ptr must be valid for writes of len/4 bytes
+/// - indices_ptr must be valid for writes of len/4 bytes
+/// - len must be divisible by 16
+#[target_feature(enable = "avx512f")]
+#[allow(unused_assignments)]
+pub unsafe fn permute_512_with_separate_pointers(
+    mut input_ptr: *const u8,
+    mut alphas_ptr: *mut u64,
+    mut colors_ptr: *mut u32,
+    mut indices_ptr: *mut u32,
+    len: usize,
+) {
+    debug_assert!(len % 16 == 0);
+
+    let mut aligned_len = len - (len % 128);
+
+    // Note(sewer): We need to subtract 32 (half register) as to not write beyond the end of the
+    // buffer. We write 64 bytes with vmovdqu64, so the final indices_ptr write goes 32 bytes beyond
+    // the limit. We need to guard against this. However, because the indices also represent 4 / 16
+    // of the blocks, we need to multiply the amount we subtract by 4 to account for split buffers.
+    aligned_len = aligned_len.saturating_sub(32 * 4);
+
+    if aligned_len > 0 {
+        let mut aligned_end = input_ptr.add(aligned_len);
+
+        const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
+        const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
+
+        // Load permutation patterns
+        let perm_alpha =
+            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        asm!(
+            ".p2align 5",
+            "2:",
+
+            // Load 128 bytes (eight blocks)
+            "vmovdqu64 {zmm4}, [{input_ptr}]",      // Load first 4 blocks
+            "vmovdqu64 {zmm5}, [{input_ptr} + 64]", // Load next 4 blocks
+            "vmovdqa64 {zmm3}, {zmm4}",             // Copy first 4 blocks to zmm3
+            "vpermt2q {zmm3}, {perm_alpha}, {zmm5}",// Filter out the alphas from zmm3 (zmm4) + zmm5
+            "add {input_ptr}, 128",
+
+            // Permute to separate colors and indices
+            "vmovdqa64 {zmm6}, {zmm4}",
+            "vpermt2d {zmm6}, {perm_colors}, {zmm5}",  // Gather colors from zmm4 + zmm5
+            "vpermt2d {zmm4}, {perm_indices}, {zmm5}", // Gather indices from zmm4 + zmm5
+
+            // Store results
+            "vmovdqu64 [{alphas_ptr}], {zmm3}",
+            "vmovdqu64 [{colors_ptr}], {zmm6}",
+            "vmovdqu64 [{indices_ptr}], {zmm4}",
+
+            // Update pointers
+            "add {alphas_ptr}, 64",
+            "add {colors_ptr}, 32",
+            "add {indices_ptr}, 32",
+
+            // Loop until done
+            "cmp {input_ptr}, {aligned_end}",
+            "jb 2b",
+
+            input_ptr = inout(reg) input_ptr,
+            alphas_ptr = inout(reg) alphas_ptr,
+            colors_ptr = inout(reg) colors_ptr,
+            indices_ptr = inout(reg) indices_ptr,
+            aligned_end = inout(reg) aligned_end,
+            perm_alpha = in(zmm_reg) perm_alpha,
+            perm_colors = in(zmm_reg) perm_colors,
+            perm_indices = in(zmm_reg) perm_indices,
+            zmm3 = out(zmm_reg) _,
+            zmm4 = out(zmm_reg) _,
+            zmm5 = out(zmm_reg) _,
+            zmm6 = out(zmm_reg) _,
+            options(nostack, preserves_flags)
+        );
+    }
+
+    // Process any remaining elements
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(input_ptr, alphas_ptr, colors_ptr, indices_ptr, remaining);
+    }
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[allow(unused_assignments)]
+pub unsafe fn permute_512(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let alphas_ptr = output_ptr as *mut u64;
+    let colors_ptr = output_ptr.add(len / 2);
+    let indices_ptr = colors_ptr.add(len / 4);
+
+    permute_512_with_separate_pointers(
+        input_ptr,
+        alphas_ptr,
+        colors_ptr as *mut u32,
+        indices_ptr as *mut u32,
+        len,
+    );
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "avx512f")]
+#[allow(unused_assignments)]
+pub unsafe fn permute_512_intrinsics(mut input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut aligned_len = len - (len % 128);
+    let mut alpha_ptr = output_ptr;
+
+    // Note(sewer): We need to subtract 32 (half register) as to not write beyond the end of the
+    // buffer. We write 64 bytes with vmovdqu64, so the final indices_ptr write goes 32 bytes beyond
+    // the limit. We need to guard against this. However, because the indices also represent 4 / 16
+    // of the blocks, we need to multiply the amount we subtract by 4 to account for split buffers.
+    aligned_len = aligned_len.saturating_sub(32 * 4);
+
+    let mut colors_ptr = alpha_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let aligned_end = input_ptr.add(aligned_len);
+
+        // Constant data for permutation masks
+        const PERM_COLORS_BYTES: [i8; 8] = [2, 6, 10, 14, 18, 22, 26, 30]; // For vpermt2d to gather color values
+        const PERM_INDICES_BYTES: [i8; 8] = [3, 7, 11, 15, 19, 23, 27, 31]; // For vpermt2d to gather index values
+
+        // Load permutation patterns
+        let perm_alpha =
+            _mm512_cvtepi8_epi64(_mm_loadl_epi64(PERM_ALPHA_BYTES.as_ptr() as *const _));
+        let perm_colors =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_COLORS_BYTES.as_ptr() as *const _));
+        let perm_indices =
+            _mm512_cvtepi8_epi32(_mm_loadl_epi64(PERM_INDICES_BYTES.as_ptr() as *const _));
+
+        while input_ptr < aligned_end {
+            // Load 128 bytes (eight blocks)
+            let zmm4 = _mm512_loadu_si512(input_ptr as *const __m512i);
+            let zmm5 = _mm512_loadu_si512(input_ptr.add(64) as *const __m512i);
+
+            // Copy first 4 blocks to zmm3
+            let mut zmm3 = zmm4;
+
+            // Filter out the alphas using vpermt2q
+            zmm3 = _mm512_permutex2var_epi64(zmm3, perm_alpha, zmm5);
+
+            // Update input pointer
+            input_ptr = input_ptr.add(128);
+
+            // Permute to separate colors and indices
+            let mut zmm6 = zmm4;
+            zmm6 = _mm512_permutex2var_epi32(zmm6, perm_colors, zmm5); // colours
+            let zmm4_indices = _mm512_permutex2var_epi32(zmm4, perm_indices, zmm5); // indices
+
+            // Store results
+            _mm512_storeu_si512(alpha_ptr as *mut __m512i, zmm3); // alphas
+            _mm512_storeu_si512(colors_ptr as *mut __m512i, zmm6); // colours
+            _mm512_storeu_si512(indices_ptr as *mut __m512i, zmm4_indices); // indices
+
+            // Update pointers
+            alpha_ptr = alpha_ptr.add(64);
+            colors_ptr = colors_ptr.add(32);
+            indices_ptr = indices_ptr.add(32);
+        }
+    }
+
+    // Process any remaining elements
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            alpha_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    #[rstest]
+    #[case(permute_512_intrinsics, "avx512_permute_intrinsics")]
+    #[case(permute_512_intrinsics, "avx512_permute_asm")]
+    fn test_avx512_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {
+        if !has_avx512f() {
+            return;
+        }
+
+        // AVX512 implementation processes 256 bytes per iteration, so max_blocks = 256 * 2 / 16 = 32
+        run_standard_transform_unaligned_test(permute_fn, 32, impl_name);
+    }
+}

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/mod.rs
@@ -19,7 +19,7 @@ pub mod portable32;
 pub use portable32::*;
 
 // Wrapper functions for benchmarks
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+#[cfg(target_arch = "x86_64")]
 pub unsafe fn sse2_shuffle_v3(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     super::sse2::shuffle_v3(input_ptr, output_ptr, len)
 }

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/mod.rs
@@ -1,0 +1,45 @@
+#![allow(clippy::missing_safety_doc)]
+#![cfg(not(tarpaulin_include))]
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod sse2;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub use sse2::*;
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod avx512;
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub use avx512::*;
+
+pub mod portable32;
+pub use portable32::*;
+
+// Wrapper functions for benchmarks
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn sse2_shuffle_v3(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::sse2::shuffle_v3(input_ptr, output_ptr, len)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn sse2_shuffle_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::sse2::shuffle_v2(input_ptr, output_ptr, len)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx2::shuffle(input_ptr, output_ptr, len)
+}
+
+pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::portable32::u32(input_ptr, output_ptr, len)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn permute_512_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::permute_512_v2(input_ptr, output_ptr, len)
+}

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/portable32.rs
@@ -1,0 +1,155 @@
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut alphas_ptr = output_ptr as *mut u64;
+    let mut colours_ptr = output_ptr.add(len / 2) as *mut u32;
+    let mut indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;
+
+    let mut input_ptr = input_ptr as *mut u8;
+    let max_ptr = input_ptr.add(len);
+    let max_aligned_input = input_ptr.add(len.saturating_sub(32));
+
+    while input_ptr < max_aligned_input {
+        // First block
+        let alpha_value1 = (input_ptr as *const u64).read_unaligned();
+        let color_value1 = (input_ptr.add(8) as *const u32).read_unaligned();
+        let index_value1 = (input_ptr.add(12) as *const u32).read_unaligned();
+
+        // Second block
+        let alpha_value2 = (input_ptr.add(16) as *const u64).read_unaligned();
+        let color_value2 = (input_ptr.add(24) as *const u32).read_unaligned();
+        let index_value2 = (input_ptr.add(28) as *const u32).read_unaligned();
+        // compiler may reorder this to later (unfortauntely)
+        // I tried memory barriers (fence / compiler_fence), but it didn't seem to help
+        input_ptr = input_ptr.add(32);
+
+        // Store first block
+        alphas_ptr.write_unaligned(alpha_value1);
+        colours_ptr.write_unaligned(color_value1);
+        indices_ptr.write_unaligned(index_value1);
+
+        // Store second block
+        alphas_ptr.add(1).write_unaligned(alpha_value2);
+        colours_ptr.add(1).write_unaligned(color_value2);
+        indices_ptr.add(1).write_unaligned(index_value2);
+
+        // Advance pointers
+        alphas_ptr = alphas_ptr.add(2);
+        colours_ptr = colours_ptr.add(2);
+        indices_ptr = indices_ptr.add(2);
+    }
+
+    while input_ptr < max_ptr {
+        // Split into colours (lower 4 bytes) and indices (upper 4 bytes)
+        let alpha_value = (input_ptr as *const u64).read_unaligned();
+        let color_value = (input_ptr.add(8) as *const u32).read_unaligned();
+        let index_value = (input_ptr.add(12) as *const u32).read_unaligned();
+        input_ptr = input_ptr.add(16);
+
+        // Store colours and indices to their respective halves
+        alphas_ptr.write_unaligned(alpha_value);
+        colours_ptr.write_unaligned(color_value);
+        indices_ptr.write_unaligned(index_value);
+
+        alphas_ptr = alphas_ptr.add(1);
+        colours_ptr = colours_ptr.add(1);
+        indices_ptr = indices_ptr.add(1);
+    }
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+pub unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut alphas_ptr = output_ptr as *mut u64;
+    let mut colours_ptr = output_ptr.add(len / 2) as *mut u32;
+    let mut indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;
+
+    let mut input_ptr = input_ptr as *mut u8;
+    let max_ptr = input_ptr.add(len);
+    let max_aligned_input = input_ptr.add(len.saturating_sub(64));
+
+    while input_ptr < max_aligned_input {
+        // First block
+        let alpha_value1 = (input_ptr as *const u64).read_unaligned();
+        let color_value1 = (input_ptr.add(8) as *const u32).read_unaligned();
+        let index_value1 = (input_ptr.add(12) as *const u32).read_unaligned();
+
+        // Second block
+        let alpha_value2 = (input_ptr.add(16) as *const u64).read_unaligned();
+        let color_value2 = (input_ptr.add(24) as *const u32).read_unaligned();
+        let index_value2 = (input_ptr.add(28) as *const u32).read_unaligned();
+
+        // Third block
+        let alpha_value3 = (input_ptr.add(32) as *const u64).read_unaligned();
+        let color_value3 = (input_ptr.add(40) as *const u32).read_unaligned();
+        let index_value3 = (input_ptr.add(44) as *const u32).read_unaligned();
+
+        // Fourth block
+        let alpha_value4 = (input_ptr.add(48) as *const u64).read_unaligned();
+        let color_value4 = (input_ptr.add(56) as *const u32).read_unaligned();
+        let index_value4 = (input_ptr.add(60) as *const u32).read_unaligned();
+        // compiler may reorder this to later (unfortauntely)
+        // I tried memory barriers (fence / compiler_fence), but it didn't seem to help
+        input_ptr = input_ptr.add(64);
+
+        // Store all blocks
+        alphas_ptr.write_unaligned(alpha_value1);
+        colours_ptr.write_unaligned(color_value1);
+        indices_ptr.write_unaligned(index_value1);
+
+        alphas_ptr.add(1).write_unaligned(alpha_value2);
+        colours_ptr.add(1).write_unaligned(color_value2);
+        indices_ptr.add(1).write_unaligned(index_value2);
+
+        alphas_ptr.add(2).write_unaligned(alpha_value3);
+        colours_ptr.add(2).write_unaligned(color_value3);
+        indices_ptr.add(2).write_unaligned(index_value3);
+
+        alphas_ptr.add(3).write_unaligned(alpha_value4);
+        colours_ptr.add(3).write_unaligned(color_value4);
+        indices_ptr.add(3).write_unaligned(index_value4);
+
+        // Advance pointers
+        alphas_ptr = alphas_ptr.add(4);
+        colours_ptr = colours_ptr.add(4);
+        indices_ptr = indices_ptr.add(4);
+    }
+
+    while input_ptr < max_ptr {
+        // Split into colours (lower 4 bytes) and indices (upper 4 bytes)
+        let alpha_value = (input_ptr as *const u64).read_unaligned();
+        let color_value = (input_ptr.add(8) as *const u32).read_unaligned();
+        let index_value = (input_ptr.add(12) as *const u32).read_unaligned();
+        input_ptr = input_ptr.add(16);
+
+        // Store colours and indices to their respective halves
+        alphas_ptr.write_unaligned(alpha_value);
+        colours_ptr.write_unaligned(color_value);
+        indices_ptr.write_unaligned(index_value);
+
+        alphas_ptr = alphas_ptr.add(1);
+        colours_ptr = colours_ptr.add(1);
+        indices_ptr = indices_ptr.add(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    #[rstest]
+    #[case(u32_unroll_2, "u32 unroll_2")]
+    #[case(u32_unroll_4, "u32 unroll_4")]
+    fn test_portable32_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {
+        run_standard_transform_unaligned_test(permute_fn, 512, impl_name);
+    }
+}

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/sse2.rs
@@ -1,0 +1,191 @@
+use crate::transforms::standard::transform::portable32::u32_with_separate_pointers;
+use core::arch::asm;
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "sse2")]
+#[allow(unused_assignments)]
+pub unsafe fn shuffle_v1(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let aligned_len = len - (len % 32);
+    let mut colors_ptr = output_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let mut end = input_ptr.add(aligned_len);
+
+        asm!(
+            ".p2align 5",
+            "2:",
+
+            // Load 32 bytes (two blocks)
+            "movdqu {xmm0}, [{input_ptr}]",      // First block
+            "movdqu {xmm1}, [{input_ptr} + 16]", // Second block
+            "add {input_ptr}, 32", // input += 2 * 16
+
+            // Current Register Layout:
+            // [A0 - A8] [C0 - C4] [I0 - I4]
+            // Make copies for unpacking/blending
+            "movaps {xmm2}, {xmm0}",
+
+            // Extract all alphas into one register
+            // XMM0: [A0 - A16]
+            "punpcklqdq {xmm0}, {xmm1}", // Combine both alphas
+
+            // Shuffle XMM0 (xmm2) and XMM1 to group colors and indices back again.
+            // Desired XMM2: [C0 - C8] [I0 - I8]
+
+            // XMM2: {0,1,2,3, 4,5,6,7, -128,-127,-126,-125, -64,-63,-62,-61}
+            // XMM1: {8,9,10,11, 12,13,14,15, -124,-123,-122,-121, -60,-59,-58,-57}
+            // Desired XMM2: {-128,-127,-126,-125, -124,-123,-122,-121, -64,-63,-62,-61, -60,-59,-58,-57}
+            "shufps {xmm2}, {xmm1}, 0xEE", // 0b11_10_11_10
+            // Current XMM2: {-128,-127,-126,-125, -64,-63,-62,-61, -124,-123,-122,-121, -60,-59,-58,-57}
+            "shufps {xmm2}, {xmm2}, 0xD8", // 0b11_01_10_00
+
+            // Store combined alphas
+            "movdqu [{alpha_ptr}], {xmm0}",
+            "add {alpha_ptr}, 16",
+
+            // Store colours and indices
+            "movq [{colors_ptr}], {xmm2}",
+            "add {colors_ptr}, 8",
+            "movhpd [{indices_ptr}], {xmm2}",
+            "add {indices_ptr}, 8",
+
+            // Loop until done
+            "cmp {input_ptr}, {end}",
+            "jb 2b",
+
+            input_ptr = inout(reg) input_ptr,
+            alpha_ptr = inout(reg) output_ptr,
+            colors_ptr = inout(reg) colors_ptr,
+            indices_ptr = inout(reg) indices_ptr,
+            end = inout(reg) end,
+            xmm0 = out(xmm_reg) _,
+            xmm1 = out(xmm_reg) _,
+            xmm2 = out(xmm_reg) _,
+            options(nostack)
+        );
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            output_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "sse2")]
+#[allow(unused_assignments)]
+pub unsafe fn shuffle_v1_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let aligned_len = len - (len % 64);
+    let mut colors_ptr = output_ptr.add(len / 2);
+    let mut indices_ptr = colors_ptr.add(len / 4);
+
+    if aligned_len > 0 {
+        let mut end = input_ptr.add(aligned_len);
+        asm!(
+            ".p2align 5",
+            "2:",
+
+            // Load 64 bytes (four blocks)
+            "movdqu {xmm0}, [{input_ptr}]",      // First block
+            "movdqu {xmm1}, [{input_ptr} + 16]", // Second block
+            "movdqu {xmm3}, [{input_ptr} + 32]", // Third block
+            "movdqu {xmm4}, [{input_ptr} + 48]", // Fourth block
+            "add {input_ptr}, 64",
+
+            // Setup scratch registers.
+            "movaps {xmm2}, {xmm0}",
+            "punpcklqdq {xmm0}, {xmm1}", // alpha -> xmm0
+            "movaps {xmm5}, {xmm3}",
+            "punpcklqdq {xmm3}, {xmm4}", // alpha -> xmm3
+
+            // XMM2: {0,1,2,3, 4,5,6,7, -128,-127,-126,-125, -64,-63,-62,-61}
+            // XMM1: {8,9,10,11, 12,13,14,15, -124,-123,-122,-121, -60,-59,-58,-57}
+            // Desired XMM2: {-128,-127,-126,-125, -124,-123,-122,-121, -64,-63,-62,-61, -60,-59,-58,-57}
+
+            // Move the colours + indices to xmm2
+            "shufps {xmm2}, {xmm1}, 0xEE",
+            "shufps {xmm2}, {xmm2}, 0xD8",
+
+            // Process second pair of blocks
+            "shufps {xmm5}, {xmm4}, 0xEE",
+            "shufps {xmm5}, {xmm5}, 0xD8",
+
+            // Store results
+            "movdqu [{alpha_ptr}], {xmm0}",
+            "movdqu [{alpha_ptr} + 16], {xmm3}",
+            "add {alpha_ptr}, 32",
+
+            "movq [{colors_ptr}], {xmm2}",
+            "movq [{colors_ptr} + 8], {xmm5}",
+            "add {colors_ptr}, 16",
+
+            "movhpd [{indices_ptr}], {xmm2}",
+            "movhpd [{indices_ptr} + 8], {xmm5}",
+            "add {indices_ptr}, 16",
+
+            // Loop until done
+            "cmp {input_ptr}, {end}",
+            "jb 2b",
+
+            input_ptr = inout(reg) input_ptr,
+            alpha_ptr = inout(reg) output_ptr,
+            colors_ptr = inout(reg) colors_ptr,
+            indices_ptr = inout(reg) indices_ptr,
+            end = inout(reg) end,
+            xmm0 = out(xmm_reg) _,
+            xmm1 = out(xmm_reg) _,
+            xmm2 = out(xmm_reg) _,
+            xmm3 = out(xmm_reg) _,
+            xmm4 = out(xmm_reg) _,
+            xmm5 = out(xmm_reg) _,
+            options(nostack)
+        );
+    }
+
+    // Process any remaining elements after the aligned blocks
+    let remaining = len - aligned_len;
+    if remaining > 0 {
+        u32_with_separate_pointers(
+            input_ptr,
+            output_ptr as *mut u64,
+            colors_ptr as *mut u32,
+            indices_ptr as *mut u32,
+            remaining,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    #[rstest]
+    #[case(shuffle_v1, "shuffle_v1")]
+    #[case(shuffle_v1_unroll_2, "shuffle_v1_unroll_2")]
+    fn test_sse2_unaligned(#[case] transform_fn: StandardTransformFn, #[case] impl_name: &str) {
+        if !has_sse2() {
+            return;
+        }
+        // SSE2 implementation processes 64 bytes per iteration, so max_blocks = 64 * 2 / 16 = 8
+        run_standard_transform_unaligned_test(transform_fn, 8, impl_name);
+    }
+}

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/mod.rs
@@ -1,25 +1,17 @@
 pub mod portable32;
-pub use portable32::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse2;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use sse2::*;
-
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx2;
-
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx2::*;
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx512;
 
-#[cfg(feature = "nightly")]
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx512::*;
+#[cfg(feature = "bench")]
+pub mod bench;
 
 /// Transform BC2 data from standard interleaved format to separated alpha/color/index format
 /// using the best known implementation for the current CPU.
@@ -41,7 +33,7 @@ pub unsafe fn split_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        u32(input_ptr, output_ptr, len)
+        portable32::u32(input_ptr, output_ptr, len)
     }
 }
 
@@ -81,7 +73,7 @@ pub unsafe fn split_blocks_with_separate_pointers(
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        u32_with_separate_pointers(input_ptr, alphas_ptr, colors_ptr, indices_ptr, len)
+        portable32::u32_with_separate_pointers(input_ptr, alphas_ptr, colors_ptr, indices_ptr, len)
     }
 }
 
@@ -144,7 +136,7 @@ unsafe fn split_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len: u
     }
 
     // Fallback to portable implementation
-    u32(input_ptr, output_ptr, len)
+    portable32::u32(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -260,5 +252,5 @@ unsafe fn split_blocks_with_separate_pointers_x86(
     }
 
     // Fallback to portable implementation
-    u32_with_separate_pointers(input_ptr, alphas_ptr, colors_ptr, indices_ptr, len)
+    portable32::u32_with_separate_pointers(input_ptr, alphas_ptr, colors_ptr, indices_ptr, len)
 }

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/portable32.rs
@@ -3,7 +3,7 @@
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Split output into color and index sections
@@ -25,7 +25,7 @@ pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - colours_ptr must be valid for writes of len/4 bytes
 /// - indices_ptr must be valid for writes of len/4 bytes
 /// - len must be divisible by 16
-pub unsafe fn u32_with_separate_pointers(
+pub(crate) unsafe fn u32_with_separate_pointers(
     input_ptr: *const u8,
     mut alphas_ptr: *mut u64,
     mut colours_ptr: *mut u32,
@@ -55,149 +55,6 @@ pub unsafe fn u32_with_separate_pointers(
     }
 }
 
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let mut alphas_ptr = output_ptr as *mut u64;
-    let mut colours_ptr = output_ptr.add(len / 2) as *mut u32;
-    let mut indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;
-
-    let mut input_ptr = input_ptr as *mut u8;
-    let max_ptr = input_ptr.add(len);
-    let max_aligned_input = input_ptr.add(len.saturating_sub(32));
-
-    while input_ptr < max_aligned_input {
-        // First block
-        let alpha_value1 = (input_ptr as *const u64).read_unaligned();
-        let color_value1 = (input_ptr.add(8) as *const u32).read_unaligned();
-        let index_value1 = (input_ptr.add(12) as *const u32).read_unaligned();
-
-        // Second block
-        let alpha_value2 = (input_ptr.add(16) as *const u64).read_unaligned();
-        let color_value2 = (input_ptr.add(24) as *const u32).read_unaligned();
-        let index_value2 = (input_ptr.add(28) as *const u32).read_unaligned();
-        // compiler may reorder this to later (unfortauntely)
-        // I tried memory barriers (fence / compiler_fence), but it didn't seem to help
-        input_ptr = input_ptr.add(32);
-
-        // Store first block
-        alphas_ptr.write_unaligned(alpha_value1);
-        colours_ptr.write_unaligned(color_value1);
-        indices_ptr.write_unaligned(index_value1);
-
-        // Store second block
-        alphas_ptr.add(1).write_unaligned(alpha_value2);
-        colours_ptr.add(1).write_unaligned(color_value2);
-        indices_ptr.add(1).write_unaligned(index_value2);
-
-        // Advance pointers
-        alphas_ptr = alphas_ptr.add(2);
-        colours_ptr = colours_ptr.add(2);
-        indices_ptr = indices_ptr.add(2);
-    }
-
-    while input_ptr < max_ptr {
-        // Split into colours (lower 4 bytes) and indices (upper 4 bytes)
-        let alpha_value = (input_ptr as *const u64).read_unaligned();
-        let color_value = (input_ptr.add(8) as *const u32).read_unaligned();
-        let index_value = (input_ptr.add(12) as *const u32).read_unaligned();
-        input_ptr = input_ptr.add(16);
-
-        // Store colours and indices to their respective halves
-        alphas_ptr.write_unaligned(alpha_value);
-        colours_ptr.write_unaligned(color_value);
-        indices_ptr.write_unaligned(index_value);
-
-        alphas_ptr = alphas_ptr.add(1);
-        colours_ptr = colours_ptr.add(1);
-        indices_ptr = indices_ptr.add(1);
-    }
-}
-
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-pub unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let mut alphas_ptr = output_ptr as *mut u64;
-    let mut colours_ptr = output_ptr.add(len / 2) as *mut u32;
-    let mut indices_ptr = output_ptr.add(len / 2 + len / 4) as *mut u32;
-
-    let mut input_ptr = input_ptr as *mut u8;
-    let max_ptr = input_ptr.add(len);
-    let max_aligned_input = input_ptr.add(len.saturating_sub(64));
-
-    while input_ptr < max_aligned_input {
-        // First block
-        let alpha_value1 = (input_ptr as *const u64).read_unaligned();
-        let color_value1 = (input_ptr.add(8) as *const u32).read_unaligned();
-        let index_value1 = (input_ptr.add(12) as *const u32).read_unaligned();
-
-        // Second block
-        let alpha_value2 = (input_ptr.add(16) as *const u64).read_unaligned();
-        let color_value2 = (input_ptr.add(24) as *const u32).read_unaligned();
-        let index_value2 = (input_ptr.add(28) as *const u32).read_unaligned();
-
-        // Third block
-        let alpha_value3 = (input_ptr.add(32) as *const u64).read_unaligned();
-        let color_value3 = (input_ptr.add(40) as *const u32).read_unaligned();
-        let index_value3 = (input_ptr.add(44) as *const u32).read_unaligned();
-
-        // Fourth block
-        let alpha_value4 = (input_ptr.add(48) as *const u64).read_unaligned();
-        let color_value4 = (input_ptr.add(56) as *const u32).read_unaligned();
-        let index_value4 = (input_ptr.add(60) as *const u32).read_unaligned();
-        // compiler may reorder this to later (unfortauntely)
-        // I tried memory barriers (fence / compiler_fence), but it didn't seem to help
-        input_ptr = input_ptr.add(64);
-
-        // Store all blocks
-        alphas_ptr.write_unaligned(alpha_value1);
-        colours_ptr.write_unaligned(color_value1);
-        indices_ptr.write_unaligned(index_value1);
-
-        alphas_ptr.add(1).write_unaligned(alpha_value2);
-        colours_ptr.add(1).write_unaligned(color_value2);
-        indices_ptr.add(1).write_unaligned(index_value2);
-
-        alphas_ptr.add(2).write_unaligned(alpha_value3);
-        colours_ptr.add(2).write_unaligned(color_value3);
-        indices_ptr.add(2).write_unaligned(index_value3);
-
-        alphas_ptr.add(3).write_unaligned(alpha_value4);
-        colours_ptr.add(3).write_unaligned(color_value4);
-        indices_ptr.add(3).write_unaligned(index_value4);
-
-        // Advance pointers
-        alphas_ptr = alphas_ptr.add(4);
-        colours_ptr = colours_ptr.add(4);
-        indices_ptr = indices_ptr.add(4);
-    }
-
-    while input_ptr < max_ptr {
-        // Split into colours (lower 4 bytes) and indices (upper 4 bytes)
-        let alpha_value = (input_ptr as *const u64).read_unaligned();
-        let color_value = (input_ptr.add(8) as *const u32).read_unaligned();
-        let index_value = (input_ptr.add(12) as *const u32).read_unaligned();
-        input_ptr = input_ptr.add(16);
-
-        // Store colours and indices to their respective halves
-        alphas_ptr.write_unaligned(alpha_value);
-        colours_ptr.write_unaligned(color_value);
-        indices_ptr.write_unaligned(index_value);
-
-        alphas_ptr = alphas_ptr.add(1);
-        colours_ptr = colours_ptr.add(1);
-        indices_ptr = indices_ptr.add(1);
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -205,8 +62,6 @@ mod tests {
 
     #[rstest]
     #[case(u32, "u32 no-unroll")]
-    #[case(u32_unroll_2, "u32 unroll_2")]
-    #[case(u32_unroll_4, "u32 unroll_4")]
     fn test_portable32_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {
         run_standard_transform_unaligned_test(permute_fn, 512, impl_name);
     }

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/sse2.rs
@@ -7,179 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
-pub unsafe fn shuffle_v1(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let aligned_len = len - (len % 32);
-    let mut colors_ptr = output_ptr.add(len / 2);
-    let mut indices_ptr = colors_ptr.add(len / 4);
-
-    if aligned_len > 0 {
-        let mut end = input_ptr.add(aligned_len);
-
-        asm!(
-            ".p2align 5",
-            "2:",
-
-            // Load 32 bytes (two blocks)
-            "movdqu {xmm0}, [{input_ptr}]",      // First block
-            "movdqu {xmm1}, [{input_ptr} + 16]", // Second block
-            "add {input_ptr}, 32", // input += 2 * 16
-
-            // Current Register Layout:
-            // [A0 - A8] [C0 - C4] [I0 - I4]
-            // Make copies for unpacking/blending
-            "movaps {xmm2}, {xmm0}",
-
-            // Extract all alphas into one register
-            // XMM0: [A0 - A16]
-            "punpcklqdq {xmm0}, {xmm1}", // Combine both alphas
-
-            // Shuffle XMM0 (xmm2) and XMM1 to group colors and indices back again.
-            // Desired XMM2: [C0 - C8] [I0 - I8]
-
-            // XMM2: {0,1,2,3, 4,5,6,7, -128,-127,-126,-125, -64,-63,-62,-61}
-            // XMM1: {8,9,10,11, 12,13,14,15, -124,-123,-122,-121, -60,-59,-58,-57}
-            // Desired XMM2: {-128,-127,-126,-125, -124,-123,-122,-121, -64,-63,-62,-61, -60,-59,-58,-57}
-            "shufps {xmm2}, {xmm1}, 0xEE", // 0b11_10_11_10
-            // Current XMM2: {-128,-127,-126,-125, -64,-63,-62,-61, -124,-123,-122,-121, -60,-59,-58,-57}
-            "shufps {xmm2}, {xmm2}, 0xD8", // 0b11_01_10_00
-
-            // Store combined alphas
-            "movdqu [{alpha_ptr}], {xmm0}",
-            "add {alpha_ptr}, 16",
-
-            // Store colours and indices
-            "movq [{colors_ptr}], {xmm2}",
-            "add {colors_ptr}, 8",
-            "movhpd [{indices_ptr}], {xmm2}",
-            "add {indices_ptr}, 8",
-
-            // Loop until done
-            "cmp {input_ptr}, {end}",
-            "jb 2b",
-
-            input_ptr = inout(reg) input_ptr,
-            alpha_ptr = inout(reg) output_ptr,
-            colors_ptr = inout(reg) colors_ptr,
-            indices_ptr = inout(reg) indices_ptr,
-            end = inout(reg) end,
-            xmm0 = out(xmm_reg) _,
-            xmm1 = out(xmm_reg) _,
-            xmm2 = out(xmm_reg) _,
-            options(nostack)
-        );
-    }
-
-    // Process any remaining elements after the aligned blocks
-    let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_with_separate_pointers(
-            input_ptr,
-            output_ptr as *mut u64,
-            colors_ptr as *mut u32,
-            indices_ptr as *mut u32,
-            remaining,
-        );
-    }
-}
-
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-#[target_feature(enable = "sse2")]
-#[allow(unused_assignments)]
-pub unsafe fn shuffle_v1_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let aligned_len = len - (len % 64);
-    let mut colors_ptr = output_ptr.add(len / 2);
-    let mut indices_ptr = colors_ptr.add(len / 4);
-
-    if aligned_len > 0 {
-        let mut end = input_ptr.add(aligned_len);
-        asm!(
-            ".p2align 5",
-            "2:",
-
-            // Load 64 bytes (four blocks)
-            "movdqu {xmm0}, [{input_ptr}]",      // First block
-            "movdqu {xmm1}, [{input_ptr} + 16]", // Second block
-            "movdqu {xmm3}, [{input_ptr} + 32]", // Third block
-            "movdqu {xmm4}, [{input_ptr} + 48]", // Fourth block
-            "add {input_ptr}, 64",
-
-            // Setup scratch registers.
-            "movaps {xmm2}, {xmm0}",
-            "punpcklqdq {xmm0}, {xmm1}", // alpha -> xmm0
-            "movaps {xmm5}, {xmm3}",
-            "punpcklqdq {xmm3}, {xmm4}", // alpha -> xmm3
-
-            // XMM2: {0,1,2,3, 4,5,6,7, -128,-127,-126,-125, -64,-63,-62,-61}
-            // XMM1: {8,9,10,11, 12,13,14,15, -124,-123,-122,-121, -60,-59,-58,-57}
-            // Desired XMM2: {-128,-127,-126,-125, -124,-123,-122,-121, -64,-63,-62,-61, -60,-59,-58,-57}
-
-            // Move the colours + indices to xmm2
-            "shufps {xmm2}, {xmm1}, 0xEE",
-            "shufps {xmm2}, {xmm2}, 0xD8",
-
-            // Process second pair of blocks
-            "shufps {xmm5}, {xmm4}, 0xEE",
-            "shufps {xmm5}, {xmm5}, 0xD8",
-
-            // Store results
-            "movdqu [{alpha_ptr}], {xmm0}",
-            "movdqu [{alpha_ptr} + 16], {xmm3}",
-            "add {alpha_ptr}, 32",
-
-            "movq [{colors_ptr}], {xmm2}",
-            "movq [{colors_ptr} + 8], {xmm5}",
-            "add {colors_ptr}, 16",
-
-            "movhpd [{indices_ptr}], {xmm2}",
-            "movhpd [{indices_ptr} + 8], {xmm5}",
-            "add {indices_ptr}, 16",
-
-            // Loop until done
-            "cmp {input_ptr}, {end}",
-            "jb 2b",
-
-            input_ptr = inout(reg) input_ptr,
-            alpha_ptr = inout(reg) output_ptr,
-            colors_ptr = inout(reg) colors_ptr,
-            indices_ptr = inout(reg) indices_ptr,
-            end = inout(reg) end,
-            xmm0 = out(xmm_reg) _,
-            xmm1 = out(xmm_reg) _,
-            xmm2 = out(xmm_reg) _,
-            xmm3 = out(xmm_reg) _,
-            xmm4 = out(xmm_reg) _,
-            xmm5 = out(xmm_reg) _,
-            options(nostack)
-        );
-    }
-
-    // Process any remaining elements after the aligned blocks
-    let remaining = len - aligned_len;
-    if remaining > 0 {
-        u32_with_separate_pointers(
-            input_ptr,
-            output_ptr as *mut u64,
-            colors_ptr as *mut u32,
-            indices_ptr as *mut u32,
-            remaining,
-        );
-    }
-}
-
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-#[target_feature(enable = "sse2")]
-#[allow(unused_assignments)]
-pub unsafe fn shuffle_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shuffle_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     let alphas_ptr = output_ptr as *mut u64;
@@ -196,7 +24,7 @@ pub unsafe fn shuffle_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) 
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn shuffle_v3(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shuffle_v3(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     let alphas_ptr = output_ptr as *mut u64;
@@ -215,7 +43,7 @@ pub unsafe fn shuffle_v3(input_ptr: *const u8, output_ptr: *mut u8, len: usize) 
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn shuffle_v3_with_separate_pointers(
+pub(crate) unsafe fn shuffle_v3_with_separate_pointers(
     mut input_ptr: *const u8,
     mut alphas_ptr: *mut u64,
     mut colors_ptr: *mut u32,
@@ -325,7 +153,7 @@ pub unsafe fn shuffle_v3_with_separate_pointers(
 /// - indices_ptr must be valid for writes of len / 4 bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
-pub unsafe fn shuffle_v2_with_separate_pointers(
+pub(crate) unsafe fn shuffle_v2_with_separate_pointers(
     mut input_ptr: *const u8,
     mut alphas_ptr: *mut u64,
     mut colors_ptr: *mut u32,
@@ -411,8 +239,6 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(shuffle_v1, "shuffle_v1")]
-    #[case(shuffle_v1_unroll_2, "shuffle_v1_unroll_2")]
     #[case(shuffle_v2, "shuffle_v2")]
     #[cfg_attr(target_arch = "x86_64", case(shuffle_v3, "shuffle_v3"))]
     fn test_sse2_unaligned(#[case] transform_fn: StandardTransformFn, #[case] impl_name: &str) {

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/sse2.rs
@@ -7,6 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
+#[cfg_attr(target_arch = "x86_64", allow(dead_code))]
 pub(crate) unsafe fn shuffle_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
@@ -153,6 +154,7 @@ pub(crate) unsafe fn shuffle_v3_with_separate_pointers(
 /// - indices_ptr must be valid for writes of len / 4 bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
+#[cfg_attr(target_arch = "x86_64", allow(dead_code))]
 pub(crate) unsafe fn shuffle_v2_with_separate_pointers(
     mut input_ptr: *const u8,
     mut alphas_ptr: *mut u64,

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx2.rs
@@ -14,7 +14,7 @@ static INDCOL_PERMUTE_MASK: [u32; 8] = [0, 4, 2, 6, 1, 5, 3, 7u32];
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     let alpha_ptr = input_ptr;
     let colors_ptr = alpha_ptr.add(len / 2);
@@ -32,7 +32,7 @@ pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn avx2_shuffle_with_components(
+pub(crate) unsafe fn avx2_shuffle_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut alpha_ptr: *const u8,
@@ -209,7 +209,7 @@ pub unsafe fn avx2_shuffle_with_components(
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86")]
-pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     let alpha_ptr = input_ptr;
     let colors_ptr = alpha_ptr.add(len / 2);
     let indices_ptr = colors_ptr.add(len / 4);
@@ -226,7 +226,7 @@ pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 #[target_feature(enable = "avx2")]
 #[allow(unused_assignments)]
 #[cfg(target_arch = "x86")]
-pub unsafe fn avx2_shuffle_with_components(
+pub(crate) unsafe fn avx2_shuffle_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut alpha_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx512.rs
@@ -34,6 +34,7 @@ pub(crate) unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, l
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
 #[allow(unused_assignments)]
+#[allow(dead_code)] // Reference code. Inline assembly has Zen optimizations; this can be used to generate for other arches.
 pub(crate) unsafe fn avx512_shuffle_intrinsics(
     input_ptr: *const u8,
     output_ptr: *mut u8,

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx512.rs
@@ -15,7 +15,7 @@ use core::arch::*;
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
 #[allow(unused_assignments)]
-pub unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     let alpha_ptr = input_ptr;
     let colors_ptr = alpha_ptr.add(len / 2);
@@ -34,7 +34,11 @@ pub unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
 #[allow(unused_assignments)]
-pub unsafe fn avx512_shuffle_intrinsics(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_shuffle_intrinsics(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 16 == 0);
     let alpha_ptr = input_ptr;
     let colors_ptr = alpha_ptr.add(len / 2);
@@ -53,7 +57,7 @@ pub unsafe fn avx512_shuffle_intrinsics(input_ptr: *const u8, output_ptr: *mut u
 #[allow(unused_assignments)]
 #[allow(clippy::zero_prefixed_literal)]
 #[allow(clippy::identity_op)]
-pub unsafe fn avx512_shuffle_with_components_intrinsics(
+pub(crate) unsafe fn avx512_shuffle_with_components_intrinsics(
     mut output_ptr: *mut u8,
     len: usize,
     mut alpha_ptr: *const u8,
@@ -188,7 +192,7 @@ pub unsafe fn avx512_shuffle_with_components_intrinsics(
 #[allow(clippy::zero_prefixed_literal)]
 #[allow(clippy::identity_op)]
 #[cfg(target_arch = "x86_64")]
-pub unsafe fn avx512_shuffle_with_components(
+pub(crate) unsafe fn avx512_shuffle_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut alpha_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/mod.rs
@@ -1,5 +1,4 @@
 pub mod portable32;
-pub use portable32::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse2;
@@ -10,10 +9,6 @@ pub mod avx2;
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx512;
-
-#[cfg(feature = "nightly")]
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx512::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
@@ -61,7 +56,7 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
     }
 
     // Fallback to portable implementation
-    u32_detransform(input_ptr, output_ptr, len)
+    portable32::u32_detransform(input_ptr, output_ptr, len)
 }
 
 /// Transform BC2 data from separated alpha/color/index format back to standard interleaved format
@@ -84,7 +79,7 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        u32_detransform(input_ptr, output_ptr, len)
+        portable32::u32_detransform(input_ptr, output_ptr, len)
     }
 }
 
@@ -176,7 +171,13 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     }
 
     // Fallback to portable implementation
-    u32_detransform_with_separate_pointers(alphas_ptr, colors_ptr, indices_ptr, output_ptr, len)
+    portable32::u32_detransform_with_separate_pointers(
+        alphas_ptr,
+        colors_ptr,
+        indices_ptr,
+        output_ptr,
+        len,
+    )
 }
 
 /// Unsplit BC2 blocks, putting them back into standard interleaved format from a separated alpha/color/index format
@@ -213,6 +214,37 @@ pub unsafe fn unsplit_block_with_separate_pointers(
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        u32_detransform_with_separate_pointers(alphas_ptr, colors_ptr, indices_ptr, output_ptr, len)
+        portable32::u32_detransform_with_separate_pointers(
+            alphas_ptr,
+            colors_ptr,
+            indices_ptr,
+            output_ptr,
+            len,
+        )
+    }
+}
+
+// Re-export functions for benchmarking when the 'bench' feature is enabled
+#[cfg(feature = "bench")]
+#[allow(clippy::missing_safety_doc)]
+pub mod bench_exports {
+    pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::portable32::u32_detransform(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn sse2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::sse2::shuffle(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn avx2_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::avx2::avx2_shuffle(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(feature = "nightly")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn avx512_shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::avx512::avx512_shuffle(input_ptr, output_ptr, len)
     }
 }

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/portable32.rs
@@ -5,7 +5,7 @@ use core::ptr::{read_unaligned, write_unaligned};
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Get pointers to the alpha, color, index sections.

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/untransform/sse2.rs
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
-pub unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     // Process 4 blocks (64 bytes) at a time
     let alpha_ptr = input_ptr;
@@ -25,7 +25,7 @@ pub unsafe fn shuffle(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
 #[allow(unused_assignments)]
-pub unsafe fn shuffle_with_components(
+pub(crate) unsafe fn shuffle_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut alpha_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -56,3 +56,6 @@ harness = false
 name = "normalize_blocks"
 path = "benches/normalize_blocks/main.rs"
 harness = false
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(tarpaulin_include)"] }

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -17,6 +17,8 @@ pgo = []
 no-runtime-cpu-detection = []
 # Use nightly compiler features (AVX512)
 nightly = ["dxt-lossless-transform-common/nightly"]
+# Benchmarking feature to expose internal APIs
+bench = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -37,11 +39,13 @@ pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 name = "transform_standard"
 path = "benches/transform_standard/main.rs"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "untransform_standard"
 path = "benches/untransform_standard/main.rs"
 harness = false
+required-features = ["bench"]
 
 [[bench]]
 name = "block_decode"

--- a/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx2.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx2.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::transform::bench_exports::u32_avx2_transform;
+use dxt_lossless_transform_bc3::transforms::standard::transform::bench::u32_avx2_transform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx2.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx2.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::transform::u32_avx2;
+use dxt_lossless_transform_bc3::transforms::standard::transform::bench_exports::u32_avx2_transform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_avx2(
+        u32_avx2_transform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx512.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::transform::bench_exports::avx512_vbmi_transform;
+use dxt_lossless_transform_bc3::transforms::standard::transform::bench::avx512_vbmi_transform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx512_vbmi(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/transform_standard/avx512.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::transform::avx512_vbmi;
+use dxt_lossless_transform_bc3::transforms::standard::transform::bench_exports::avx512_vbmi_transform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx512_vbmi(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        avx512_vbmi(
+        avx512_vbmi_transform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc3/benches/transform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/transform_standard/portable32.rs
@@ -1,5 +1,7 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::transform::bench_exports::*;
+use dxt_lossless_transform_bc3::transforms::standard::transform::bench::{
+    portable32::u32_unroll_2, *,
+};
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
@@ -14,7 +16,7 @@ fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut R
 
 fn bench_portable32_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_transform_unroll_2(
+        u32_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc3/benches/transform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/transform_standard/portable32.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::transform::*;
+use dxt_lossless_transform_bc3::transforms::standard::transform::bench_exports::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32(
+        u32_transform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -14,7 +14,7 @@ fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut R
 
 fn bench_portable32_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_unroll_2(
+        u32_transform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/avx512.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::{
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::{
     avx512_detransform, avx512_detransform_32_vbmi, avx512_detransform_32_vl,
 };
 use safe_allocator_api::RawAlloc;

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/avx512.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::{
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::{
     avx512_detransform, avx512_detransform_32_vbmi, avx512_detransform_32_vl,
 };
 use safe_allocator_api::RawAlloc;

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable32.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::*;
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable32.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::*;
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable64.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable64.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::u64_detransform;
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::u64_detransform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable64(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable64.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/portable64.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::u64_detransform;
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::u64_detransform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable64(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/sse2.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::{
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::{
     u32_detransform_sse2, u64_detransform_sse2,
 };
 use safe_allocator_api::RawAlloc;

--- a/projects/dxt-lossless-transform-bc3/benches/untransform_standard/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/benches/untransform_standard/sse2.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::{
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench_exports::{
     u32_detransform_sse2, u64_detransform_sse2,
 };
 use safe_allocator_api::RawAlloc;

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/avx2.rs
@@ -11,7 +11,7 @@ use super::portable32::u32_with_separate_endpoints;
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16 (BC3 block size)
 #[target_feature(enable = "avx2")]
-pub unsafe fn u32_avx2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_avx2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Setup pointers for alpha components
@@ -42,7 +42,7 @@ pub unsafe fn u32_avx2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - All output buffers must not overlap with each other or the input buffer
 /// - len must be divisible by 16 (BC3 block size)
 #[target_feature(enable = "avx2")]
-pub unsafe fn u32_avx2_with_separate_pointers(
+pub(crate) unsafe fn u32_avx2_with_separate_pointers(
     input_ptr: *const u8,
     mut alpha_byte_out_ptr: *mut u16,
     mut alpha_bit_out_ptr: *mut u8,

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/avx512.rs
@@ -13,7 +13,7 @@ use super::portable32::u32_with_separate_endpoints;
 #[target_feature(enable = "avx512vbmi")]
 #[allow(clippy::identity_op)]
 #[allow(clippy::erasing_op)]
-pub unsafe fn avx512_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Setup pointers for alpha components
@@ -45,7 +45,7 @@ pub unsafe fn avx512_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize)
 #[target_feature(enable = "avx512vbmi")]
 #[allow(clippy::identity_op)]
 #[allow(clippy::erasing_op)]
-pub unsafe fn avx512_vbmi_with_separate_pointers(
+pub(crate) unsafe fn avx512_vbmi_with_separate_pointers(
     input_ptr: *const u8,
     mut alpha_byte_out_ptr: *mut u8,
     mut alpha_bit_out_ptr: *mut u8,

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/bench/mod.rs
@@ -1,0 +1,18 @@
+#![allow(clippy::missing_safety_doc)]
+
+pub mod portable32;
+
+pub unsafe fn u32_transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::portable32::u32(input_ptr, output_ptr, len)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn u32_avx2_transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx2::u32_avx2(input_ptr, output_ptr, len)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn avx512_vbmi_transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_vbmi(input_ptr, output_ptr, len)
+}

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/bench/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![cfg(not(tarpaulin_include))]
 
 pub mod portable32;
 

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/bench/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/bench/portable32.rs
@@ -1,0 +1,81 @@
+/// # Safety
+///
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+/// - len must be divisible by 16
+pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    let mut alpha_byte_out_ptr = output_ptr as *mut u16;
+    let mut alpha_bit_out_ptr = output_ptr.add(len / 16 * 2) as *mut u16;
+    let mut color_byte_out_ptr = output_ptr.add(len / 16 * 8) as *mut u32;
+    let mut index_byte_out_ptr = output_ptr.add(len / 16 * 12) as *mut u32;
+
+    let mut current_input_ptr = input_ptr;
+    let alpha_byte_end_ptr = output_ptr.add((len / 16 * 2).saturating_sub(16)) as *mut u16;
+
+    while alpha_byte_out_ptr < alpha_byte_end_ptr {
+        // Block 1
+        let alpha_bytes1 = (current_input_ptr as *const u16).read_unaligned();
+        let alpha_bits1_a = (current_input_ptr.add(2) as *const u16).read_unaligned();
+        let alpha_bits1_b = (current_input_ptr.add(4) as *const u32).read_unaligned();
+        let color_bytes1 = (current_input_ptr.add(8) as *const u32).read_unaligned();
+        let index_bytes1 = (current_input_ptr.add(12) as *const u32).read_unaligned();
+
+        // Block 2
+        let alpha_bytes2 = (current_input_ptr.add(16) as *const u16).read_unaligned();
+        let alpha_bits2_a = (current_input_ptr.add(18) as *const u16).read_unaligned();
+        let alpha_bits2_b = (current_input_ptr.add(20) as *const u32).read_unaligned();
+        let color_bytes2 = (current_input_ptr.add(24) as *const u32).read_unaligned();
+        let index_bytes2 = (current_input_ptr.add(28) as *const u32).read_unaligned();
+
+        // Write Block 1
+        alpha_byte_out_ptr.write_unaligned(alpha_bytes1);
+        alpha_bit_out_ptr.write_unaligned(alpha_bits1_a);
+        (alpha_bit_out_ptr.add(1) as *mut u32).write_unaligned(alpha_bits1_b);
+        color_byte_out_ptr.write_unaligned(color_bytes1);
+        index_byte_out_ptr.write_unaligned(index_bytes1);
+
+        // Write Block 2
+        alpha_byte_out_ptr.add(1).write_unaligned(alpha_bytes2);
+        alpha_bit_out_ptr.add(3).write_unaligned(alpha_bits2_a);
+        (alpha_bit_out_ptr.add(4) as *mut u32).write_unaligned(alpha_bits2_b);
+        color_byte_out_ptr.add(1).write_unaligned(color_bytes2);
+        index_byte_out_ptr.add(1).write_unaligned(index_bytes2);
+
+        // Advance pointers
+        alpha_byte_out_ptr = alpha_byte_out_ptr.add(2);
+        alpha_bit_out_ptr = alpha_bit_out_ptr.add(6);
+        color_byte_out_ptr = color_byte_out_ptr.add(2);
+        index_byte_out_ptr = index_byte_out_ptr.add(2);
+        current_input_ptr = current_input_ptr.add(32);
+    }
+
+    // Handle remaining blocks
+    let alpha_byte_end_ptr = output_ptr.add(len / 16 * 2) as *mut u16;
+    crate::transforms::standard::transform::portable32::u32_with_separate_endpoints(
+        current_input_ptr,
+        alpha_byte_out_ptr,
+        alpha_bit_out_ptr,
+        color_byte_out_ptr,
+        index_byte_out_ptr,
+        alpha_byte_end_ptr,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    #[rstest]
+    #[case(u32_unroll_2, "portable32_unroll_2", 2)]
+    fn test_portable32_unaligned(
+        #[case] transform_fn: StandardTransformFn,
+        #[case] impl_name: &str,
+        #[case] max_blocks: usize,
+    ) {
+        // For portable32: processes 16 bytes (1 block) per iteration, so max_blocks = 16 bytes × 2 ÷ 16 = 2
+        run_standard_transform_unaligned_test(transform_fn, max_blocks, impl_name);
+    }
+}

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/mod.rs
@@ -207,24 +207,4 @@ pub unsafe fn split_blocks_with_separate_pointers(
 
 // Re-export functions for benchmarking when the 'bench' feature is enabled
 #[cfg(feature = "bench")]
-#[allow(clippy::missing_safety_doc)]
-pub mod bench_exports {
-    pub unsafe fn u32_transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::portable32::u32(input_ptr, output_ptr, len)
-    }
-
-    pub unsafe fn u32_transform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::portable32::u32_unroll_2(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn u32_avx2_transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::avx2::u32_avx2(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(feature = "nightly")]
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn avx512_vbmi_transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::avx512::avx512_vbmi(input_ptr, output_ptr, len)
-    }
-}
+pub mod bench;

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/portable32.rs
@@ -3,7 +3,7 @@
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     let alpha_byte_out_ptr = output_ptr as *mut u16;
@@ -31,7 +31,7 @@ pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - alpha_byte_end_ptr must equal alpha_byte_out_ptr + (len/16) when cast to u16 pointers
 /// - All output buffers must not overlap with each other or the input buffer
 /// - len must be divisible by 16 (BC3 block size)
-pub unsafe fn u32_with_separate_endpoints(
+pub(crate) unsafe fn u32_with_separate_endpoints(
     input_ptr: *const u8,
     mut alpha_byte_out_ptr: *mut u16,
     mut alpha_bit_out_ptr: *mut u16,
@@ -71,7 +71,7 @@ pub unsafe fn u32_with_separate_endpoints(
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     let mut alpha_byte_out_ptr = output_ptr as *mut u16;

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/transform/portable32.rs
@@ -66,79 +66,13 @@ pub(crate) unsafe fn u32_with_separate_endpoints(
     }
 }
 
-/// # Safety
-///
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-/// - len must be divisible by 16
-pub(crate) unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    let mut alpha_byte_out_ptr = output_ptr as *mut u16;
-    let mut alpha_bit_out_ptr = output_ptr.add(len / 16 * 2) as *mut u16;
-    let mut color_byte_out_ptr = output_ptr.add(len / 16 * 8) as *mut u32;
-    let mut index_byte_out_ptr = output_ptr.add(len / 16 * 12) as *mut u32;
-
-    let mut current_input_ptr = input_ptr;
-    let alpha_byte_end_ptr = output_ptr.add((len / 16 * 2).saturating_sub(16)) as *mut u16;
-
-    while alpha_byte_out_ptr < alpha_byte_end_ptr {
-        // Block 1
-        let alpha_bytes1 = (current_input_ptr as *const u16).read_unaligned();
-        let alpha_bits1_a = (current_input_ptr.add(2) as *const u16).read_unaligned();
-        let alpha_bits1_b = (current_input_ptr.add(4) as *const u32).read_unaligned();
-        let color_bytes1 = (current_input_ptr.add(8) as *const u32).read_unaligned();
-        let index_bytes1 = (current_input_ptr.add(12) as *const u32).read_unaligned();
-
-        // Block 2
-        let alpha_bytes2 = (current_input_ptr.add(16) as *const u16).read_unaligned();
-        let alpha_bits2_a = (current_input_ptr.add(18) as *const u16).read_unaligned();
-        let alpha_bits2_b = (current_input_ptr.add(20) as *const u32).read_unaligned();
-        let color_bytes2 = (current_input_ptr.add(24) as *const u32).read_unaligned();
-        let index_bytes2 = (current_input_ptr.add(28) as *const u32).read_unaligned();
-
-        // Write Block 1
-        alpha_byte_out_ptr.write_unaligned(alpha_bytes1);
-        alpha_bit_out_ptr.write_unaligned(alpha_bits1_a);
-        (alpha_bit_out_ptr.add(1) as *mut u32).write_unaligned(alpha_bits1_b);
-        color_byte_out_ptr.write_unaligned(color_bytes1);
-        index_byte_out_ptr.write_unaligned(index_bytes1);
-
-        // Write Block 2
-        alpha_byte_out_ptr.add(1).write_unaligned(alpha_bytes2);
-        alpha_bit_out_ptr.add(3).write_unaligned(alpha_bits2_a);
-        (alpha_bit_out_ptr.add(4) as *mut u32).write_unaligned(alpha_bits2_b);
-        color_byte_out_ptr.add(1).write_unaligned(color_bytes2);
-        index_byte_out_ptr.add(1).write_unaligned(index_bytes2);
-
-        // Advance pointers
-        alpha_byte_out_ptr = alpha_byte_out_ptr.add(2);
-        alpha_bit_out_ptr = alpha_bit_out_ptr.add(6);
-        color_byte_out_ptr = color_byte_out_ptr.add(2);
-        index_byte_out_ptr = index_byte_out_ptr.add(2);
-        current_input_ptr = current_input_ptr.add(32);
-    }
-
-    // Handle remaining blocks
-    let alpha_byte_end_ptr = output_ptr.add(len / 16 * 2) as *mut u16;
-    u32_with_separate_endpoints(
-        current_input_ptr,
-        alpha_byte_out_ptr,
-        alpha_bit_out_ptr,
-        color_byte_out_ptr,
-        index_byte_out_ptr,
-        alpha_byte_end_ptr,
-    );
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{u32, u32_unroll_2};
+    use super::*;
     use crate::test_prelude::*;
 
     #[rstest]
     #[case(u32, "portable32", 2)]
-    #[case(u32_unroll_2, "portable32_unroll_2", 2)]
     fn test_portable32_unaligned(
         #[case] transform_fn: StandardTransformFn,
         #[case] impl_name: &str,

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/avx512.rs
@@ -11,7 +11,7 @@ use crate::transforms::standard::untransform::portable::u32_detransform_with_sep
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512vbmi")]
-pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     // Non-64bit has an optimized path, and vl + non-vl variant,
     // however it turns out it's negigible in speed difference with 64-bit path, and sometimes slower even.
     // Somehow L1 cache reads are way faster than expected.
@@ -44,7 +44,7 @@ pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len:
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512vbmi")]
-pub unsafe fn avx512_detransform_32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_detransform_32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     #[cfg(target_feature = "avx512vl")]
     let is_vl_supported = true;
 
@@ -65,7 +65,11 @@ pub unsafe fn avx512_detransform_32(input_ptr: *const u8, output_ptr: *mut u8, l
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512vbmi")]
 #[target_feature(enable = "avx512vl")]
-pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_detransform_32_vl(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 16 == 0);
 
     // Process as many 64-byte blocks as possible
@@ -93,7 +97,11 @@ pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512vbmi")]
-pub unsafe fn avx512_detransform_32_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn avx512_detransform_32_vbmi(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 16 == 0);
 
     // Process as many 64-byte blocks as possible
@@ -139,7 +147,7 @@ pub unsafe fn avx512_detransform_32_vbmi(input_ptr: *const u8, output_ptr: *mut 
 #[allow(clippy::erasing_op)]
 #[allow(clippy::identity_op)]
 #[target_feature(enable = "avx512vbmi")]
-pub unsafe fn avx512_detransform_separate_components(
+pub(crate) unsafe fn avx512_detransform_separate_components(
     mut alpha_byte_in_ptr: *const u8,
     mut alpha_bit_in_ptr: *const u8,
     mut color_byte_in_ptr: *const u8,
@@ -541,7 +549,7 @@ pub unsafe fn avx512_detransform_separate_components(
 #[allow(clippy::erasing_op)]
 #[allow(clippy::identity_op)]
 #[target_feature(enable = "avx512vbmi")]
-pub unsafe fn avx512_detransform_separate_components_32(
+pub(crate) unsafe fn avx512_detransform_separate_components_32(
     mut alpha_byte_in_ptr: *const u8,
     mut alpha_bit_in_ptr: *const u8,
     mut color_byte_in_ptr: *const u8,
@@ -686,7 +694,7 @@ pub unsafe fn avx512_detransform_separate_components_32(
 #[allow(clippy::identity_op)]
 #[target_feature(enable = "avx512vbmi")]
 #[target_feature(enable = "avx512vl")]
-pub unsafe fn avx512_detransform_separate_components_32_vl(
+pub(crate) unsafe fn avx512_detransform_separate_components_32_vl(
     mut alpha_byte_in_ptr: *const u8,
     mut alpha_bit_in_ptr: *const u8,
     mut color_byte_in_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/avx512.rs
@@ -44,6 +44,7 @@ pub(crate) unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512vbmi")]
+#[allow(dead_code)] // This should be faster on 32-bit builds, but somehow it only trades blows.
 pub(crate) unsafe fn avx512_detransform_32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     #[cfg(target_feature = "avx512vl")]
     let is_vl_supported = true;

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/mod.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::missing_safety_doc)]
+#![cfg(not(tarpaulin_include))]
 
 pub mod portable;
 

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/mod.rs
@@ -1,0 +1,46 @@
+#![allow(clippy::missing_safety_doc)]
+
+pub mod portable;
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub mod sse2;
+
+pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    portable::u32_detransform(input_ptr, output_ptr, len)
+}
+
+pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::portable::u32_detransform_v2(input_ptr, output_ptr, len)
+}
+
+pub unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    portable::u64_detransform(input_ptr, output_ptr, len)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    sse2::u32_detransform_sse2(input_ptr, output_ptr, len)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::sse2::u64_detransform_sse2(input_ptr, output_ptr, len)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_detransform(input_ptr, output_ptr, len)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn avx512_detransform_32_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_detransform_32_vbmi(input_ptr, output_ptr, len)
+}
+
+#[cfg(feature = "nightly")]
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_detransform_32_vl(input_ptr, output_ptr, len)
+}

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/sse2.rs
@@ -1,0 +1,134 @@
+#[cfg(target_arch = "x86")]
+use core::arch::x86::*;
+#[cfg(target_arch = "x86_64")]
+use core::arch::x86_64::*;
+use core::arch::*;
+
+use crate::transforms::standard::untransform::portable::u32_detransform_with_separate_pointers;
+
+/// # Safety
+///
+/// - Same safety requirements as the scalar version:
+/// - input_ptr must be valid for reads of len bytes
+/// - output_ptr must be valid for writes of len bytes
+#[target_feature(enable = "sse2")]
+pub(crate) unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    debug_assert!(len % 16 == 0);
+
+    const BYTES_PER_ITERATION: usize = 64;
+    // Process as many 64-byte blocks as possible
+    let aligned_len = len - (len % BYTES_PER_ITERATION);
+
+    let mut current_output_ptr = output_ptr;
+
+    // Set up input pointers for each section
+    let mut alpha_byte_in_ptr = input_ptr as *const u32;
+    let mut alpha_bit_in_ptr = input_ptr.add(len / 16 * 2) as *const u32;
+    let mut color_byte_in_ptr = input_ptr.add(len / 16 * 8) as *const __m128i;
+    let mut index_byte_in_ptr = input_ptr.add(len / 16 * 12) as *const __m128i;
+
+    if aligned_len > 0 {
+        let alpha_byte_aligned_end_ptr = input_ptr.add(aligned_len / 16 * 2) as *const u32;
+        while alpha_byte_in_ptr < alpha_byte_aligned_end_ptr {
+            // Write the alpha bytes.
+            let alpha_bytes = alpha_byte_in_ptr.read_unaligned();
+            write_u16(current_output_ptr, 0, shift_u32_u16(alpha_bytes, 0));
+            write_u16(current_output_ptr, 16, shift_u32_u16(alpha_bytes, 16));
+            let alpha_bytes = alpha_byte_in_ptr.add(1).read_unaligned();
+            write_u16(current_output_ptr, 32, shift_u32_u16(alpha_bytes, 0));
+            write_u16(current_output_ptr, 48, shift_u32_u16(alpha_bytes, 16));
+            alpha_byte_in_ptr = alpha_byte_in_ptr.add(2);
+
+            // Write the alpha bits - read 4 bytes at a time
+            let alpha_bits = alpha_bit_in_ptr.read_unaligned();
+            let alpha_bits_2 = alpha_bit_in_ptr.add(1).read_unaligned();
+            write_u32(current_output_ptr, 2, alpha_bits);
+            write_u16(current_output_ptr, 6, shift_u32_u16(alpha_bits_2, 0)); // block 0 done
+            write_u16(current_output_ptr, 16 + 2, shift_u32_u16(alpha_bits_2, 16));
+
+            let alpha_bits_3 = alpha_bit_in_ptr.add(2).read_unaligned();
+            let alpha_bits_4 = alpha_bit_in_ptr.add(3).read_unaligned();
+            write_u32(current_output_ptr, 16 + 4, alpha_bits_3); // block 1 done
+            write_u32(current_output_ptr, 32 + 2, alpha_bits_4);
+
+            let alpha_bits_5 = alpha_bit_in_ptr.add(4).read_unaligned();
+            let alpha_bits_6 = alpha_bit_in_ptr.add(5).read_unaligned();
+            write_u16(current_output_ptr, 32 + 6, shift_u32_u16(alpha_bits_5, 0)); // block 2 done
+            write_u16(current_output_ptr, 48 + 2, shift_u32_u16(alpha_bits_5, 16));
+            write_u32(current_output_ptr, 48 + 4, alpha_bits_6); // block 3 done
+            alpha_bit_in_ptr = alpha_bit_in_ptr.add(6);
+
+            // Load and interleave colors/indices
+            let colors = _mm_loadu_si128(color_byte_in_ptr);
+            let indices = _mm_loadu_si128(index_byte_in_ptr);
+
+            let low = _mm_unpacklo_epi32(colors, indices);
+            let high = _mm_unpackhi_epi32(colors, indices);
+
+            asm!(
+                "movq [{out}], {low}",
+                "movhps [{out_high}], {low}",
+                "movq [{out_mid}], {high}",
+                "movhps [{out_high_mid}], {high}",
+                out = in(reg) current_output_ptr.add(8),
+                out_high = in(reg) current_output_ptr.add(24),
+                out_mid = in(reg) current_output_ptr.add(40),
+                out_high_mid = in(reg) current_output_ptr.add(56),
+                low = in(xmm_reg) low,
+                high = in(xmm_reg) high,
+                options(nostack, preserves_flags)
+            );
+
+            color_byte_in_ptr = color_byte_in_ptr.add(1);
+            index_byte_in_ptr = index_byte_in_ptr.add(1);
+            current_output_ptr = current_output_ptr.add(BYTES_PER_ITERATION);
+        }
+    }
+
+    // Convert pointers to the types expected by u32_detransform_with_separate_pointers
+    let alpha_byte_in_ptr_u16 = alpha_byte_in_ptr as *const u16;
+    let alpha_bit_in_ptr_u16 = alpha_bit_in_ptr as *const u16;
+    let color_byte_in_ptr_u32 = color_byte_in_ptr as *const u32;
+    let index_byte_in_ptr_u32 = index_byte_in_ptr as *const u32;
+
+    u32_detransform_with_separate_pointers(
+        alpha_byte_in_ptr_u16,
+        alpha_bit_in_ptr_u16,
+        color_byte_in_ptr_u32,
+        index_byte_in_ptr_u32,
+        current_output_ptr,
+        len - aligned_len,
+    );
+}
+
+#[inline(always)]
+unsafe fn write_u16(ptr: *mut u8, offset: usize, value: u16) {
+    (ptr.add(offset) as *mut u16).write_unaligned(value);
+}
+
+#[inline(always)]
+unsafe fn write_u32(ptr: *mut u8, offset: usize, value: u32) {
+    (ptr.add(offset) as *mut u32).write_unaligned(value);
+}
+
+#[inline(always)]
+unsafe fn shift_u32_u16(value: u32, shift: usize) -> u16 {
+    (value >> shift) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    #[rstest]
+    #[case(u32_detransform_sse2, "u32", 8)]
+    fn test_sse2_unaligned(
+        #[case] detransform_fn: StandardTransformFn,
+        #[case] impl_name: &str,
+        #[case] max_blocks: usize,
+    ) {
+        // For SSE2: processes 64 bytes (4 blocks) per iteration, so max_blocks = 64 bytes × 2 ÷ 16 = 8
+        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+    }
+}

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/mod.rs
@@ -7,6 +7,9 @@ pub mod sse2;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx512;
 
+#[cfg(feature = "bench")]
+pub mod bench;
+
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
 unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
@@ -37,9 +40,9 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
         sse2::u64_detransform_sse2(input_ptr, output_ptr, len);
     }
 
-    #[cfg(target_arch = "x86")]
+    #[cfg(not(target_arch = "x86_64"))]
     {
-        u32_detransform_v2(input_ptr, output_ptr, len);
+        portable::u32_detransform_v2(input_ptr, output_ptr, len);
     }
 }
 
@@ -63,7 +66,7 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        u32_detransform_v2(input_ptr, output_ptr, len)
+        portable::u32_detransform_v2(input_ptr, output_ptr, len)
     }
 }
 
@@ -184,54 +187,5 @@ pub unsafe fn unsplit_block_with_separate_pointers(
             output_ptr,
             len,
         )
-    }
-}
-
-// Public wrapper functions available through bench_exports module when 'bench' feature is enabled
-#[cfg(feature = "bench")]
-#[allow(clippy::missing_safety_doc)]
-pub mod bench_exports {
-    pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::portable::u32_detransform(input_ptr, output_ptr, len)
-    }
-
-    pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::portable::u32_detransform_v2(input_ptr, output_ptr, len)
-    }
-
-    pub unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::portable::u64_detransform(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::sse2::u32_detransform_sse2(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::sse2::u64_detransform_sse2(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(feature = "nightly")]
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::avx512::avx512_detransform(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(feature = "nightly")]
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn avx512_detransform_32_vbmi(
-        input_ptr: *const u8,
-        output_ptr: *mut u8,
-        len: usize,
-    ) {
-        super::avx512::avx512_detransform_32_vbmi(input_ptr, output_ptr, len)
-    }
-
-    #[cfg(feature = "nightly")]
-    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-    pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::avx512::avx512_detransform_32_vl(input_ptr, output_ptr, len)
     }
 }

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/mod.rs
@@ -1,19 +1,11 @@
 pub mod portable;
-pub use portable::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse2;
 
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use sse2::*;
-
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx512;
-
-#[cfg(feature = "nightly")]
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx512::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
@@ -192,5 +184,54 @@ pub unsafe fn unsplit_block_with_separate_pointers(
             output_ptr,
             len,
         )
+    }
+}
+
+// Public wrapper functions available through bench_exports module when 'bench' feature is enabled
+#[cfg(feature = "bench")]
+#[allow(clippy::missing_safety_doc)]
+pub mod bench_exports {
+    pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::portable::u32_detransform(input_ptr, output_ptr, len)
+    }
+
+    pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::portable::u32_detransform_v2(input_ptr, output_ptr, len)
+    }
+
+    pub unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::portable::u64_detransform(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::sse2::u32_detransform_sse2(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::sse2::u64_detransform_sse2(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(feature = "nightly")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::avx512::avx512_detransform(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(feature = "nightly")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn avx512_detransform_32_vbmi(
+        input_ptr: *const u8,
+        output_ptr: *mut u8,
+        len: usize,
+    ) {
+        super::avx512::avx512_detransform_32_vbmi(input_ptr, output_ptr, len)
+    }
+
+    #[cfg(feature = "nightly")]
+    #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+    pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::avx512::avx512_detransform_32_vl(input_ptr, output_ptr, len)
     }
 }

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/portable.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/portable.rs
@@ -3,7 +3,7 @@
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Set up input pointers for each section
@@ -27,7 +27,7 @@ pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: us
 ///
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
-pub unsafe fn u32_detransform_with_separate_pointers(
+pub(crate) unsafe fn u32_detransform_with_separate_pointers(
     mut alpha_byte_in_ptr: *const u16,
     mut alpha_bit_in_ptr: *const u16,
     mut color_byte_in_ptr: *const u32,
@@ -64,7 +64,7 @@ pub unsafe fn u32_detransform_with_separate_pointers(
 /// - input_ptr must be valid for reads based on the transformed layout derived from len bytes of output.
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     const BYTES_PER_ITERATION: usize = 32;
     let aligned_len = len - (len % BYTES_PER_ITERATION);
@@ -141,7 +141,7 @@ pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len:
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     const BYTES_PER_ITERATION: usize = 32;
     let aligned_len = len - (len % BYTES_PER_ITERATION);

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/sse2.rs
@@ -12,6 +12,7 @@ use crate::transforms::standard::untransform::portable::u32_detransform_with_sep
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
+#[cfg_attr(target_arch = "x86", allow(dead_code))] // x86 does not use this path.
 pub(crate) unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
@@ -139,101 +140,6 @@ pub(crate) unsafe fn u64_detransform_sse2_separate_components(
     );
 }
 
-/// # Safety
-///
-/// - Same safety requirements as the scalar version:
-/// - input_ptr must be valid for reads of len bytes
-/// - output_ptr must be valid for writes of len bytes
-#[target_feature(enable = "sse2")]
-pub(crate) unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    debug_assert!(len % 16 == 0);
-
-    const BYTES_PER_ITERATION: usize = 64;
-    // Process as many 64-byte blocks as possible
-    let aligned_len = len - (len % BYTES_PER_ITERATION);
-
-    let mut current_output_ptr = output_ptr;
-
-    // Set up input pointers for each section
-    let mut alpha_byte_in_ptr = input_ptr as *const u32;
-    let mut alpha_bit_in_ptr = input_ptr.add(len / 16 * 2) as *const u32;
-    let mut color_byte_in_ptr = input_ptr.add(len / 16 * 8) as *const __m128i;
-    let mut index_byte_in_ptr = input_ptr.add(len / 16 * 12) as *const __m128i;
-
-    if aligned_len > 0 {
-        let alpha_byte_aligned_end_ptr = input_ptr.add(aligned_len / 16 * 2) as *const u32;
-        while alpha_byte_in_ptr < alpha_byte_aligned_end_ptr {
-            // Write the alpha bytes.
-            let alpha_bytes = alpha_byte_in_ptr.read_unaligned();
-            write_u16(current_output_ptr, 0, shift_u32_u16(alpha_bytes, 0));
-            write_u16(current_output_ptr, 16, shift_u32_u16(alpha_bytes, 16));
-            let alpha_bytes = alpha_byte_in_ptr.add(1).read_unaligned();
-            write_u16(current_output_ptr, 32, shift_u32_u16(alpha_bytes, 0));
-            write_u16(current_output_ptr, 48, shift_u32_u16(alpha_bytes, 16));
-            alpha_byte_in_ptr = alpha_byte_in_ptr.add(2);
-
-            // Write the alpha bits - read 4 bytes at a time
-            let alpha_bits = alpha_bit_in_ptr.read_unaligned();
-            let alpha_bits_2 = alpha_bit_in_ptr.add(1).read_unaligned();
-            write_u32(current_output_ptr, 2, alpha_bits);
-            write_u16(current_output_ptr, 6, shift_u32_u16(alpha_bits_2, 0)); // block 0 done
-            write_u16(current_output_ptr, 16 + 2, shift_u32_u16(alpha_bits_2, 16));
-
-            let alpha_bits_3 = alpha_bit_in_ptr.add(2).read_unaligned();
-            let alpha_bits_4 = alpha_bit_in_ptr.add(3).read_unaligned();
-            write_u32(current_output_ptr, 16 + 4, alpha_bits_3); // block 1 done
-            write_u32(current_output_ptr, 32 + 2, alpha_bits_4);
-
-            let alpha_bits_5 = alpha_bit_in_ptr.add(4).read_unaligned();
-            let alpha_bits_6 = alpha_bit_in_ptr.add(5).read_unaligned();
-            write_u16(current_output_ptr, 32 + 6, shift_u32_u16(alpha_bits_5, 0)); // block 2 done
-            write_u16(current_output_ptr, 48 + 2, shift_u32_u16(alpha_bits_5, 16));
-            write_u32(current_output_ptr, 48 + 4, alpha_bits_6); // block 3 done
-            alpha_bit_in_ptr = alpha_bit_in_ptr.add(6);
-
-            // Load and interleave colors/indices
-            let colors = _mm_loadu_si128(color_byte_in_ptr);
-            let indices = _mm_loadu_si128(index_byte_in_ptr);
-
-            let low = _mm_unpacklo_epi32(colors, indices);
-            let high = _mm_unpackhi_epi32(colors, indices);
-
-            asm!(
-                "movq [{out}], {low}",
-                "movhps [{out_high}], {low}",
-                "movq [{out_mid}], {high}",
-                "movhps [{out_high_mid}], {high}",
-                out = in(reg) current_output_ptr.add(8),
-                out_high = in(reg) current_output_ptr.add(24),
-                out_mid = in(reg) current_output_ptr.add(40),
-                out_high_mid = in(reg) current_output_ptr.add(56),
-                low = in(xmm_reg) low,
-                high = in(xmm_reg) high,
-                options(nostack, preserves_flags)
-            );
-
-            color_byte_in_ptr = color_byte_in_ptr.add(1);
-            index_byte_in_ptr = index_byte_in_ptr.add(1);
-            current_output_ptr = current_output_ptr.add(BYTES_PER_ITERATION);
-        }
-    }
-
-    // Convert pointers to the types expected by u32_detransform_with_separate_pointers
-    let alpha_byte_in_ptr_u16 = alpha_byte_in_ptr as *const u16;
-    let alpha_bit_in_ptr_u16 = alpha_bit_in_ptr as *const u16;
-    let color_byte_in_ptr_u32 = color_byte_in_ptr as *const u32;
-    let index_byte_in_ptr_u32 = index_byte_in_ptr as *const u32;
-
-    u32_detransform_with_separate_pointers(
-        alpha_byte_in_ptr_u16,
-        alpha_bit_in_ptr_u16,
-        color_byte_in_ptr_u32,
-        index_byte_in_ptr_u32,
-        current_output_ptr,
-        len - aligned_len,
-    );
-}
-
 #[inline(always)]
 unsafe fn write_u16(ptr: *mut u8, offset: usize, value: u16) {
     (ptr.add(offset) as *mut u16).write_unaligned(value);
@@ -255,11 +161,6 @@ unsafe fn shift_u64_u16(value: u64, shift: usize) -> u16 {
 }
 
 #[inline(always)]
-unsafe fn shift_u32_u16(value: u32, shift: usize) -> u16 {
-    (value >> shift) as u16
-}
-
-#[inline(always)]
 unsafe fn shift_u64_u32(value: u64, shift: usize) -> u32 {
     (value >> shift) as u32
 }
@@ -270,7 +171,6 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform_sse2, "u32", 8)]
     #[case(u64_detransform_sse2, "u64", 8)]
     fn test_sse2_unaligned(
         #[case] detransform_fn: StandardTransformFn,

--- a/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc3/src/transforms/standard/untransform/sse2.rs
@@ -12,7 +12,7 @@ use crate::transforms::standard::untransform::portable::u32_detransform_with_sep
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
-pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Process as many 64-byte blocks as possible
@@ -55,7 +55,7 @@ pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, le
 /// - `current_output_ptr` must be valid for writes for `len` bytes.
 /// - `len` must be a multiple of 16 (the size of a BC3 block).
 /// - Pointers do not need to be aligned; unaligned loads/reads are used.
-pub unsafe fn u64_detransform_sse2_separate_components(
+pub(crate) unsafe fn u64_detransform_sse2_separate_components(
     mut alpha_byte_in_ptr: *const u64,
     mut alpha_bit_in_ptr: *const u64,
     mut color_byte_in_ptr: *const __m128i,
@@ -145,7 +145,7 @@ pub unsafe fn u64_detransform_sse2_separate_components(
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
-pub unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     const BYTES_PER_ITERATION: usize = 64;


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dedicated benchmarking modules and feature flags for BC2 and BC3 projects, enabling access to internal APIs for benchmarking when the "bench" feature is enabled.
  - Added new SIMD-accelerated and portable data transformation and detransformation functions for benchmarking, including AVX512, SSE2, and portable 32-bit implementations.

- **Refactor**
  - Restricted visibility of many internal transformation and detransformation functions, making them accessible only within the crate.
  - Removed legacy or redundant SIMD transformation implementations and streamlined module exports.
  - Updated benchmark imports to use new, dedicated benchmarking exports for clarity and encapsulation.

- **Chores**
  - Updated benchmark configuration to require the "bench" feature for execution.
  - Added linting configuration to warn about unexpected attributes in BC2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->