### PR TITLE
Changed: Disable unused code paths when default features are used.

### DIFF
--- a/projects/api/dxt-lossless-transform-bc1-api/src/c_api/transform/unstable.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/c_api/transform/unstable.rs
@@ -161,7 +161,7 @@ mod tests {
 
     #[test]
     fn test_unstable_null_pointer_handling() {
-        let data = vec![0u8; 8];
+        let data = [0u8; 8];
         let mut output = vec![0u8; 8];
         let details = Dltbc1TransformDetails {
             decorrelation_mode: YCoCgVariant::None,

--- a/projects/core/dxt-lossless-transform-bc1/src/transforms/standard/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transforms/standard/mod.rs
@@ -69,6 +69,7 @@ pub(crate) unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: u
 /// - len must be divisible by 8 (BC1 block size)
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 /// - The color and index buffers must not overlap with each other or the input buffer
+#[cfg(feature = "experimental")]
 #[inline]
 pub(crate) unsafe fn transform_with_separate_pointers(
     input_ptr: *const u8,

--- a/projects/core/dxt-lossless-transform-bc1/src/transforms/standard/transform/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transforms/standard/transform/mod.rs
@@ -52,6 +52,7 @@ pub(crate) unsafe fn transform(input_ptr: *const u8, output_ptr: *mut u8, len: u
 /// - len must be divisible by 8 (BC1 block size)
 /// - It is recommended that all pointers are at least 16-byte aligned (recommended 32-byte align)
 /// - The color and index buffers must not overlap with each other or the input buffer
+#[cfg(feature = "experimental")]
 #[inline]
 pub(crate) unsafe fn transform_with_separate_pointers(
     input_ptr: *const u8,
@@ -120,6 +121,7 @@ unsafe fn transform_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     portable32::u32(input_ptr, output_ptr, len)
 }
 
+#[cfg(feature = "experimental")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 #[inline(always)]
 unsafe fn transform_with_separate_pointers_x86(


### PR DESCRIPTION
Also fix a case of using vec instead of box in test

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->
