### PR TITLE
Improve: Hide Unnecessary BC1 APIs from Public View

### DIFF
--- a/README-DEV.MD
+++ b/README-DEV.MD
@@ -61,7 +61,7 @@ profiles, you should get one for debugging benchmarks.
 Execute the following:
 
 ```
-cargo bench --bench my_benchmark --profile profile -- --profile-time 10
+cargo bench --features bench --bench my_benchmark --profile profile -- --profile-time 10
 ```
 
 This should give you a flamegraph in `target/criterion/<method_name>/profile`. You can open that flamegraph in a web browser.
@@ -71,7 +71,7 @@ This should give you a flamegraph in `target/criterion/<method_name>/profile`. Y
 Execute the following:
 
 ```
-cargo bench --bench my_benchmark --no-run --profile profile
+cargo bench --features bench --bench my_benchmark --no-run --profile profile
 ```
 
 Navigate to the executable listed in the commandline:
@@ -172,19 +172,19 @@ rustup component add llvm-tools-preview
 Then run an 'instrumented' benchmark, this will run your code in `pgo_benchmark` and collect some data:
 
 ```
-cargo +nightly pgo instrument bench
+cargo +nightly pgo instrument bench --features bench
 ```
 
 After that run a regular benchmark to create a 'baseline' number:
 
 ```
-cargo +nightly bench
+cargo +nightly bench --features bench
 ```
 
 And run the PGO optimized build:
 
 ```
-cargo +nightly pgo optimize bench
+cargo +nightly pgo optimize bench --features bench
 ```
 
 If most of the results are equal or show an improvement, PGO has helped.

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,9 +11,9 @@ cargo-fuzz = true
 libfuzzer-sys = { version = "0.4", features = ["arbitrary-derive"] }
 rgbcx-sys = "1.1.3"
 bcdec_rs = "0.2.0"
-dxt-lossless-transform-bc1 = { path = "../projects/dxt-lossless-transform-bc1" }
-dxt-lossless-transform-bc2 = { path = "../projects/dxt-lossless-transform-bc2" }
-dxt-lossless-transform-bc3 = { path = "../projects/dxt-lossless-transform-bc3" }
+dxt-lossless-transform-bc1 = { path = "../projects/dxt-lossless-transform-bc1", features = ["experimental"] }
+dxt-lossless-transform-bc2 = { path = "../projects/dxt-lossless-transform-bc2", features = ["experimental"] }
+dxt-lossless-transform-bc3 = { path = "../projects/dxt-lossless-transform-bc3", features = ["experimental"] }
 dxt-lossless-transform-common = { path = "../projects/dxt-lossless-transform-common" }
 
 [[bin]]
@@ -50,6 +50,7 @@ path = "fuzz_targets/bc1_normalize.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc1/experimental"]
 
 [[bin]]
 name = "bc1_normalize_all_modes"
@@ -57,6 +58,7 @@ path = "fuzz_targets/bc1_normalize_all_modes.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc1/experimental"]
 
 [[bin]]
 name = "bc2_normalize"
@@ -64,6 +66,7 @@ path = "fuzz_targets/bc2_normalize.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc2/experimental"]
 
 [[bin]]
 name = "bc2_normalize_all_modes"
@@ -71,6 +74,7 @@ path = "fuzz_targets/bc2_normalize_all_modes.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc2/experimental"]
 
 [[bin]]
 name = "bc3_normalize"
@@ -78,6 +82,7 @@ path = "fuzz_targets/bc3_normalize.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc3/experimental"]
 
 [[bin]]
 name = "bc3_normalize_all_modes"
@@ -85,6 +90,7 @@ path = "fuzz_targets/bc3_normalize_all_modes.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc3/experimental"]
 
 [[bin]]
 name = "bc1_normalize_in_place"
@@ -92,6 +98,7 @@ path = "fuzz_targets/bc1_normalize_in_place.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc1/experimental"]
 
 [[bin]]
 name = "bc2_normalize_in_place"
@@ -99,6 +106,7 @@ path = "fuzz_targets/bc2_normalize_in_place.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc2/experimental"]
 
 [[bin]]
 name = "bc3_normalize_in_place"
@@ -106,3 +114,4 @@ path = "fuzz_targets/bc3_normalize_in_place.rs"
 test = false
 doc = false
 bench = false
+required-features = ["dxt-lossless-transform-bc3/experimental"]

--- a/projects/dxt-lossless-transform-bc1-api/README.MD
+++ b/projects/dxt-lossless-transform-bc1-api/README.MD
@@ -84,7 +84,7 @@ Untransform BC1 (`unsplit_blocks`):
 You can run the benchmarks like this (example):
 
 ```bash,ignore
-cargo bench -p dxt-lossless-transform-bc1 --bench unsplit_blocks -- "avx2 shuffle_permute"
+cargo bench -p dxt-lossless-transform-bc1 --bench untransform_standard --features bench -- "avx2 shuffle_permute"
 ```
 
 Measured on Linux with `performance` governor. 8MiB file (see: `projects/dxt-lossless-transform-bc1/benches`).

--- a/projects/dxt-lossless-transform-bc1/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc1/Cargo.toml
@@ -19,6 +19,8 @@ no-runtime-cpu-detection = []
 nightly = ["dxt-lossless-transform-common/nightly"]
 # Code only required for benchmarks.
 bench = []
+# Experimental features, not ready for prime time. Use at your own risk!
+experimental = []
 
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }

--- a/projects/dxt-lossless-transform-bc1/README.MD
+++ b/projects/dxt-lossless-transform-bc1/README.MD
@@ -67,7 +67,7 @@ We can split the colour endpoints
 +-------+-------+ +-------+-------+
 ```
 
-### Making Solid Blocks Represented the Same Across Texture (Normalizing Blocks) [Experimental]
+### Making Solid Blocks Represented the Same Across Texture (Normalizing Blocks) `[Experimental]`
 
 BC1 can represent solid color blocks in multiple ways.
 We make this representation consistent whenever possible.

--- a/projects/dxt-lossless-transform-bc1/benches/transform_standard/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/transform_standard/avx2.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc1::transforms::standard::transform::bench::*;
+use dxt_lossless_transform_bc1::bench::transform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx2_gather(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/benches/transform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/transform_standard/avx512.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc1::transforms::standard::transform::bench::*;
+use dxt_lossless_transform_bc1::bench::transform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx512_permute_unroll_2(

--- a/projects/dxt-lossless-transform-bc1/benches/transform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/transform_standard/portable32.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc1::transforms::standard::transform::bench::*;
+use dxt_lossless_transform_bc1::bench::transform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/benches/transform_standard/portable64.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/transform_standard/portable64.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc1::transforms::standard::transform::bench::*;
+use dxt_lossless_transform_bc1::bench::transform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable64_shift(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/benches/transform_standard/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/transform_standard/sse2.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc1::transforms::standard::transform::bench::*;
+use dxt_lossless_transform_bc1::bench::transform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_punpckhqdq_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/benches/untransform_standard/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/untransform_standard/avx2.rs
@@ -1,12 +1,10 @@
 use criterion::*;
-use dxt_lossless_transform_bc1::transforms::standard::untransform::bench::{
-    avx2::unpck_detransform, *,
-};
+use dxt_lossless_transform_bc1::bench::untransform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        unpck_detransform(
+        avx2_unpck_detransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -16,7 +14,7 @@ fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAll
 
 fn bench_unpck_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        unpck_detransform_unroll_2(
+        avx2_unpck_detransform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/dxt-lossless-transform-bc1/benches/untransform_standard/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/untransform_standard/avx512.rs
@@ -1,5 +1,5 @@
 use criterion::*;
-use dxt_lossless_transform_bc1::transforms::standard::untransform::bench::*;
+use dxt_lossless_transform_bc1::bench::untransform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_permute_512_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/benches/untransform_standard/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/untransform_standard/portable32.rs
@@ -1,5 +1,5 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc1::transforms::standard::untransform::bench::*;
+use dxt_lossless_transform_bc1::bench::untransform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/benches/untransform_standard/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/benches/untransform_standard/sse2.rs
@@ -1,5 +1,5 @@
 use criterion::*;
-use dxt_lossless_transform_bc1::transforms::standard::untransform::{bench::sse2::*, bench::*};
+use dxt_lossless_transform_bc1::bench::untransform::standard::*;
 use safe_allocator_api::RawAlloc;
 
 fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {

--- a/projects/dxt-lossless-transform-bc1/src/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/bench/mod.rs
@@ -3,8 +3,8 @@
 //! This module re-exposes internal benchmark functions that were changed to `pub(crate)` visibility
 //! so that external benchmarks can still access them when the `bench` feature is enabled.
 #![allow(clippy::missing_safety_doc)]
+#![cfg(not(tarpaulin_include))]
 
-#[cfg(feature = "bench")]
 pub mod transform {
     //! Transform benchmark functions
 
@@ -196,7 +196,6 @@ pub mod transform {
     }
 }
 
-#[cfg(feature = "bench")]
 pub mod untransform {
     //! Untransform benchmark functions
 

--- a/projects/dxt-lossless-transform-bc1/src/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/bench/mod.rs
@@ -1,0 +1,349 @@
+//! Benchmark functions re-exported for external benchmarks.
+//!
+//! This module re-exposes internal benchmark functions that were changed to `pub(crate)` visibility
+//! so that external benchmarks can still access them when the `bench` feature is enabled.
+#![allow(clippy::missing_safety_doc)]
+
+#[cfg(feature = "bench")]
+pub mod transform {
+    //! Transform benchmark functions
+
+    pub mod standard {
+        //! Standard transform benchmark functions
+
+        // Wrapper functions for transform benchmark APIs
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::shufps_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn shuffle_permute_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::transform::bench::shuffle_permute_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::u32(input_ptr, output_ptr, len)
+        }
+
+        #[cfg(feature = "nightly")]
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn permute_512(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::permute_512(input_ptr, output_ptr, len)
+        }
+
+        // SSE2 functions
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn punpckhqdq_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::sse2::punpckhqdq_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn punpckhqdq_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::sse2::punpckhqdq_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn shufps_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::sse2::shufps_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        // AVX2 functions
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn gather(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::avx2::gather(input_ptr, output_ptr, len)
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn permute(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::avx2::permute(input_ptr, output_ptr, len)
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn permute_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::avx2::permute_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn shuffle_permute(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::avx2::shuffle_permute(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        // AVX512 functions
+        #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
+        pub unsafe fn permute_512_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::avx512::permute_512_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
+        pub unsafe fn permute_512_unroll_2_with_separate_pointers(
+            input_ptr: *const u8,
+            colors_ptr: *mut u32,
+            indices_ptr: *mut u32,
+            len: usize,
+        ) {
+            crate::transforms::standard::transform::bench::avx512::permute_512_unroll_2_with_separate_pointers(
+                input_ptr, colors_ptr, indices_ptr, len
+            )
+        }
+
+        // Portable32 functions
+        pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable32::u32_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable32::u32_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn u32_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable32::u32_unroll_8(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        // Portable64 functions
+        pub unsafe fn portable(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable64::portable(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable64::shift(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable64::shift_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable64::shift_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable64::shift_unroll_8(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_with_count(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::transform::bench::portable64::shift_with_count(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_with_count_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::transform::bench::portable64::shift_with_count_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_with_count_unroll_4(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::transform::bench::portable64::shift_with_count_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn shift_with_count_unroll_8(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::transform::bench::portable64::shift_with_count_unroll_8(
+                input_ptr, output_ptr, len,
+            )
+        }
+    }
+}
+
+#[cfg(feature = "bench")]
+pub mod untransform {
+    //! Untransform benchmark functions
+
+    pub mod standard {
+        //! Standard untransform benchmark functions
+
+        // Wrapper functions for untransform benchmark APIs
+
+        pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::untransform::bench::u32_detransform(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn unpck_detransform_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::unpck_detransform_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn permd_detransform_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::permd_detransform_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
+        pub unsafe fn permute_512_detransform_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::permute_512_detransform_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        // SSE2 functions
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn unpck_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::untransform::bench::sse2::unpck_detransform(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(target_arch = "x86_64")]
+        pub unsafe fn unpck_detransform_unroll_4(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::sse2::unpck_detransform_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        // AVX2 functions
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn permd_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transforms::standard::untransform::bench::avx2::permd_detransform(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn avx2_unpck_detransform(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::avx2::unpck_detransform(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+        pub unsafe fn avx2_unpck_detransform_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::avx2::unpck_detransform_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        // AVX512 functions
+        #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
+        pub unsafe fn permute_512_detransform_unroll_2_intrinsics(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::avx512::permute_512_detransform_unroll_2_intrinsics(input_ptr, output_ptr, len)
+        }
+
+        #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
+        pub unsafe fn permute_512_detransform_unroll_2_with_components_intrinsics(
+            output_ptr: *mut u8,
+            len: usize,
+            indices_ptr: *const u8,
+            colors_ptr: *const u8,
+        ) {
+            crate::transforms::standard::untransform::bench::avx512::permute_512_detransform_unroll_2_with_components_intrinsics(
+                output_ptr, len, indices_ptr, colors_ptr
+            )
+        }
+
+        // Portable32 functions
+        pub unsafe fn u32_detransform_unroll_2(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::portable32::u32_detransform_unroll_2(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn u32_detransform_unroll_4(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::portable32::u32_detransform_unroll_4(
+                input_ptr, output_ptr, len,
+            )
+        }
+
+        pub unsafe fn u32_detransform_unroll_8(
+            input_ptr: *const u8,
+            output_ptr: *mut u8,
+            len: usize,
+        ) {
+            crate::transforms::standard::untransform::bench::portable32::u32_detransform_unroll_8(
+                input_ptr, output_ptr, len,
+            )
+        }
+    }
+}

--- a/projects/dxt-lossless-transform-bc1/src/determine_optimal_transform.rs
+++ b/projects/dxt-lossless-transform-bc1/src/determine_optimal_transform.rs
@@ -1,8 +1,6 @@
+#[cfg(feature = "experimental")]
 use crate::experimental::determine_best_transform_details_with_normalization;
-use crate::{
-    experimental::normalize_blocks::ColorNormalizationMode, transforms::standard::transform,
-    Bc1TransformDetails,
-};
+use crate::{ColorNormalizationMode, transforms::standard::transform, Bc1TransformDetails};
 use core::mem::size_of;
 use core::slice;
 use dxt_lossless_transform_common::{
@@ -85,11 +83,14 @@ pub unsafe fn determine_best_transform_details<F>(
 where
     F: Fn(*const u8, usize) -> usize,
 {
-    if transform_options.test_normalize_options {
-        determine_best_transform_details_with_normalization(input_ptr, len, transform_options)
-    } else {
-        determine_best_transform_details_fast(input_ptr, len, transform_options)
+    #[cfg(feature = "experimental")]
+    {
+        if transform_options.test_normalize_options {
+            return determine_best_transform_details_with_normalization(input_ptr, len, transform_options);
+        }
     }
+    
+    determine_best_transform_details_fast(input_ptr, len, transform_options)
 }
 
 /// Determine the best transform details without normalization testing (fast variant).

--- a/projects/dxt-lossless-transform-bc1/src/experimental/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/experimental/mod.rs
@@ -1,7 +1,5 @@
 //! Experimental features, not ready for prime time yet.
-//! Use at your own risk!
-//!
-//! Stuff in here isn't disabled by `feature`, it just wouldn't be exposed in stable API until ready.
+//! Use at your own risk! Expect API to be very unstable.
 
 pub use crate::experimental::normalize_blocks::*;
 pub mod normalize_blocks;

--- a/projects/dxt-lossless-transform-bc1/src/experimental/normalize_blocks/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/experimental/normalize_blocks/mod.rs
@@ -121,6 +121,8 @@ use dxt_lossless_transform_common::{
 /// - work_ptr must be valid for writes of len/2 bytes
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
+///
+/// [`determine_optimal_transform::determine_best_transform_details`]: crate::determine_optimal_transform::determine_best_transform_details
 #[inline]
 pub unsafe fn transform_bc1_with_normalize_blocks(
     input_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -7,9 +7,12 @@
     feature(stdarch_x86_avx512)
 )]
 
+pub(crate) mod transforms;
+
+#[cfg(feature = "bench")]
+pub mod bench;
 pub mod determine_optimal_transform;
 pub mod experimental;
-pub mod transforms;
 pub mod util;
 
 use crate::transforms::{

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -12,6 +12,7 @@ pub(crate) mod transforms;
 #[cfg(feature = "bench")]
 pub mod bench;
 pub mod determine_optimal_transform;
+#[cfg(feature = "experimental")]
 pub mod experimental;
 pub mod util;
 
@@ -20,7 +21,26 @@ use crate::transforms::{
     with_recorrelate, with_split_colour, with_split_colour_and_recorr,
 };
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
+
+#[cfg(feature = "experimental")]
 use experimental::normalize_blocks::ColorNormalizationMode;
+
+/// Color normalization mode for BC1 blocks.
+/// This is the fallback definition when the experimental feature is disabled.
+#[cfg(not(feature = "experimental"))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum ColorNormalizationMode {
+    /// No color normalization, preserves original color data
+    None,
+}
+
+#[cfg(not(feature = "experimental"))]
+impl ColorNormalizationMode {
+    /// Returns all possible values of the enum.
+    pub fn all_values() -> &'static [ColorNormalizationMode] {
+        &[ColorNormalizationMode::None]
+    }
+}
 
 /// The information about the BC1 transform that was just performed.
 /// Each item transformed via [`transform_bc1`] will produce an instance of this struct.

--- a/projects/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc1/src/lib.rs
@@ -246,4 +246,4 @@ pub unsafe fn untransform_bc1(
 
 /// Common test prelude for avoiding duplicate imports in test modules
 #[cfg(test)]
-pub mod test_prelude;
+pub(crate) mod test_prelude;

--- a/projects/dxt-lossless-transform-bc1/src/test_prelude.rs
+++ b/projects/dxt-lossless-transform-bc1/src/test_prelude.rs
@@ -11,6 +11,7 @@ pub use rstest::rstest;
 pub use crate::{transform_bc1, Bc1TransformDetails};
 
 // Experimental features commonly tested
+#[cfg(feature = "experimental")]
 pub use crate::experimental::normalize_blocks::*;
 
 // Common types from dxt_lossless_transform_common

--- a/projects/dxt-lossless-transform-bc1/src/test_prelude.rs
+++ b/projects/dxt-lossless-transform-bc1/src/test_prelude.rs
@@ -2,6 +2,7 @@
 //!
 //! This module provides a common prelude for test modules to avoid
 //! duplicate imports across the codebase.
+#![allow(unused_imports)]
 
 // External crates commonly used in tests
 pub use rstest::rstest;
@@ -15,7 +16,6 @@ pub use crate::experimental::normalize_blocks::*;
 // Common types from dxt_lossless_transform_common
 pub use dxt_lossless_transform_common::color_565::YCoCgVariant;
 pub use dxt_lossless_transform_common::color_8888::Color8888;
-#[allow(unused_imports)] // Might be unused in some CPU architectures, and that's ok.
 pub use dxt_lossless_transform_common::cpu_detect::*;
 pub use dxt_lossless_transform_common::decoded_4x4_block::Decoded4x4Block;
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/mod.rs
@@ -1,7 +1,7 @@
 //! This module contains accelerated routines/intrinsics for performing combined detransformation steps
 //! from the various formats that transformed data may be in.
 
-pub mod standard;
-pub mod with_recorrelate;
-pub mod with_split_colour;
-pub mod with_split_colour_and_recorr;
+pub(crate) mod standard;
+pub(crate) mod with_recorrelate;
+pub(crate) mod with_split_colour;
+pub(crate) mod with_split_colour_and_recorr;

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/mod.rs
@@ -37,8 +37,8 @@
 //! In addition, decompression speed increases (as much as 50%!), as LZ matches are more likely
 //! to be in the lower levels (L1, L2) of CPU cache. The match length is often longer, too.
 
-pub mod transform;
-pub mod untransform;
+pub(crate) mod transform;
+pub(crate) mod untransform;
 
 /// Transform BC1 data from standard interleaved format to separated color/index format
 /// using the best known implementation for the current CPU.
@@ -50,7 +50,7 @@ pub mod untransform;
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     transform::transform(input_ptr, output_ptr, len);
 }
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/avx2.rs
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
@@ -90,7 +90,7 @@ pub unsafe fn permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: us
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn permute_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permute_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
@@ -177,7 +177,7 @@ pub unsafe fn permute_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn gather(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn gather(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 128-byte blocks as possible
     let aligned_len = len - (len % 128);
@@ -251,7 +251,7 @@ pub unsafe fn gather(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usi
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn shuffle_permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shuffle_permute(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/avx512.rs
@@ -18,7 +18,7 @@ const PERM_INDICES_BYTES: [i8; 16] = [1, 3, 5, 7, 9, 11, 13, 15, 17, 19, 21, 23,
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "avx512f")]
-pub unsafe fn permute_512_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permute_512_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let colors_ptr = output_ptr as *mut u32;
@@ -38,7 +38,7 @@ pub unsafe fn permute_512_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, le
 /// - The color and index buffers must not overlap with each other or the input buffer
 #[allow(unused_assignments)] // no feature for 512
 #[target_feature(enable = "avx512f")]
-pub unsafe fn permute_512_unroll_2_with_separate_pointers(
+pub(crate) unsafe fn permute_512_unroll_2_with_separate_pointers(
     mut input_ptr: *const u8,
     mut colors_ptr: *mut u32,
     mut indices_ptr: *mut u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/mod.rs
@@ -2,47 +2,39 @@
 #![cfg(not(tarpaulin_include))]
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod sse2;
+pub(crate) mod sse2;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use sse2::*;
-
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx2;
-
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx2::*;
+pub(crate) mod avx2;
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx512;
+pub(crate) mod avx512;
 
-#[cfg(feature = "nightly")]
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx512::*;
-
-pub mod portable32;
-pub use portable32::*;
-pub mod portable64;
-pub use portable64::*;
+pub(crate) mod portable32;
+pub(crate) mod portable64;
 
 // Wrapper functions for benchmarks
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     super::sse2::shufps_unroll_4(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn shuffle_permute_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shuffle_permute_unroll_2(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     super::avx2::shuffle_permute_unroll_2(input_ptr, output_ptr, len)
 }
 
-pub unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     super::portable32::u32(input_ptr, output_ptr, len)
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn permute_512(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permute_512(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     super::avx512::permute_512(input_ptr, output_ptr, len)
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/portable32.rs
@@ -5,7 +5,7 @@ use core::ptr::{read_unaligned, write_unaligned};
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_aligned_ptr = input_ptr.add(len / 16 * 16) as *mut u8; // Aligned to 16 bytes
@@ -58,7 +58,7 @@ pub unsafe fn u32_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_aligned_ptr = input_ptr.add(len / 32 * 32) as *mut u8; // Aligned to 32 bytes
@@ -122,7 +122,7 @@ pub unsafe fn u32_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn u32_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_aligned_ptr = input_ptr.add(len / 64 * 64) as *mut u8; // Aligned to 64 bytes

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/portable64.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/portable64.rs
@@ -32,7 +32,7 @@ fn get_index(value: u64) -> u32 {
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
 #[inline(always)]
-pub unsafe fn portable(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn portable(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     // This implementation is a good general purpose one for all vector sizes
@@ -44,7 +44,7 @@ pub unsafe fn portable(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_ptr = input_ptr.add(len) as *mut u64;
@@ -75,7 +75,7 @@ pub unsafe fn shift(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_aligned_ptr = input_ptr.add(len / 16 * 16) as *mut u64;
@@ -132,7 +132,7 @@ pub unsafe fn shift_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_aligned_ptr = input_ptr.add(len / 32 * 32) as *mut u64;
@@ -199,7 +199,7 @@ pub unsafe fn shift_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let max_aligned_ptr = input_ptr.add(len / 64 * 64) as *mut u64;
@@ -287,7 +287,7 @@ pub unsafe fn shift_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_with_count(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_with_count(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     let mut num_elements = len / 8;
@@ -320,7 +320,7 @@ pub unsafe fn shift_with_count(input_ptr: *const u8, output_ptr: *mut u8, len: u
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_with_count_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_with_count_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     // Process full 16-byte chunks
@@ -382,7 +382,7 @@ pub unsafe fn shift_with_count_unroll_2(input_ptr: *const u8, output_ptr: *mut u
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_with_count_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_with_count_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     // Process full 32-byte chunks
@@ -456,7 +456,7 @@ pub unsafe fn shift_with_count_unroll_4(input_ptr: *const u8, output_ptr: *mut u
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn shift_with_count_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shift_with_count_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     // Process full 64-byte chunks

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/bench/sse2.rs
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn punpckhqdq_unroll_4(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn punpckhqdq_unroll_4(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
@@ -89,7 +89,7 @@ pub unsafe fn punpckhqdq_unroll_4(mut input_ptr: *const u8, mut output_ptr: *mut
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn punpckhqdq_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn punpckhqdq_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);
@@ -159,7 +159,7 @@ pub unsafe fn punpckhqdq_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn shufps_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shufps_unroll_2(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/mod.rs
@@ -1,14 +1,14 @@
-pub mod portable32;
+mod portable32;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod sse2;
+mod sse2;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx2;
+mod avx2;
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx512;
+mod avx512;
 
 #[cfg(feature = "bench")]
 pub mod bench;

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/mod.rs
@@ -23,7 +23,7 @@ pub mod bench;
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -53,7 +53,7 @@ pub unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 /// - The color and index buffers must not overlap with each other or the input buffer
 #[inline]
-pub unsafe fn transform_with_separate_pointers(
+pub(crate) unsafe fn transform_with_separate_pointers(
     input_ptr: *const u8,
     colors_ptr: *mut u32,
     indices_ptr: *mut u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/transform/sse2.rs
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     let colors_ptr = output_ptr;
     let indices_ptr = output_ptr.add(len / 2);
     shufps_unroll_4_with_separate_pointers(
@@ -25,7 +25,7 @@ pub unsafe fn shufps_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: us
 /// - indices_ptr must be valid for writes of len/2 bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn shufps_unroll_4_with_separate_pointers(
+pub(crate) unsafe fn shufps_unroll_4_with_separate_pointers(
     mut input_ptr: *const u8,
     mut colors_out: *mut u32,
     mut indices_out: *mut u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx2.rs
@@ -294,10 +294,14 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(unpck_detransform, "avx_unpack")]
-    #[case(permd_detransform, "avx_permd")]
-    #[case(unpck_detransform_unroll_2, "avx_unpack_unroll_2")]
-    fn test_avx2_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
-        run_standard_untransform_unaligned_test(detransform_fn, 512, impl_name);
+    #[case(unpck_detransform, "avx_unpack", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
+    #[case(permd_detransform, "avx_permd", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
+    #[case(unpck_detransform_unroll_2, "avx_unpack_unroll_2", 32)] // processes 128 bytes per iteration, so max_blocks = 128 × 2 ÷ 8 = 32
+    fn test_avx2_unaligned(
+        #[case] detransform_fn: StandardTransformFn,
+        #[case] impl_name: &str,
+        #[case] max_blocks: usize,
+    ) {
+        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx2.rs
@@ -7,7 +7,11 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permd_detransform(
+    mut input_ptr: *const u8,
+    mut output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
@@ -137,7 +141,11 @@ pub unsafe fn permd_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn unpck_detransform(
+    mut input_ptr: *const u8,
+    mut output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 8 == 0);
     // Process as many 64-byte blocks as possible
     let aligned_len = len - (len % 64);
@@ -202,7 +210,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub unsafe fn unpck_detransform_unroll_2(
+pub(crate) unsafe fn unpck_detransform_unroll_2(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx512.rs
@@ -108,13 +108,18 @@ mod tests {
     #[rstest]
     #[case(
         permute_512_detransform_unroll_2_intrinsics,
-        "avx512_permute_unroll_2_intrinsics"
+        "avx512_permute_unroll_2_intrinsics",
+        64 // processes 256 bytes per iteration, so max_blocks = 256 × 2 ÷ 8 = 64
     )]
-    fn test_avx512_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    fn test_avx512_unaligned(
+        #[case] detransform_fn: StandardTransformFn,
+        #[case] impl_name: &str,
+        #[case] max_blocks: usize,
+    ) {
         if !has_avx512f() {
             return;
         }
 
-        run_standard_untransform_unaligned_test(detransform_fn, 512, impl_name);
+        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/avx512.rs
@@ -13,7 +13,7 @@ use core::arch::x86::*;
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
-pub unsafe fn permute_512_detransform_unroll_2_intrinsics(
+pub(crate) unsafe fn permute_512_detransform_unroll_2_intrinsics(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -39,7 +39,7 @@ pub unsafe fn permute_512_detransform_unroll_2_intrinsics(
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
-pub unsafe fn permute_512_detransform_unroll_2_with_components_intrinsics(
+pub(crate) unsafe fn permute_512_detransform_unroll_2_with_components_intrinsics(
     mut output_ptr: *mut u8,
     len: usize,
     mut indices_ptr: *const u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/mod.rs
@@ -2,7 +2,6 @@
 #![cfg(not(tarpaulin_include))]
 
 pub mod portable32;
-pub use portable32::*;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse2;
@@ -14,28 +13,32 @@ pub mod avx2;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod avx512;
 
-#[cfg(feature = "nightly")]
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub use avx512::*;
-
 // Wrapper functions for benchmarks
-pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     super::portable32::u32_detransform(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn unpck_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn unpck_detransform_unroll_2(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     super::sse2::unpck_detransform_unroll_2(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn permd_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn permd_detransform_unroll_2(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     super::avx2::permd_detransform_unroll_2(input_ptr, output_ptr, len)
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn permute_512_detransform_unroll_2(
+pub(crate) unsafe fn permute_512_detransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/portable32.rs
@@ -217,13 +217,14 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform_unroll_2, "unroll_2")]
-    #[case(u32_detransform_unroll_4, "unroll_4")]
-    #[case(u32_detransform_unroll_8, "unroll_8")]
+    #[case(u32_detransform_unroll_2, "unroll_2", 4)] // processes 16 bytes per iteration, so max_blocks = 16 × 2 ÷ 8 = 4
+    #[case(u32_detransform_unroll_4, "unroll_4", 8)] // processes 32 bytes per iteration, so max_blocks = 32 × 2 ÷ 8 = 8
+    #[case(u32_detransform_unroll_8, "unroll_8", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
     fn test_portable32_unaligned(
         #[case] detransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
+        #[case] max_blocks: usize,
     ) {
-        run_standard_untransform_unaligned_test(detransform_fn, 512, impl_name);
+        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/portable32.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/portable32.rs
@@ -5,7 +5,11 @@ use core::ptr::{read_unaligned, write_unaligned};
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn u32_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform_unroll_2(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 8 == 0);
 
     let mut colours_ptr = input_ptr as *const u32;
@@ -58,7 +62,11 @@ pub unsafe fn u32_detransform_unroll_2(input_ptr: *const u8, output_ptr: *mut u8
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn u32_detransform_unroll_4(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform_unroll_4(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 8 == 0);
 
     let mut colours_ptr = input_ptr as *const u32;
@@ -121,7 +129,11 @@ pub unsafe fn u32_detransform_unroll_4(input_ptr: *const u8, output_ptr: *mut u8
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub unsafe fn u32_detransform_unroll_8(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_detransform_unroll_8(
+    input_ptr: *const u8,
+    output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 8 == 0);
 
     let mut colours_ptr = input_ptr as *const u32;

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/sse2.rs
@@ -174,12 +174,16 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(unpck_detransform, "unpck")]
+    #[case(unpck_detransform, "unpck", 8)] // processes 32 bytes per iteration, so max_blocks = 32 × 2 ÷ 8 = 8
     #[cfg_attr(
         target_arch = "x86_64",
-        case(unpck_detransform_unroll_4, "unpck_unroll_4")
+        case(unpck_detransform_unroll_4, "unpck_unroll_4", 32) // processes 128 bytes per iteration, so max_blocks = 128 × 2 ÷ 8 = 32
     )]
-    fn test_sse2_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
-        run_standard_untransform_unaligned_test(detransform_fn, 512, impl_name);
+    fn test_sse2_unaligned(
+        #[case] detransform_fn: StandardTransformFn,
+        #[case] impl_name: &str,
+        #[case] max_blocks: usize,
+    ) {
+        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/bench/sse2.rs
@@ -7,7 +7,11 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn unpck_detransform(
+    mut input_ptr: *const u8,
+    mut output_ptr: *mut u8,
+    len: usize,
+) {
     debug_assert!(len % 8 == 0);
     // Process as many 32-byte blocks as possible
     let aligned_len = len - (len % 32);
@@ -70,7 +74,7 @@ pub unsafe fn unpck_detransform(mut input_ptr: *const u8, mut output_ptr: *mut u
 #[cfg(target_arch = "x86_64")]
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub unsafe fn unpck_detransform_unroll_4(
+pub(crate) unsafe fn unpck_detransform_unroll_4(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/mod.rs
@@ -1,21 +1,21 @@
-pub mod portable32;
+mod portable32;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod sse2;
+mod sse2;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx2;
+mod avx2;
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx512;
+mod avx512;
 
 #[cfg(feature = "bench")]
 pub mod bench;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
-unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+unsafe fn untransform_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     #[cfg(not(feature = "no-runtime-cpu-detection"))]
     {
         #[cfg(feature = "nightly")]
@@ -73,7 +73,7 @@ pub unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize)
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     {
-        unsplit_blocks_x86(input_ptr, output_ptr, len)
+        untransform_x86(input_ptr, output_ptr, len)
     }
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
@@ -84,7 +84,7 @@ pub unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize)
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
-unsafe fn unsplit_block_with_separate_pointers_x86(
+unsafe fn untransform_with_separate_pointers_x86(
     colors_ptr: *const u32,
     indices_ptr: *const u32,
     output_ptr: *mut u8,
@@ -174,7 +174,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
 /// - len must be divisible by 8
 /// - It is recommended that colors_ptr and indices_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn unsplit_block_with_separate_pointers(
+pub unsafe fn untransform_with_separate_pointers(
     colors_ptr: *const u32,
     indices_ptr: *const u32,
     output_ptr: *mut u8,
@@ -184,7 +184,7 @@ pub unsafe fn unsplit_block_with_separate_pointers(
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
     {
-        unsplit_block_with_separate_pointers_x86(colors_ptr, indices_ptr, output_ptr, len)
+        untransform_with_separate_pointers_x86(colors_ptr, indices_ptr, output_ptr, len)
     }
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]

--- a/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/standard/untransform/mod.rs
@@ -68,7 +68,7 @@ unsafe fn untransform_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize)
 /// - len must be divisible by 8
 /// - It is recommended that input_ptr and output_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
@@ -174,7 +174,7 @@ unsafe fn untransform_with_separate_pointers_x86(
 /// - len must be divisible by 8
 /// - It is recommended that colors_ptr and indices_ptr are at least 16-byte aligned (recommended 32-byte align)
 #[inline]
-pub unsafe fn untransform_with_separate_pointers(
+pub(crate) unsafe fn untransform_with_separate_pointers(
     colors_ptr: *const u32,
     indices_ptr: *const u32,
     output_ptr: *mut u8,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/transform/mod.rs
@@ -1,13 +1,13 @@
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx2;
+mod avx2;
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx512;
-pub mod generic;
+mod avx512;
+mod generic;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod sse2;
+mod sse2;
 
 /// Split BC1 blocks from standard interleaved format to separate color/index format,
 /// applying YCoCg-R decorrelation to color endpoints.

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_recorrelate/untransform/mod.rs
@@ -1,16 +1,16 @@
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
-pub mod generic;
+mod generic;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod sse2;
+mod sse2;
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx2;
+mod avx2;
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub mod avx512;
+mod avx512;
 
 #[inline(always)]
 pub(crate) unsafe fn untransform_with_recorrelate(

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/mod.rs
@@ -36,8 +36,8 @@
 //!   2      | 2    | color1 (RGB565, little-endian)  
 //!   4      | 4    | indices (2 bits per pixel, little-endian)
 
-pub mod transform;
-pub mod untransform;
+pub(crate) mod transform;
+pub(crate) mod untransform;
 
 /// Transform BC1 data from standard interleaved format to three separate arrays
 /// (color0, color1, indices) using best known implementation for current CPU.

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/transform/mod.rs
@@ -3,14 +3,14 @@
 //! For the inverse of `untransform_with_split_colour`, see the corresponding untransform module.
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub mod avx2;
+mod avx2;
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub mod avx512;
+mod avx512;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-pub mod sse2;
+mod sse2;
 
-pub mod generic;
+mod generic;
 
 /// Split standard interleaved BC1 blocks into separate color0, color1, and index buffers.
 ///

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx2.rs
@@ -6,7 +6,7 @@ use core::arch::x86::*;
 
 #[target_feature(enable = "avx2")]
 #[allow(clippy::identity_op)]
-pub unsafe fn untransform_with_split_colour(
+pub(crate) unsafe fn untransform_with_split_colour(
     mut color0_in: *const u16,
     mut color1_in: *const u16,
     mut indices_in: *const u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx512.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/avx512.rs
@@ -7,7 +7,7 @@ use core::arch::x86::*;
 #[target_feature(enable = "avx512f")]
 #[target_feature(enable = "avx512bw")]
 #[allow(clippy::identity_op)]
-pub unsafe fn untransform_with_split_colour(
+pub(crate) unsafe fn untransform_with_split_colour(
     mut color0_in: *const u16,
     mut color1_in: *const u16,
     mut indices_in: *const u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/mod.rs
@@ -1,5 +1,3 @@
-//!   ```
-
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod avx512;

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/sse2.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour/untransform/sse2.rs
@@ -6,7 +6,7 @@ use core::arch::x86::*;
 
 #[target_feature(enable = "sse2")]
 #[allow(clippy::identity_op)]
-pub unsafe fn untransform_with_split_colour(
+pub(crate) unsafe fn untransform_with_split_colour(
     mut color0_in: *const u16,
     mut color1_in: *const u16,
     mut indices_in: *const u32,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/mod.rs
@@ -38,8 +38,8 @@
 //!   4      | 4    | indices (2 bits per pixel, little-endian)
 //!   ```
 
-pub mod transform;
-pub mod untransform;
+pub(crate) mod transform;
+pub(crate) mod untransform;
 
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/mod.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/transform/mod.rs
@@ -6,6 +6,8 @@
 //!
 //! This module selects the best available implementation for the current CPU at
 //! runtime (unless `no-runtime-cpu-detection` feature is enabled).
+//!
+//! [`Color565`]: dxt_lossless_transform_common::color_565::Color565
 
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 mod generic;
@@ -29,7 +31,7 @@ mod sse2;
 /// - `color1_out` must be valid for `block_count*2` bytes of writes.
 /// - `indices_out` must be valid for `block_count*4` bytes of writes.
 #[inline]
-pub unsafe fn transform_with_split_colour_and_recorr(
+pub(crate) unsafe fn transform_with_split_colour_and_recorr(
     input_ptr: *const u8,
     color0_out: *mut u16,
     color1_out: *mut u16,

--- a/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/generic.rs
+++ b/projects/dxt-lossless-transform-bc1/src/transforms/with_split_colour_and_recorr/untransform/generic.rs
@@ -1,4 +1,4 @@
-use crate::transforms::standard::untransform::unsplit_block_with_separate_pointers;
+use crate::transforms::standard::untransform::untransform_with_separate_pointers;
 use core::hint::unreachable_unchecked;
 use dxt_lossless_transform_common::{
     allocate::allocate_align_64,
@@ -41,7 +41,7 @@ pub(crate) unsafe fn untransform_with_split_colour_and_recorr_generic(
         );
 
         // Now unsplit the colours, placing them into the final buffer
-        unsplit_block_with_separate_pointers(
+        untransform_with_separate_pointers(
             work_ptr as *const u32,
             indices_in,
             output_ptr,

--- a/projects/dxt-lossless-transform-bc2-api/README.MD
+++ b/projects/dxt-lossless-transform-bc2-api/README.MD
@@ -79,7 +79,7 @@ Untransform bc2 (`unsplit_blocks`):
 You can run the benchmarks like this (example):
 
 ```bash,ignore
-cargo bench -p dxt-lossless-transform-bc2 --bench unsplit_blocks -- "avx2 permd unroll 2"
+cargo bench -p dxt-lossless-transform-bc2 --bench untransform_standard --features bench -- "avx2 permd unroll 2"
 ```
 
 Measured on Linux with `performance` governor. 8MiB file (see: `projects/dxt-lossless-transform-bc2/benches`).

--- a/projects/dxt-lossless-transform-bc2/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc2/Cargo.toml
@@ -19,6 +19,8 @@ no-runtime-cpu-detection = []
 nightly = ["dxt-lossless-transform-common/nightly"]
 # Code only required for benchmarks.
 bench = []
+# Experimental features, not ready for prime time. Use at your own risk!
+experimental = []
 
 [dependencies]
 dxt-lossless-transform-common = { path = "../dxt-lossless-transform-common" }

--- a/projects/dxt-lossless-transform-bc2/src/experimental/mod.rs
+++ b/projects/dxt-lossless-transform-bc2/src/experimental/mod.rs
@@ -1,7 +1,5 @@
 //! Experimental features, not ready for prime time yet.
-//! Use at your own risk!
-//!
-//! Stuff in here isn't disabled by `feature`, it just wouldn't be exposed in stable API until ready.
+//! Use at your own risk! Expect API to be very unstable.
 
 pub use crate::experimental::normalize_blocks::*;
 pub mod normalize_blocks;

--- a/projects/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc2/src/lib.rs
@@ -7,6 +7,7 @@
     feature(stdarch_x86_avx512)
 )]
 
+#[cfg(feature = "experimental")]
 pub mod experimental;
 pub mod transforms;
 pub mod util;

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/bench/portable32.rs
@@ -147,9 +147,9 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_unroll_2, "u32 unroll_2")]
-    #[case(u32_unroll_4, "u32 unroll_4")]
-    fn test_portable32_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {
-        run_standard_transform_unaligned_test(permute_fn, 512, impl_name);
+    #[case(u32_unroll_2, "u32 unroll_2", 4)]
+    #[case(u32_unroll_4, "u32 unroll_4", 8)]
+    fn test_portable32_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str, #[case] max_blocks: usize) {
+        run_standard_transform_unaligned_test(permute_fn, max_blocks, impl_name);
     }
 }

--- a/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/portable32.rs
+++ b/projects/dxt-lossless-transform-bc2/src/transforms/standard/transform/portable32.rs
@@ -63,6 +63,6 @@ mod tests {
     #[rstest]
     #[case(u32, "u32 no-unroll")]
     fn test_portable32_unaligned(#[case] permute_fn: StandardTransformFn, #[case] impl_name: &str) {
-        run_standard_transform_unaligned_test(permute_fn, 512, impl_name);
+        run_standard_transform_unaligned_test(permute_fn, 2, impl_name);
     }
 }

--- a/projects/dxt-lossless-transform-bc3-api/README.MD
+++ b/projects/dxt-lossless-transform-bc3-api/README.MD
@@ -87,7 +87,7 @@ Portable 64-bit implementation did not yield performance benefits for transform/
 You can run the benchmarks like this (example):
 
 ```bash,ignore
-cargo bench -p dxt-lossless-transform-bc3 --bench unsplit_blocks -- "u64 sse2"
+cargo bench -p dxt-lossless-transform-bc3 --bench untransform_standard --features bench -- "u64 sse2"
 ```
 
 Measured on Linux with `performance` governor. 8MiB file (see: `projects/dxt-lossless-transform-bc3/benches`).

--- a/projects/dxt-lossless-transform-bc3/Cargo.toml
+++ b/projects/dxt-lossless-transform-bc3/Cargo.toml
@@ -19,6 +19,8 @@ no-runtime-cpu-detection = []
 nightly = ["dxt-lossless-transform-common/nightly"]
 # Benchmarking feature to expose internal APIs
 bench = []
+# Experimental features, not ready for prime time. Use at your own risk!
+experimental = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/projects/dxt-lossless-transform-bc3/src/experimental/mod.rs
+++ b/projects/dxt-lossless-transform-bc3/src/experimental/mod.rs
@@ -1,6 +1,4 @@
 //! Experimental features, not ready for prime time yet.
-//! Use at your own risk!
-//!
-//! Stuff in here isn't disabled by `feature`, it just wouldn't be exposed in stable API until ready.
+//! Use at your own risk! Expect API to be very unstable.
 
 pub mod normalize_blocks;

--- a/projects/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/dxt-lossless-transform-bc3/src/lib.rs
@@ -7,6 +7,7 @@
     feature(stdarch_x86_avx512)
 )]
 
+#[cfg(feature = "experimental")]
 pub mod experimental;
 pub mod transforms;
 pub mod util;

--- a/projects/dxt-lossless-transform-cli/Cargo.toml
+++ b/projects/dxt-lossless-transform-cli/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # Currently BC7
 debug-bc7 = ["debug"]
 # Debugging BC1 behaviour
-debug-bc1 = ["debug"]
+debug-bc1 = ["debug", "dxt-lossless-transform-bc1/experimental"]
 # Common debugging utilities
 debug = ["zstd-sys", "derive_more", "derive-new", "thiserror-no-std", "bytesize", "xxhash-rust", "bincode", "serde", "dirs", "derive-enum-all-values"]
 


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced an "experimental" feature flag for select crates, allowing users to enable experimental functionality at their own risk.
  - Added a "bench" feature flag to enable benchmarking APIs and commands.

- **Documentation**
  - Updated benchmarking instructions and examples in multiple README files to require the `--features bench` flag and reflect new benchmark targets.
  - Clarified and streamlined documentation for experimental modules and feature usage.
  - Improved markdown formatting in documentation headers for clarity.

- **Refactor**
  - Restricted visibility of many internal modules and functions to improve encapsulation and API stability.
  - Centralized and conditionally exposed benchmarking functions under feature flags.
  - Renamed and unified certain function and module names for consistency.

- **Chores**
  - Updated configuration files to require feature flags for experimental and benchmarking builds.
  - Suppressed unused import warnings in test modules for cleaner builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->