### PR TITLE
Changed: no_std now uses a shared prelude between no_std and std, to ensure consistency.

### DIFF
--- a/projects/api/dxt-lossless-transform-api-common/src/estimate/mod.rs
+++ b/projects/api/dxt-lossless-transform-api-common/src/estimate/mod.rs
@@ -4,6 +4,8 @@
 //! of data, which can be used for optimization algorithms that need to compare
 //! compression ratios without performing full compression.
 
+use alloc::boxed::Box;
+
 /// Enum representing the type of data being estimated for compressed size.
 ///
 /// # Remarks

--- a/projects/api/dxt-lossless-transform-api-common/src/lib.rs
+++ b/projects/api/dxt-lossless-transform-api-common/src/lib.rs
@@ -1,9 +1,13 @@
 #![doc = include_str!("../README.MD")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(missing_docs)]
 
+extern crate alloc;
 #[cfg(feature = "std")]
 extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
 
 pub mod allocate;
 pub mod estimate;

--- a/projects/api/dxt-lossless-transform-api-common/src/test_prelude.rs
+++ b/projects/api/dxt-lossless-transform-api-common/src/test_prelude.rs
@@ -1,0 +1,16 @@
+//! Common test imports and utilities for API Common tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;

--- a/projects/api/dxt-lossless-transform-bc1-api/src/c_api/transform/auto_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/c_api/transform/auto_transform_builder.rs
@@ -5,6 +5,7 @@
 
 use crate::c_api::error::{Dltbc1ErrorCode, Dltbc1Result};
 use crate::c_api::transform::manual_transform_builder::Dltbc1ManualTransformBuilder;
+use alloc::boxed::Box;
 use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
 
 /// Opaque handle for BC1 auto transform builder.
@@ -251,8 +252,7 @@ pub unsafe extern "C" fn dltbc1_AutoTransformBuilder_Transform(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
-    use std::{ffi::c_void, ptr};
+    use crate::test_prelude::*;
 
     /// Test helper: Create a dummy size estimator for testing
     fn create_dummy_estimator() -> DltSizeEstimator {

--- a/projects/api/dxt-lossless-transform-bc1-api/src/c_api/transform/manual_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/c_api/transform/manual_transform_builder.rs
@@ -12,6 +12,7 @@ use crate::{
     c_api::error::{Dltbc1ErrorCode, Dltbc1Result},
     transform::Bc1ManualTransformBuilder,
 };
+use alloc::boxed::Box;
 use core::{ptr, slice};
 use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;
 
@@ -354,8 +355,7 @@ pub unsafe extern "C" fn dltbc1_ManualTransformBuilder_Untransform(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;
-    use std::ptr;
+    use crate::test_prelude::*;
 
     /// Helper function to create sample BC1 test data (2 blocks = 16 bytes)
     fn create_test_bc1_data() -> Vec<u8> {

--- a/projects/api/dxt-lossless-transform-bc1-api/src/error.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/error.rs
@@ -1,5 +1,6 @@
 //! Error types for BC1 transform operations.
 
+use alloc::string::String;
 use dxt_lossless_transform_bc1::{
     Bc1AutoTransformError, Bc1ValidationError, DetermineBestTransformError,
 };

--- a/projects/api/dxt-lossless-transform-bc1-api/src/lib.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/lib.rs
@@ -1,6 +1,13 @@
 #![doc = include_str!("../README.MD")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(missing_docs)]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
 
 // Module declarations
 pub mod error;

--- a/projects/api/dxt-lossless-transform-bc1-api/src/test_prelude.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/test_prelude.rs
@@ -16,5 +16,6 @@ pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 pub use std::{ffi::c_void, is_x86_feature_detected, ptr};
 
 // External crates commonly used in API tests
+#[cfg(feature = "c-exports")]
 pub use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
 pub use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;

--- a/projects/api/dxt-lossless-transform-bc1-api/src/test_prelude.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/test_prelude.rs
@@ -1,0 +1,20 @@
+//! Common test imports and utilities for BC1 API tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::{ffi::c_void, is_x86_feature_detected, ptr};
+
+// External crates commonly used in API tests
+pub use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
+pub use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;

--- a/projects/core/dxt-lossless-transform-bc1/src/c_api/transform_auto.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/c_api/transform_auto.rs
@@ -192,6 +192,7 @@ pub unsafe extern "C" fn dltbc1core_transform_auto(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
     use std::{ffi::c_void, ptr};
 

--- a/projects/core/dxt-lossless-transform-bc1/src/c_api/transform_with_settings.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/c_api/transform_with_settings.rs
@@ -148,6 +148,7 @@ pub unsafe extern "C" fn dltbc1core_untransform(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use std::ptr;
 
     /// Helper function to create sample BC1 test data (2 blocks = 16 bytes)

--- a/projects/core/dxt-lossless-transform-bc1/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 // Not yet in stable today, but will be in 1.89.0
 #![allow(stable_features)]
 #![cfg_attr(
@@ -7,6 +7,12 @@
     feature(stdarch_x86_avx512)
 )]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
 
 pub(crate) mod transform;
 
@@ -21,10 +27,6 @@ pub use transform::*;
 
 // Re-export YCoCgVariant for convenience
 pub use dxt_lossless_transform_common::color_565::YCoCgVariant;
-
-/// Common test prelude for avoiding duplicate imports in test modules
-#[cfg(test)]
-pub mod test_prelude;
 
 /// C API exports
 #[cfg(feature = "c-exports")]

--- a/projects/core/dxt-lossless-transform-bc1/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/test_prelude.rs
@@ -4,6 +4,17 @@
 //! duplicate imports across the codebase.
 #![allow(unused_imports)]
 
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;
+
 // External crates commonly used in tests
 pub use rstest::rstest;
 

--- a/projects/core/dxt-lossless-transform-bc2/src/experimental/normalize_blocks/normalize.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/experimental/normalize_blocks/normalize.rs
@@ -479,7 +479,7 @@ pub unsafe fn normalize_split_blocks_in_place(
 #[allow(clippy::needless_range_loop)]
 mod tests {
     use super::*;
-    use rstest::rstest;
+    use crate::test_prelude::*;
 
     /// Test normalizing a solid color block with uniform alpha
     #[rstest]

--- a/projects/core/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 // Not yet in stable today, but will be in 1.89.0
 #![allow(stable_features)]
 #![cfg_attr(
@@ -7,6 +7,9 @@
     feature(stdarch_x86_avx512)
 )]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "experimental")]
 pub mod experimental;

--- a/projects/core/dxt-lossless-transform-bc2/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/test_prelude.rs
@@ -2,6 +2,18 @@
 //!
 //! This module provides a common prelude for test modules to avoid
 //! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;
 
 // External crates commonly used in tests
 pub use rstest::rstest;

--- a/projects/core/dxt-lossless-transform-bc3/src/experimental/normalize_blocks/normalize.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/experimental/normalize_blocks/normalize.rs
@@ -696,8 +696,8 @@ pub unsafe fn normalize_split_blocks_in_place(
 #[allow(clippy::needless_range_loop)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use core::ptr::null_mut;
-    use rstest::rstest;
 
     /// Test normalizing a solid color block with uniform alpha
     #[rstest]

--- a/projects/core/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 // Not yet in stable today, but will be in 1.89.0
 #![allow(stable_features)]
 #![cfg_attr(
@@ -7,6 +7,9 @@
     feature(stdarch_x86_avx512)
 )]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 #[cfg(feature = "experimental")]
 pub mod experimental;

--- a/projects/core/dxt-lossless-transform-bc3/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/test_prelude.rs
@@ -2,6 +2,18 @@
 //!
 //! This module provides a common prelude for test modules to avoid
 //! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;
 
 // External crates commonly used in tests
 pub use rstest::rstest;

--- a/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/avx512.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/avx512.rs
@@ -4,6 +4,7 @@
 use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
+use std::is_x86_feature_detected;
 
 use crate::transforms::standard::untransform::portable::u32_detransform_with_separate_pointers;
 

--- a/projects/core/dxt-lossless-transform-bc7/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-bc7/src/lib.rs
@@ -1,6 +1,9 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 /// Used by BC7, since that has unusual non-standard bit order.
 #[allow(dead_code)]

--- a/projects/core/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx2.rs
+++ b/projects/core/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx2.rs
@@ -188,6 +188,7 @@ mod tests {
     use super::*;
     use crate::color_565::Color565;
     use rstest::rstest;
+    use std::is_x86_feature_detected;
 
     /// Test data for all decorrelation variants
     fn get_test_colors() -> [Color565; 16] {

--- a/projects/core/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx512.rs
+++ b/projects/core/dxt-lossless-transform-common/src/intrinsics/color_565/decorrelate/avx512.rs
@@ -269,6 +269,7 @@ mod tests {
     use super::*;
     use crate::color_565::Color565;
     use rstest::rstest;
+    use std::is_x86_feature_detected;
 
     /// Test data for all decorrelation variants
     fn get_test_colors() -> [Color565; 32] {

--- a/projects/core/dxt-lossless-transform-common/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-common/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 // Not yet in stable today, but will be in 1.89.0
 #![allow(stable_features)]
 #![cfg_attr(
@@ -8,6 +8,12 @@
 )]
 #![cfg_attr(feature = "nightly", feature(allocator_api))]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
 
 pub mod color_565;
 pub mod color_8888;

--- a/projects/core/dxt-lossless-transform-common/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-common/src/test_prelude.rs
@@ -1,0 +1,19 @@
+//! Common test imports and utilities for DXT Lossless Transform Common tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;
+
+// External crates commonly used in tests
+pub use rstest::rstest;

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx512.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/avx512.rs
@@ -103,8 +103,8 @@ pub(crate) unsafe fn avx512_impl(colors: *const u8, colors_out: *mut u8, colors_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::split_565_color_endpoints::tests::*;
-    use rstest::rstest;
 
     #[rstest]
     #[case(avx512_impl, "avx512_impl")]

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/avx2.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/avx2.rs
@@ -225,11 +225,11 @@ pub(crate) unsafe fn avx2_shuf_impl_unroll_2(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::split_565_color_endpoints::tests::{
         assert_implementation_matches_reference, generate_test_data,
         transform_with_reference_implementation,
     };
-    use rstest::rstest;
 
     // Define the function pointer type
     type TransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/avx512.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/avx512.rs
@@ -114,8 +114,8 @@ pub(crate) unsafe fn avx512_impl_unroll2(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::split_565_color_endpoints::tests::*;
-    use rstest::rstest;
 
     #[rstest]
     #[case(avx512_impl_unroll2, "avx512_impl_unroll2")]

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/portable64.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/portable64.rs
@@ -695,11 +695,11 @@ fn get_fourth2bytes(value: u64) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::split_565_color_endpoints::tests::{
         assert_implementation_matches_reference, generate_test_data,
         transform_with_reference_implementation,
     };
-    use rstest::rstest;
 
     // Define the function pointer type
     type TransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/sse2.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/sse2.rs
@@ -281,11 +281,11 @@ pub(crate) unsafe fn sse2_shuf_unroll2_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::split_565_color_endpoints::tests::{
         assert_implementation_matches_reference, generate_test_data,
         transform_with_reference_implementation,
     };
-    use rstest::rstest;
 
     // Define the function pointer type
     type TransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/ssse3.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/bench/ssse3.rs
@@ -185,11 +185,11 @@ pub unsafe fn ssse3_pshufb_unroll4_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use crate::transforms::split_565_color_endpoints::tests::{
         assert_implementation_matches_reference, generate_test_data,
         transform_with_reference_implementation,
     };
-    use rstest::rstest;
 
     // Define the function pointer type
     type TransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/tests.rs
+++ b/projects/core/dxt-lossless-transform-common/src/transforms/split_565_color_endpoints/tests.rs
@@ -4,6 +4,7 @@
 //! across different SIMD implementation test modules.
 
 use super::portable32;
+use crate::test_prelude::*;
 
 /// Function pointer type for split color endpoints implementations
 pub type TransformFn = unsafe fn(*const u8, *mut u8, usize);

--- a/projects/extensions/dxt-lossless-transform-dds/src/dds/is_dds.rs
+++ b/projects/extensions/dxt-lossless-transform-dds/src/dds/is_dds.rs
@@ -10,6 +10,7 @@ pub fn is_dds(ptr: *const u8, len: usize) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
     use core::iter::repeat_n;
 
     #[test]

--- a/projects/extensions/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -106,7 +106,7 @@ pub unsafe fn parse_dds(ptr: *const u8, len: usize) -> Option<DdsInfo> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rstest::rstest;
+    use crate::test_prelude::*;
 
     #[rstest]
     #[case(FOURCC_DXT1, DdsFormat::BC1)]

--- a/projects/extensions/dxt-lossless-transform-dds/src/lib.rs
+++ b/projects/extensions/dxt-lossless-transform-dds/src/lib.rs
@@ -1,3 +1,10 @@
 #![doc = include_str!("../README.MD")]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
+
 pub mod dds;

--- a/projects/extensions/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -1,0 +1,19 @@
+//! Common test imports and utilities for DDS extension tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;
+
+// External crates commonly used in tests
+pub use rstest::rstest;

--- a/projects/extensions/dxt-lossless-transform-ltu/src/c_api.rs
+++ b/projects/extensions/dxt-lossless-transform-ltu/src/c_api.rs
@@ -43,6 +43,7 @@
 //! [`dltbc1_EstimateOptionsBuilder_BuildAndDetermineOptimal`]: https://docs.rs/dxt-lossless-transform-bc1-api/latest/dxt_lossless_transform_bc1_api/c_api/determine_optimal_transform/fn.dltbc1_EstimateOptionsBuilder_BuildAndDetermineOptimal.html
 
 use crate::{EstimationSettings, LosslessTransformUtilsSizeEstimation};
+use alloc::boxed::Box;
 use core::ffi::c_void;
 
 // Note: DltSizeEstimator is defined in dxt-lossless-transform-api-common

--- a/projects/extensions/dxt-lossless-transform-ltu/src/lib.rs
+++ b/projects/extensions/dxt-lossless-transform-ltu/src/lib.rs
@@ -1,6 +1,13 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(missing_docs)]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
 
 #[cfg(feature = "c-exports")]
 pub mod c_api;

--- a/projects/extensions/dxt-lossless-transform-ltu/src/test_prelude.rs
+++ b/projects/extensions/dxt-lossless-transform-ltu/src/test_prelude.rs
@@ -1,0 +1,19 @@
+//! Common test imports and utilities for LTU extension tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::{ffi::c_void, is_x86_feature_detected, ptr};
+
+// External crates commonly used in API tests
+pub use dxt_lossless_transform_api_common::estimate::DataType;

--- a/projects/extensions/dxt-lossless-transform-zstd/src/lib.rs
+++ b/projects/extensions/dxt-lossless-transform-zstd/src/lib.rs
@@ -1,9 +1,16 @@
 #![doc = include_str!(concat!("../", core::env!("CARGO_PKG_README")))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![warn(missing_docs)]
+
+#[cfg(feature = "std")]
+extern crate std;
 
 extern crate alloc;
 
+#[cfg(test)]
+pub mod test_prelude;
+
+use alloc::string::String;
 use core::{ffi::c_void, slice};
 use dxt_lossless_transform_api_common::estimate::{DataType, SizeEstimationOperations};
 use dxt_lossless_transform_common::allocate::AllocateError;
@@ -195,6 +202,7 @@ fn zstd_setcommoncompressparams(cctx: *mut ZSTD_CCtx_s, level: Option<i32>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_prelude::*;
 
     #[test]
     fn estimate_empty_data() {

--- a/projects/extensions/dxt-lossless-transform-zstd/src/test_prelude.rs
+++ b/projects/extensions/dxt-lossless-transform-zstd/src/test_prelude.rs
@@ -1,0 +1,16 @@
+//! Common test imports and utilities for ZSTD extension tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::is_x86_feature_detected;


### PR DESCRIPTION

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared test prelude module across multiple crates to centralize and simplify test imports, improving consistency and reducing duplication in test code.

* **Chores**
  * Updated all crates to use unconditional no_std mode for better compatibility with embedded and constrained environments.
  * Added explicit imports for standard library features and the alloc crate where needed to support no_std configurations.
  * Enhanced test modules to use the new test prelude, streamlining test setup and utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->