### PR TITLE
Refactored: Every case of 'detransform' is now 'untransform' for constency

### DIFF
--- a/projects/api/dxt-lossless-transform-bc1-api/README.MD
+++ b/projects/api/dxt-lossless-transform-bc1-api/README.MD
@@ -284,32 +284,32 @@ Total data processed: 8692.896 MiB
 
 📈 NoSplit/YCoCg1:
   Decompress: avg 1.93 GiB/s, total 4389.38 ms
-  Detransform: avg 30.17 GiB/s, total 281.42 ms
+  Untransform: avg 30.17 GiB/s, total 281.42 ms
   Combined: avg 1.82 GiB/s, total 4670.80 ms
 
 📈 NoSplit/None:
   Decompress: avg 1.90 GiB/s, total 4456.52 ms
-  Detransform: avg 34.86 GiB/s, total 243.53 ms
+  Untransform: avg 34.86 GiB/s, total 243.53 ms
   Combined: avg 1.81 GiB/s, total 4700.06 ms
 
 📈 Split/None:
   Decompress: avg 1.91 GiB/s, total 4452.17 ms
-  Detransform: avg 33.37 GiB/s, total 254.37 ms
+  Untransform: avg 33.37 GiB/s, total 254.37 ms
   Combined: avg 1.80 GiB/s, total 4706.55 ms
 
 📈 API Recommended:
   Decompress: avg 1.92 GiB/s, total 4412.05 ms
-  Detransform: avg 28.04 GiB/s, total 302.70 ms
+  Untransform: avg 28.04 GiB/s, total 302.70 ms
   Combined: avg 1.80 GiB/s, total 4714.75 ms
 
 📈 Split/YCoCg1:
   Decompress: avg 1.93 GiB/s, total 4409.77 ms
-  Detransform: avg 27.64 GiB/s, total 307.18 ms
+  Untransform: avg 27.64 GiB/s, total 307.18 ms
   Combined: avg 1.80 GiB/s, total 4716.95 ms
 
 📈 Untransformed:
   Decompress: avg 1.53 GiB/s, total 5559.60 ms
-  Detransform: avg 0 B/s, total 0.00 ms
+  Untransform: avg 0 B/s, total 0.00 ms
   Combined: avg 1.53 GiB/s, total 5559.60 ms
 
 ═══════════════════════════════════════════════════════════════

--- a/projects/api/dxt-lossless-transform-bc1-api/src/c_api/mod.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/c_api/mod.rs
@@ -167,7 +167,7 @@ pub mod error;
 pub mod transform;
 
 use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;
-use dxt_lossless_transform_bc1::{Bc1DetransformSettings, Bc1TransformSettings};
+use dxt_lossless_transform_bc1::{Bc1TransformSettings, Bc1UntransformSettings};
 
 /// FFI-safe version of [`Bc1TransformSettings`] for C API.
 ///
@@ -182,13 +182,13 @@ pub struct Dltbc1TransformSettings {
     pub split_colour_endpoints: bool,
 }
 
-/// FFI-safe version of [`Bc1DetransformSettings`] for C API.
+/// FFI-safe version of [`Bc1UntransformSettings`] for C API.
 ///
-/// This struct mirrors the internal [`Bc1DetransformSettings`] but is guaranteed
+/// This struct mirrors the internal [`Bc1UntransformSettings`] but is guaranteed
 /// to have stable ABI layout for C interoperability.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
-pub struct Dltbc1DetransformSettings {
+pub struct Dltbc1UntransformSettings {
     /// The decorrelation mode that was used to decorrelate the colors.
     pub decorrelation_mode: YCoCgVariant,
     /// Whether color endpoints are split.
@@ -204,7 +204,7 @@ impl Default for Dltbc1TransformSettings {
     }
 }
 
-impl Default for Dltbc1DetransformSettings {
+impl Default for Dltbc1UntransformSettings {
     fn default() -> Self {
         Self {
             decorrelation_mode: YCoCgVariant::Variant1,
@@ -232,8 +232,8 @@ impl From<Dltbc1TransformSettings> for Bc1TransformSettings {
     }
 }
 
-impl From<Bc1DetransformSettings> for Dltbc1DetransformSettings {
-    fn from(details: Bc1DetransformSettings) -> Self {
+impl From<Bc1UntransformSettings> for Dltbc1UntransformSettings {
+    fn from(details: Bc1UntransformSettings) -> Self {
         Self {
             decorrelation_mode: YCoCgVariant::from_internal_variant(details.decorrelation_mode),
             split_colour_endpoints: details.split_colour_endpoints,
@@ -241,8 +241,8 @@ impl From<Bc1DetransformSettings> for Dltbc1DetransformSettings {
     }
 }
 
-impl From<Dltbc1DetransformSettings> for Bc1DetransformSettings {
-    fn from(details: Dltbc1DetransformSettings) -> Self {
+impl From<Dltbc1UntransformSettings> for Bc1UntransformSettings {
+    fn from(details: Dltbc1UntransformSettings) -> Self {
         Self {
             decorrelation_mode: details.decorrelation_mode.to_internal_variant(),
             split_colour_endpoints: details.split_colour_endpoints,

--- a/projects/api/dxt-lossless-transform-bc1-api/src/transform/manual_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/transform/manual_transform_builder.rs
@@ -3,7 +3,7 @@
 use super::YCoCgVariant;
 use crate::Bc1Error;
 use dxt_lossless_transform_bc1::{
-    Bc1DetransformSettings, Bc1TransformSettings, transform_bc1_with_settings_safe,
+    Bc1TransformSettings, Bc1UntransformSettings, transform_bc1_with_settings_safe,
     untransform_bc1_with_settings_safe,
 };
 
@@ -142,8 +142,8 @@ impl Bc1ManualTransformBuilder {
     /// # }
     /// ```
     pub fn untransform(&self, input: &[u8], output: &mut [u8]) -> Result<(), Bc1Error> {
-        let detransform_settings: Bc1DetransformSettings = self.settings;
-        untransform_bc1_with_settings_safe(input, output, detransform_settings)
+        let untransform_settings: Bc1UntransformSettings = self.settings;
+        untransform_bc1_with_settings_safe(input, output, untransform_settings)
             .map_err(Bc1Error::from_validation_error)
     }
 }
@@ -202,17 +202,17 @@ mod tests {
             "Transform should not fail with valid BC1 data"
         );
 
-        // Detransform with same settings
-        let detransform_result = builder.untransform(&transformed, &mut restored);
+        // Untransform with same settings
+        let untransform_result = builder.untransform(&transformed, &mut restored);
         assert!(
-            detransform_result.is_ok(),
-            "Detransform should not fail with valid transformed data"
+            untransform_result.is_ok(),
+            "Untransform should not fail with valid transformed data"
         );
 
         // Verify round-trip
         assert_eq!(
             bc1_data, restored,
-            "Round-trip transform/detransform should restore original data"
+            "Round-trip transform/untransform should restore original data"
         );
     }
 }

--- a/projects/api/dxt-lossless-transform-bc3-api/README.MD
+++ b/projects/api/dxt-lossless-transform-bc3-api/README.MD
@@ -71,7 +71,7 @@ Transform BC3 (`bc3_transform`):
 - Compiler (x86-64, Rust + LLVM, no SIMD): 11.576 GiB/s `portable32 no-unroll`
 - Compiler (i686, Rust + LLVM, no SIMD): 10.510 GiB/s `portable32 no-unroll`
 
-Detransform BC3 (`bc3_detransform`):
+Untransform BC3 (`bc3_untransform`):
 
 - SSE2 (x86-64, 64-bit only): 22.234 GiB/s `u64 sse2`
 - Compiler (x86-64, 64-bit only, Rust + LLVM, no SIMD): 19.031 GiB/s `portable64 no-unroll`

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc7.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc7.rs
@@ -7,9 +7,9 @@ use super::EmbeddableTransformDetails;
 use crate::embed::{EmbedError, TransformFormat};
 use bitfield::bitfield;
 
-/// Placeholder BC7 detransform details
+/// Placeholder BC7 untransform details
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct Bc7DetransformDetails;
+struct Bc7UntransformDetails;
 
 /// Header version for BC7 format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -49,17 +49,17 @@ bitfield! {
     reserved, set_reserved: 27, 2;
 }
 
-/// Wrapper type for BC7 detransform details that can be stored in file headers
+/// Wrapper type for BC7 untransform details that can be stored in file headers
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct EmbeddableBc7Details(Bc7DetransformDetails);
+struct EmbeddableBc7Details(Bc7UntransformDetails);
 
-impl From<Bc7DetransformDetails> for EmbeddableBc7Details {
-    fn from(details: Bc7DetransformDetails) -> Self {
+impl From<Bc7UntransformDetails> for EmbeddableBc7Details {
+    fn from(details: Bc7UntransformDetails) -> Self {
         Self(details)
     }
 }
 
-impl From<EmbeddableBc7Details> for Bc7DetransformDetails {
+impl From<EmbeddableBc7Details> for Bc7UntransformDetails {
     fn from(embeddable: EmbeddableBc7Details) -> Self {
         embeddable.0
     }
@@ -82,6 +82,6 @@ impl EmbeddableTransformDetails for EmbeddableBc7Details {
         let _version = Bc7HeaderVersion::from_u32(header.header_version())?;
 
         // BC7 is not yet implemented
-        Ok(Self(Bc7DetransformDetails))
+        Ok(Self(Bc7UntransformDetails))
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/avx2.rs
+++ b/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/avx2.rs
@@ -4,7 +4,7 @@ use safe_allocator_api::RawAlloc;
 
 fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        avx2_unpck_detransform(
+        avx2_unpck_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -14,7 +14,7 @@ fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAll
 
 fn bench_unpck_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        avx2_unpck_detransform_unroll_2(
+        avx2_unpck_untransform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -24,7 +24,7 @@ fn bench_unpck_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &m
 
 fn bench_permd_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        permd_detransform_unroll_2(
+        permd_untransform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/avx512.rs
+++ b/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/avx512.rs
@@ -4,7 +4,7 @@ use safe_allocator_api::RawAlloc;
 
 fn bench_permute_512_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        permute_512_detransform_unroll_2(
+        permute_512_untransform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/portable32.rs
+++ b/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/portable32.rs
@@ -4,7 +4,7 @@ use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform(
+        u32_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -14,7 +14,7 @@ fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut R
 
 fn bench_portable32_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform_unroll_2(
+        u32_untransform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -24,7 +24,7 @@ fn bench_portable32_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, outpu
 
 fn bench_portable32_unroll_4(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform_unroll_4(
+        u32_untransform_unroll_4(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -34,7 +34,7 @@ fn bench_portable32_unroll_4(b: &mut criterion::Bencher, input: &RawAlloc, outpu
 
 fn bench_portable32_unroll_8(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform_unroll_8(
+        u32_untransform_unroll_8(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/sse2.rs
+++ b/projects/core/dxt-lossless-transform-bc1/benches/untransform_standard/sse2.rs
@@ -4,7 +4,7 @@ use safe_allocator_api::RawAlloc;
 
 fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        unpck_detransform(
+        unpck_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -14,7 +14,7 @@ fn bench_unpck(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAll
 
 fn bench_unpck_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        unpck_detransform_unroll_2(
+        unpck_untransform_unroll_2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -25,7 +25,7 @@ fn bench_unpck_unroll_2(b: &mut criterion::Bencher, input: &RawAlloc, output: &m
 #[cfg(target_arch = "x86_64")]
 fn bench_unpck_unroll_4(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        unpck_detransform_unroll_4(
+        unpck_untransform_unroll_4(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc1/src/bench/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/bench/mod.rs
@@ -205,143 +205,143 @@ pub mod untransform {
 
         // Wrapper functions for untransform benchmark APIs
 
-        pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-            crate::transform::standard::untransform::bench::u32_detransform(
+        pub unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transform::standard::untransform::bench::u32_untransform(
                 input_ptr, output_ptr, len,
             )
         }
 
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        pub unsafe fn unpck_detransform_unroll_2(
+        pub unsafe fn unpck_untransform_unroll_2(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::unpck_detransform_unroll_2(
+            crate::transform::standard::untransform::bench::unpck_untransform_unroll_2(
                 input_ptr, output_ptr, len,
             )
         }
 
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        pub unsafe fn permd_detransform_unroll_2(
+        pub unsafe fn permd_untransform_unroll_2(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::permd_detransform_unroll_2(
+            crate::transform::standard::untransform::bench::permd_untransform_unroll_2(
                 input_ptr, output_ptr, len,
             )
         }
 
         #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-        pub unsafe fn permute_512_detransform_unroll_2(
+        pub unsafe fn permute_512_untransform_unroll_2(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::permute_512_detransform_unroll_2(
+            crate::transform::standard::untransform::bench::permute_512_untransform_unroll_2(
                 input_ptr, output_ptr, len,
             )
         }
 
         // SSE2 functions
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        pub unsafe fn unpck_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-            crate::transform::standard::untransform::bench::sse2::unpck_detransform(
+        pub unsafe fn unpck_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transform::standard::untransform::bench::sse2::unpck_untransform(
                 input_ptr, output_ptr, len,
             )
         }
 
         #[cfg(target_arch = "x86_64")]
-        pub unsafe fn unpck_detransform_unroll_4(
+        pub unsafe fn unpck_untransform_unroll_4(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::sse2::unpck_detransform_unroll_4(
+            crate::transform::standard::untransform::bench::sse2::unpck_untransform_unroll_4(
                 input_ptr, output_ptr, len,
             )
         }
 
         // AVX2 functions
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        pub unsafe fn permd_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-            crate::transform::standard::untransform::bench::avx2::permd_detransform(
+        pub unsafe fn permd_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+            crate::transform::standard::untransform::bench::avx2::permd_untransform(
                 input_ptr, output_ptr, len,
             )
         }
 
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        pub unsafe fn avx2_unpck_detransform(
+        pub unsafe fn avx2_unpck_untransform(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::avx2::unpck_detransform(
+            crate::transform::standard::untransform::bench::avx2::unpck_untransform(
                 input_ptr, output_ptr, len,
             )
         }
 
         #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-        pub unsafe fn avx2_unpck_detransform_unroll_2(
+        pub unsafe fn avx2_unpck_untransform_unroll_2(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::avx2::unpck_detransform_unroll_2(
+            crate::transform::standard::untransform::bench::avx2::unpck_untransform_unroll_2(
                 input_ptr, output_ptr, len,
             )
         }
 
         // AVX512 functions
         #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-        pub unsafe fn permute_512_detransform_unroll_2_intrinsics(
+        pub unsafe fn permute_512_untransform_unroll_2_intrinsics(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::avx512::permute_512_detransform_unroll_2_intrinsics(input_ptr, output_ptr, len)
+            crate::transform::standard::untransform::bench::avx512::permute_512_untransform_unroll_2_intrinsics(input_ptr, output_ptr, len)
         }
 
         #[cfg(all(feature = "nightly", any(target_arch = "x86_64", target_arch = "x86")))]
-        pub unsafe fn permute_512_detransform_unroll_2_with_components_intrinsics(
+        pub unsafe fn permute_512_untransform_unroll_2_with_components_intrinsics(
             output_ptr: *mut u8,
             len: usize,
             indices_ptr: *const u8,
             colors_ptr: *const u8,
         ) {
-            crate::transform::standard::untransform::bench::avx512::permute_512_detransform_unroll_2_with_components_intrinsics(
+            crate::transform::standard::untransform::bench::avx512::permute_512_untransform_unroll_2_with_components_intrinsics(
                 output_ptr, len, indices_ptr, colors_ptr
             )
         }
 
         // Portable32 functions
-        pub unsafe fn u32_detransform_unroll_2(
+        pub unsafe fn u32_untransform_unroll_2(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::portable32::u32_detransform_unroll_2(
+            crate::transform::standard::untransform::bench::portable32::u32_untransform_unroll_2(
                 input_ptr, output_ptr, len,
             )
         }
 
-        pub unsafe fn u32_detransform_unroll_4(
+        pub unsafe fn u32_untransform_unroll_4(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::portable32::u32_detransform_unroll_4(
+            crate::transform::standard::untransform::bench::portable32::u32_untransform_unroll_4(
                 input_ptr, output_ptr, len,
             )
         }
 
-        pub unsafe fn u32_detransform_unroll_8(
+        pub unsafe fn u32_untransform_unroll_8(
             input_ptr: *const u8,
             output_ptr: *mut u8,
             len: usize,
         ) {
-            crate::transform::standard::untransform::bench::portable32::u32_detransform_unroll_8(
+            crate::transform::standard::untransform::bench::portable32::u32_untransform_unroll_8(
                 input_ptr, output_ptr, len,
             )
         }

--- a/projects/core/dxt-lossless-transform-bc1/src/c_api/transform_with_settings.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/c_api/transform_with_settings.rs
@@ -10,10 +10,10 @@ use crate::{
 };
 use core::slice;
 
-/// Detransform settings for BC1 data.
+/// Untransform settings for BC1 data.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
-pub struct Dltbc1DetransformSettings {
+pub struct Dltbc1UntransformSettings {
     /// Whether colour endpoints were split during transform
     pub split_colour_endpoints: bool,
     /// Decorrelation mode used during transform
@@ -29,8 +29,8 @@ impl From<Dltbc1TransformSettings> for crate::Bc1TransformSettings {
     }
 }
 
-impl From<Dltbc1DetransformSettings> for crate::Bc1DetransformSettings {
-    fn from(settings: Dltbc1DetransformSettings) -> Self {
+impl From<Dltbc1UntransformSettings> for crate::Bc1UntransformSettings {
+    fn from(settings: Dltbc1UntransformSettings) -> Self {
         crate::Bc1TransformSettings {
             split_colour_endpoints: settings.split_colour_endpoints,
             decorrelation_mode: settings.decorrelation_mode,
@@ -99,14 +99,14 @@ pub unsafe extern "C" fn dltbc1core_transform(
     }
 }
 
-/// Untransform BC1 data using specified detransform settings.
+/// Untransform BC1 data using specified untransform settings.
 ///
 /// # Parameters
 /// - `input`: Pointer to transformed BC1 data to untransform
 /// - `input_len`: Length of input data in bytes (must be divisible by 8)
 /// - `output`: Pointer to output buffer where original BC1 data will be written
 /// - `output_len`: Length of output buffer in bytes (must be at least `input_len`)
-/// - `details`: The detransform settings to use (must match original transform settings)
+/// - `details`: The untransform settings to use (must match original transform settings)
 ///
 /// # Returns
 /// A [`Dltbc1Result`] indicating success or containing an error.
@@ -114,14 +114,14 @@ pub unsafe extern "C" fn dltbc1core_transform(
 /// # Safety
 /// - `input` must be valid for reads of `input_len` bytes
 /// - `output` must be valid for writes of `output_len` bytes
-/// - The detransform settings must match the settings used for the original transformation
+/// - The untransform settings must match the settings used for the original transformation
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn dltbc1core_untransform(
     input: *const u8,
     input_len: usize,
     output: *mut u8,
     output_len: usize,
-    details: Dltbc1DetransformSettings,
+    details: Dltbc1UntransformSettings,
 ) -> Dltbc1Result {
     // Validate pointers
     if input.is_null() {
@@ -280,7 +280,7 @@ mod tests {
             split_colour_endpoints: false,
             decorrelation_mode: YCoCgVariant::None,
         };
-        let detransform_details = Dltbc1DetransformSettings {
+        let untransform_details = Dltbc1UntransformSettings {
             split_colour_endpoints: false,
             decorrelation_mode: YCoCgVariant::None,
         };
@@ -302,7 +302,7 @@ mod tests {
                 transformed.len(),
                 restored.as_mut_ptr(),
                 restored.len(),
-                detransform_details,
+                untransform_details,
             );
 
             assert_eq!(untransform_result.error_code, Dltbc1ErrorCode::Success);
@@ -316,7 +316,7 @@ mod tests {
     #[test]
     fn test_dltbc1core_untransform_null_input() {
         let mut output = vec![0u8; 16];
-        let details = Dltbc1DetransformSettings {
+        let details = Dltbc1UntransformSettings {
             split_colour_endpoints: false,
             decorrelation_mode: YCoCgVariant::None,
         };
@@ -333,7 +333,7 @@ mod tests {
     #[test]
     fn test_dltbc1core_untransform_null_output() {
         let test_data = create_test_bc1_data();
-        let details = Dltbc1DetransformSettings {
+        let details = Dltbc1UntransformSettings {
             split_colour_endpoints: false,
             decorrelation_mode: YCoCgVariant::None,
         };
@@ -368,7 +368,7 @@ mod tests {
                     split_colour_endpoints: split_colours,
                     decorrelation_mode: decorr_mode,
                 };
-                let detransform_settings = Dltbc1DetransformSettings {
+                let untransform_settings = Dltbc1UntransformSettings {
                     split_colour_endpoints: split_colours,
                     decorrelation_mode: decorr_mode,
                 };
@@ -397,7 +397,7 @@ mod tests {
                         transformed.len(),
                         restored.as_mut_ptr(),
                         restored.len(),
-                        detransform_settings,
+                        untransform_settings,
                     );
                     assert_eq!(
                         untransform_result.error_code,
@@ -416,13 +416,13 @@ mod tests {
     }
 
     #[test]
-    fn test_dltbc1_detransform_settings_conversion() {
-        let settings = Dltbc1DetransformSettings {
+    fn test_dltbc1_untransform_settings_conversion() {
+        let settings = Dltbc1UntransformSettings {
             split_colour_endpoints: true,
             decorrelation_mode: YCoCgVariant::Variant2,
         };
 
-        let rust_settings: crate::Bc1DetransformSettings = settings.into();
+        let rust_settings: crate::Bc1UntransformSettings = settings.into();
         assert!(rust_settings.split_colour_endpoints);
         assert_eq!(rust_settings.decorrelation_mode, YCoCgVariant::Variant2);
     }

--- a/projects/core/dxt-lossless-transform-bc1/src/experimental/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/experimental/mod.rs
@@ -4,11 +4,11 @@
 pub use crate::experimental::normalize_blocks::*;
 pub mod normalize_blocks;
 
-use crate::{Bc1DetransformSettings, Bc1TransformSettings, YCoCgVariant};
+use crate::{Bc1TransformSettings, Bc1UntransformSettings, YCoCgVariant};
 
 /// The information about the BC1 transform that was just performed with experimental normalization support.
 /// Each item transformed via [`normalize_blocks::transform_bc1_with_normalize_blocks`] will produce an instance of this struct.
-/// To undo the transform, you'll need to pass [`Bc1DetransformSettings`] to [`crate::untransform_bc1_with_settings`],
+/// To undo the transform, you'll need to pass [`Bc1UntransformSettings`] to [`crate::untransform_bc1_with_settings`],
 /// which can be obtained from this struct using the `into` method.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Bc1TransformDetailsWithNormalization {
@@ -27,7 +27,7 @@ pub struct Bc1TransformDetailsWithNormalization {
     pub split_colour_endpoints: bool,
 }
 
-impl From<Bc1TransformDetailsWithNormalization> for Bc1DetransformSettings {
+impl From<Bc1TransformDetailsWithNormalization> for Bc1UntransformSettings {
     fn from(transform_details: Bc1TransformDetailsWithNormalization) -> Self {
         Self {
             decorrelation_mode: transform_details.decorrelation_mode,

--- a/projects/core/dxt-lossless-transform-bc1/src/experimental/normalize_blocks/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/experimental/normalize_blocks/mod.rs
@@ -86,14 +86,14 @@ pub mod transform;
 pub use normalize::*;
 pub use transform::*;
 
-use crate::{Bc1DetransformSettings, Bc1TransformSettings, YCoCgVariant};
+use crate::{Bc1TransformSettings, Bc1UntransformSettings, YCoCgVariant};
 
 /// The information about the BC1 transform that was just performed with experimental normalization support.
 /// Each item transformed via [`transform_bc1_with_normalize_blocks`] will produce an instance of this struct.
-/// To undo the transform, you'll need to pass [`Bc1DetransformSettings`] to [`crate::untransform_bc1_with_settings`],
+/// To undo the transform, you'll need to pass [`Bc1UntransformSettings`] to [`crate::untransform_bc1_with_settings`],
 /// which can be obtained from this struct using the `into` method.
 ///
-/// [`Bc1DetransformSettings`]: crate::Bc1DetransformSettings
+/// [`Bc1UntransformSettings`]: crate::Bc1UntransformSettings
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Bc1TransformDetailsWithNormalization {
     /// The color normalization mode that was used to normalize the data.
@@ -111,7 +111,7 @@ pub struct Bc1TransformDetailsWithNormalization {
     pub split_colour_endpoints: bool,
 }
 
-impl From<Bc1TransformDetailsWithNormalization> for Bc1DetransformSettings {
+impl From<Bc1TransformDetailsWithNormalization> for Bc1UntransformSettings {
     fn from(transform_details: Bc1TransformDetailsWithNormalization) -> Self {
         Self {
             decorrelation_mode: transform_details.decorrelation_mode,

--- a/projects/core/dxt-lossless-transform-bc1/src/experimental/normalize_blocks/transform.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/experimental/normalize_blocks/transform.rs
@@ -419,7 +419,7 @@ unsafe fn test_normalize_variant_with_normalization<T>(
 mod tests {
     use super::*;
     use crate::test_prelude::*;
-    use crate::{untransform_bc1_with_settings, Bc1DetransformSettings};
+    use crate::{untransform_bc1_with_settings, Bc1UntransformSettings};
     use dxt_lossless_transform_common::allocate::allocate_align_64;
 
     /// Test roundtrip transform→untransform for all combinations of Bc1TransformDetailsWithNormalization
@@ -450,12 +450,12 @@ mod tests {
                     );
 
                     // Untransform using standard function (normalization doesn't need to be reversed)
-                    let detransform_details: Bc1DetransformSettings = details.into();
+                    let untransform_details: Bc1UntransformSettings = details.into();
                     untransform_bc1_with_settings(
                         transformed.as_ptr(),
                         reconstructed.as_mut_ptr(),
                         len,
-                        detransform_details,
+                        untransform_details,
                     );
                 }
 

--- a/projects/core/dxt-lossless-transform-bc1/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/test_prelude.rs
@@ -391,7 +391,7 @@ pub(crate) fn run_with_recorrelate_untransform_unaligned_test(
 /// iteration of the SIMD implementation being tested (i.e., bytes processed × 2 ÷ 8).
 #[inline]
 pub(crate) fn run_standard_untransform_unaligned_test(
-    detransform_fn: StandardTransformFn,
+    untransform_fn: StandardTransformFn,
     max_blocks: usize,
     impl_name: &str,
 ) {
@@ -412,7 +412,7 @@ pub(crate) fn run_standard_untransform_unaligned_test(
             transformed_unaligned.as_mut_slice()[1..].copy_from_slice(transformed.as_slice());
 
             let mut reconstructed = allocate_align_64(original.len() + 1);
-            detransform_fn(
+            untransform_fn(
                 transformed_unaligned.as_ptr().add(1),
                 reconstructed.as_mut_ptr().add(1),
                 transformed.len(),

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/safe/transform_with_settings.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/safe/transform_with_settings.rs
@@ -8,8 +8,8 @@
 
 use crate::transform::{
     transform_bc1_with_settings as unsafe_transform_bc1_with_settings,
-    untransform_bc1_with_settings as unsafe_untransform_bc1_with_settings, Bc1DetransformSettings,
-    Bc1TransformSettings,
+    untransform_bc1_with_settings as unsafe_untransform_bc1_with_settings, Bc1TransformSettings,
+    Bc1UntransformSettings,
 };
 use thiserror::Error;
 
@@ -116,7 +116,7 @@ pub fn transform_bc1_with_settings(
     Ok(())
 }
 
-/// Untransform BC1 data using specified detransform settings.
+/// Untransform BC1 data using specified untransform settings.
 ///
 /// This function reverses the transformation applied by [`transform_bc1_with_settings`]
 /// or [`super::transform_auto::transform_bc1_auto`], restoring the original BC1 data.
@@ -125,7 +125,7 @@ pub fn transform_bc1_with_settings(
 ///
 /// - `input`: The transformed BC1 data to untransform
 /// - `output`: The output buffer to write the original BC1 data to
-/// - `settings`: The detransform settings to use (must match the original transform settings)
+/// - `settings`: The untransform settings to use (must match the original transform settings)
 ///
 /// # Errors
 ///
@@ -138,7 +138,7 @@ pub fn transform_bc1_with_settings(
 /// use dxt_lossless_transform_bc1::{
 ///     transform_bc1_with_settings_safe, untransform_bc1_with_settings_safe
 /// };
-/// use dxt_lossless_transform_bc1::{Bc1TransformSettings, Bc1DetransformSettings};
+/// use dxt_lossless_transform_bc1::{Bc1TransformSettings, Bc1UntransformSettings};
 /// use dxt_lossless_transform_common::color_565::YCoCgVariant;
 /// # use dxt_lossless_transform_bc1::Bc1ValidationError;
 ///
@@ -155,11 +155,11 @@ pub fn transform_bc1_with_settings(
 /// // Transform the data
 /// transform_bc1_with_settings_safe(&bc1_data, &mut transformed, transform_settings)?;
 ///
-/// // Convert transform settings to detransform settings
-/// let detransform_settings: Bc1DetransformSettings = transform_settings.into();
+/// // Convert transform settings to untransform settings
+/// let untransform_settings: Bc1UntransformSettings = transform_settings.into();
 ///
 /// // Untransform to restore original data
-/// untransform_bc1_with_settings_safe(&transformed, &mut restored, detransform_settings)?;
+/// untransform_bc1_with_settings_safe(&transformed, &mut restored, untransform_settings)?;
 /// # assert_eq!(bc1_data, restored); // Verify round-trip works
 /// # Ok(())
 /// # }
@@ -192,7 +192,7 @@ pub fn transform_bc1_with_settings(
 pub fn untransform_bc1_with_settings(
     input: &[u8],
     output: &mut [u8],
-    settings: Bc1DetransformSettings,
+    settings: Bc1UntransformSettings,
 ) -> Result<(), Bc1ValidationError> {
     // Validate input length
     if input.len() % 8 != 0 {
@@ -291,7 +291,7 @@ mod tests {
         ];
         let mut output = [0u8; 8];
 
-        let settings = Bc1DetransformSettings {
+        let settings = Bc1UntransformSettings {
             decorrelation_mode: YCoCgVariant::Variant1,
             split_colour_endpoints: true,
         };
@@ -308,7 +308,7 @@ mod tests {
         let bc1_data = [0u8; 7]; // Invalid length (not divisible by 8)
         let mut output = [0u8; 7];
 
-        let settings = Bc1DetransformSettings {
+        let settings = Bc1UntransformSettings {
             decorrelation_mode: YCoCgVariant::Variant1,
             split_colour_endpoints: true,
         };
@@ -322,7 +322,7 @@ mod tests {
         let bc1_data = [0u8; 8];
         let mut output = [0u8; 4]; // Too small
 
-        let settings = Bc1DetransformSettings {
+        let settings = Bc1UntransformSettings {
             decorrelation_mode: YCoCgVariant::Variant1,
             split_colour_endpoints: true,
         };

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/settings.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/settings.rs
@@ -6,9 +6,9 @@
 use dxt_lossless_transform_api_common::estimate::DataType;
 use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
-/// Settings for BC1 transform and detransform operations.
+/// Settings for BC1 transform and untransform operations.
 ///
-/// This struct contains the configuration for both transforming and detransforming BC1 data.
+/// This struct contains the configuration for both transforming and untransforming BC1 data.
 /// Each item transformed via [`crate::transform_bc1_with_settings`] will use an instance of this struct.
 /// To undo the transform, pass the same settings to [`crate::untransform_bc1_with_settings`].
 ///
@@ -29,9 +29,9 @@ pub struct Bc1TransformSettings {
 
 /// Type alias for backward compatibility.
 ///
-/// [`Bc1DetransformSettings`] is now unified with [`Bc1TransformSettings`] since they were
-/// structurally identical. Use [`Bc1TransformSettings`] for both transform and detransform operations.
-pub type Bc1DetransformSettings = Bc1TransformSettings;
+/// [`Bc1UntransformSettings`] is now unified with [`Bc1TransformSettings`] since they were
+/// structurally identical. Use [`Bc1TransformSettings`] for both transform and untransform operations.
+pub type Bc1UntransformSettings = Bc1TransformSettings;
 
 impl Default for Bc1TransformSettings {
     fn default() -> Self {

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/avx2.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/avx2.rs
@@ -1,4 +1,4 @@
-use crate::transform::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transform::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 /// # Safety
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn permd_detransform_unroll_2(
+pub(crate) unsafe fn permd_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -17,7 +17,7 @@ pub(crate) unsafe fn permd_detransform_unroll_2(
     let indices_ptr = input_ptr.add(len / 2);
     let colors_ptr = input_ptr;
 
-    permd_detransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
+    permd_untransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
 }
 
 /// # Safety
@@ -27,13 +27,13 @@ pub(crate) unsafe fn permd_detransform_unroll_2(
 /// - colors_ptr must be valid for reads of len/2 bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn permd_detransform_unroll_2_with_components(
+pub(crate) unsafe fn permd_untransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut indices_in: *const u8,
     mut colors_in: *const u8,
 ) {
-    // Explanation in permd_detransform
+    // Explanation in permd_untransform
     debug_assert!(len % 8 == 0, "len must be divisible by 8");
     let aligned_len = len - (len % 128);
     let colors_aligned_end = colors_in.add(aligned_len / 2);
@@ -93,7 +93,7 @@ pub(crate) unsafe fn permd_detransform_unroll_2_with_components(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         colors_in as *const u32,
         indices_in as *const u32,
         output_ptr,
@@ -107,9 +107,9 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(permd_detransform_unroll_2, "avx_permd_unroll_2")]
-    fn test_avx2_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    #[case(permd_untransform_unroll_2, "avx_permd_unroll_2")]
+    fn test_avx2_unaligned(#[case] untransform_fn: StandardTransformFn, #[case] impl_name: &str) {
         // 128 bytes processed per main loop iteration (* 2 / 8 == 32)
-        run_standard_untransform_unaligned_test(detransform_fn, 32, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 32, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/avx512.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/avx512.rs
@@ -1,4 +1,4 @@
-use crate::transform::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transform::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 #[cfg(target_arch = "x86_64")]
@@ -14,7 +14,7 @@ use core::arch::x86::*;
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
-pub(crate) unsafe fn permute_512_detransform_unroll_2(
+pub(crate) unsafe fn permute_512_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -24,7 +24,7 @@ pub(crate) unsafe fn permute_512_detransform_unroll_2(
     let indices_ptr = input_ptr.add(len / 2);
     let colors_ptr = input_ptr;
 
-    permute_512_detransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
+    permute_512_untransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
 }
 
 /// # Safety
@@ -35,7 +35,7 @@ pub(crate) unsafe fn permute_512_detransform_unroll_2(
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
-pub(crate) unsafe fn permute_512_detransform_unroll_2_with_components(
+pub(crate) unsafe fn permute_512_untransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut indices_in: *const u8,
@@ -109,7 +109,7 @@ pub(crate) unsafe fn permute_512_detransform_unroll_2_with_components(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         colors_in as *const u32,
         indices_in as *const u32,
         output_ptr,
@@ -123,13 +123,13 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(permute_512_detransform_unroll_2, "avx512_permute_unroll_2")]
-    fn test_avx512_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    #[case(permute_512_untransform_unroll_2, "avx512_permute_unroll_2")]
+    fn test_avx512_unaligned(#[case] untransform_fn: StandardTransformFn, #[case] impl_name: &str) {
         if !has_avx512f() {
             return;
         }
 
         // 256 bytes processed per main loop iteration (* 2 / 8 == 64)
-        run_standard_untransform_unaligned_test(detransform_fn, 64, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 64, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/avx2.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/avx2.rs
@@ -1,4 +1,4 @@
-use crate::transform::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transform::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 /// # Safety
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn permd_detransform(
+pub(crate) unsafe fn permd_untransform(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,
@@ -126,7 +126,7 @@ pub(crate) unsafe fn permd_detransform(
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
     if remaining > 0 {
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             input_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
@@ -141,7 +141,7 @@ pub(crate) unsafe fn permd_detransform(
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn unpck_detransform(
+pub(crate) unsafe fn unpck_untransform(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,
@@ -195,7 +195,7 @@ pub(crate) unsafe fn unpck_detransform(
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
     if remaining > 0 {
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             input_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
@@ -210,7 +210,7 @@ pub(crate) unsafe fn unpck_detransform(
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "avx2")]
-pub(crate) unsafe fn unpck_detransform_unroll_2(
+pub(crate) unsafe fn unpck_untransform_unroll_2(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,
@@ -279,7 +279,7 @@ pub(crate) unsafe fn unpck_detransform_unroll_2(
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
     if remaining > 0 {
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             input_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
@@ -294,14 +294,14 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(unpck_detransform, "avx_unpack", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
-    #[case(permd_detransform, "avx_permd", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
-    #[case(unpck_detransform_unroll_2, "avx_unpack_unroll_2", 32)] // processes 128 bytes per iteration, so max_blocks = 128 × 2 ÷ 8 = 32
+    #[case(unpck_untransform, "avx_unpack", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
+    #[case(permd_untransform, "avx_permd", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
+    #[case(unpck_untransform_unroll_2, "avx_unpack_unroll_2", 32)] // processes 128 bytes per iteration, so max_blocks = 128 × 2 ÷ 8 = 32
     fn test_avx2_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/avx512.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/avx512.rs
@@ -1,4 +1,4 @@
-use crate::transform::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transform::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
@@ -13,7 +13,7 @@ use core::arch::x86::*;
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
-pub(crate) unsafe fn permute_512_detransform_unroll_2_intrinsics(
+pub(crate) unsafe fn permute_512_untransform_unroll_2_intrinsics(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -23,7 +23,7 @@ pub(crate) unsafe fn permute_512_detransform_unroll_2_intrinsics(
     let indices_ptr = input_ptr.add(len / 2);
     let colors_ptr = input_ptr;
 
-    permute_512_detransform_unroll_2_with_components_intrinsics(
+    permute_512_untransform_unroll_2_with_components_intrinsics(
         output_ptr,
         len,
         indices_ptr,
@@ -39,7 +39,7 @@ pub(crate) unsafe fn permute_512_detransform_unroll_2_intrinsics(
 #[allow(unused_assignments)]
 #[cfg(feature = "nightly")]
 #[target_feature(enable = "avx512f")]
-pub(crate) unsafe fn permute_512_detransform_unroll_2_with_components_intrinsics(
+pub(crate) unsafe fn permute_512_untransform_unroll_2_with_components_intrinsics(
     mut output_ptr: *mut u8,
     len: usize,
     mut indices_ptr: *const u8,
@@ -91,7 +91,7 @@ pub(crate) unsafe fn permute_512_detransform_unroll_2_with_components_intrinsics
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
     if remaining > 0 {
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             colors_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
@@ -107,12 +107,12 @@ mod tests {
 
     #[rstest]
     #[case(
-        permute_512_detransform_unroll_2_intrinsics,
+        permute_512_untransform_unroll_2_intrinsics,
         "avx512_permute_unroll_2_intrinsics",
         64 // processes 256 bytes per iteration, so max_blocks = 256 × 2 ÷ 8 = 64
     )]
     fn test_avx512_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
@@ -120,6 +120,6 @@ mod tests {
             return;
         }
 
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/mod.rs
@@ -14,34 +14,34 @@ pub mod avx2;
 pub mod avx512;
 
 // Wrapper functions for benchmarks
-pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    super::portable32::u32_detransform(input_ptr, output_ptr, len)
+pub(crate) unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::portable32::u32_untransform(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub(crate) unsafe fn unpck_detransform_unroll_2(
+pub(crate) unsafe fn unpck_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
 ) {
-    super::sse2::unpck_detransform_unroll_2(input_ptr, output_ptr, len)
+    super::sse2::unpck_untransform_unroll_2(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub(crate) unsafe fn permd_detransform_unroll_2(
+pub(crate) unsafe fn permd_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
 ) {
-    super::avx2::permd_detransform_unroll_2(input_ptr, output_ptr, len)
+    super::avx2::permd_untransform_unroll_2(input_ptr, output_ptr, len)
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub(crate) unsafe fn permute_512_detransform_unroll_2(
+pub(crate) unsafe fn permute_512_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
 ) {
-    super::avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len)
+    super::avx512::permute_512_untransform_unroll_2(input_ptr, output_ptr, len)
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/portable32.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/portable32.rs
@@ -5,7 +5,7 @@ use core::ptr::{read_unaligned, write_unaligned};
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub(crate) unsafe fn u32_detransform_unroll_2(
+pub(crate) unsafe fn u32_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -62,7 +62,7 @@ pub(crate) unsafe fn u32_detransform_unroll_2(
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub(crate) unsafe fn u32_detransform_unroll_4(
+pub(crate) unsafe fn u32_untransform_unroll_4(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -129,7 +129,7 @@ pub(crate) unsafe fn u32_detransform_unroll_4(
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub(crate) unsafe fn u32_detransform_unroll_8(
+pub(crate) unsafe fn u32_untransform_unroll_8(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -217,14 +217,14 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform_unroll_2, "unroll_2", 4)] // processes 16 bytes per iteration, so max_blocks = 16 × 2 ÷ 8 = 4
-    #[case(u32_detransform_unroll_4, "unroll_4", 8)] // processes 32 bytes per iteration, so max_blocks = 32 × 2 ÷ 8 = 8
-    #[case(u32_detransform_unroll_8, "unroll_8", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
+    #[case(u32_untransform_unroll_2, "unroll_2", 4)] // processes 16 bytes per iteration, so max_blocks = 16 × 2 ÷ 8 = 4
+    #[case(u32_untransform_unroll_4, "unroll_4", 8)] // processes 32 bytes per iteration, so max_blocks = 32 × 2 ÷ 8 = 8
+    #[case(u32_untransform_unroll_8, "unroll_8", 16)] // processes 64 bytes per iteration, so max_blocks = 64 × 2 ÷ 8 = 16
     fn test_portable32_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/sse2.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/bench/sse2.rs
@@ -1,4 +1,4 @@
-use crate::transform::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transform::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 /// # Safety
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub(crate) unsafe fn unpck_detransform(
+pub(crate) unsafe fn unpck_untransform(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,
@@ -58,7 +58,7 @@ pub(crate) unsafe fn unpck_detransform(
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
     if remaining > 0 {
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             input_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
@@ -74,7 +74,7 @@ pub(crate) unsafe fn unpck_detransform(
 #[cfg(target_arch = "x86_64")]
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub(crate) unsafe fn unpck_detransform_unroll_4(
+pub(crate) unsafe fn unpck_untransform_unroll_4(
     mut input_ptr: *const u8,
     mut output_ptr: *mut u8,
     len: usize,
@@ -159,7 +159,7 @@ pub(crate) unsafe fn unpck_detransform_unroll_4(
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
     if remaining > 0 {
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             input_ptr as *const u32,
             indices_ptr as *const u32,
             output_ptr,
@@ -174,16 +174,16 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(unpck_detransform, "unpck", 8)] // processes 32 bytes per iteration, so max_blocks = 32 × 2 ÷ 8 = 8
+    #[case(unpck_untransform, "unpck", 8)] // processes 32 bytes per iteration, so max_blocks = 32 × 2 ÷ 8 = 8
     #[cfg_attr(
         target_arch = "x86_64",
-        case(unpck_detransform_unroll_4, "unpck_unroll_4", 32) // processes 128 bytes per iteration, so max_blocks = 128 × 2 ÷ 8 = 32
+        case(unpck_untransform_unroll_4, "unpck_unroll_4", 32) // processes 128 bytes per iteration, so max_blocks = 128 × 2 ÷ 8 = 32
     )]
     fn test_sse2_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/mod.rs
@@ -20,17 +20,17 @@ unsafe fn untransform_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize)
     {
         #[cfg(feature = "nightly")]
         if dxt_lossless_transform_common::cpu_detect::has_avx512f() {
-            avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
+            avx512::permute_512_untransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
 
         if dxt_lossless_transform_common::cpu_detect::has_avx2() {
-            avx2::permd_detransform_unroll_2(input_ptr, output_ptr, len);
+            avx2::permd_untransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
 
         if dxt_lossless_transform_common::cpu_detect::has_sse2() {
-            sse2::unpck_detransform_unroll_2(input_ptr, output_ptr, len);
+            sse2::unpck_untransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
     }
@@ -39,23 +39,23 @@ unsafe fn untransform_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usize)
     {
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") {
-            avx512::permute_512_detransform_unroll_2(input_ptr, output_ptr, len);
+            avx512::permute_512_untransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
 
         if cfg!(target_feature = "avx2") {
-            avx2::permd_detransform_unroll_2(input_ptr, output_ptr, len);
+            avx2::permd_untransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
 
         if cfg!(target_feature = "sse2") {
-            sse2::unpck_detransform_unroll_2(input_ptr, output_ptr, len);
+            sse2::unpck_untransform_unroll_2(input_ptr, output_ptr, len);
             return;
         }
     }
 
     // Fallback to portable implementation
-    portable32::u32_detransform(input_ptr, output_ptr, len)
+    portable32::u32_untransform(input_ptr, output_ptr, len)
 }
 
 /// Unsplit BC1 blocks, putting them back into standard interleaved format from a separated color/index format
@@ -78,7 +78,7 @@ pub(crate) unsafe fn untransform(input_ptr: *const u8, output_ptr: *mut u8, len:
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        portable32::u32_detransform(input_ptr, output_ptr, len)
+        portable32::u32_untransform(input_ptr, output_ptr, len)
     }
 }
 
@@ -96,7 +96,7 @@ unsafe fn untransform_with_separate_pointers_x86(
         use dxt_lossless_transform_common::cpu_detect::*;
         #[cfg(feature = "nightly")]
         if has_avx512f() {
-            avx512::permute_512_detransform_unroll_2_with_components(
+            avx512::permute_512_untransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,
@@ -106,7 +106,7 @@ unsafe fn untransform_with_separate_pointers_x86(
         }
 
         if has_avx2() {
-            avx2::permd_detransform_unroll_2_with_components(
+            avx2::permd_untransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,
@@ -116,7 +116,7 @@ unsafe fn untransform_with_separate_pointers_x86(
         }
 
         if has_sse2() {
-            sse2::unpck_detransform_unroll_2_with_components(
+            sse2::unpck_untransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,
@@ -130,7 +130,7 @@ unsafe fn untransform_with_separate_pointers_x86(
     {
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512f") {
-            avx512::permute_512_detransform_unroll_2_with_components(
+            avx512::permute_512_untransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,
@@ -140,7 +140,7 @@ unsafe fn untransform_with_separate_pointers_x86(
         }
 
         if cfg!(target_feature = "avx2") {
-            avx2::permd_detransform_unroll_2_with_components(
+            avx2::permd_untransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,
@@ -150,7 +150,7 @@ unsafe fn untransform_with_separate_pointers_x86(
         }
 
         if cfg!(target_feature = "sse2") {
-            sse2::unpck_detransform_unroll_2_with_components(
+            sse2::unpck_untransform_unroll_2_with_components(
                 output_ptr,
                 len,
                 indices_ptr as *const u8,
@@ -161,7 +161,7 @@ unsafe fn untransform_with_separate_pointers_x86(
     }
 
     // Fallback to portable implementation
-    portable32::u32_detransform_with_separate_pointers(colors_ptr, indices_ptr, output_ptr, len)
+    portable32::u32_untransform_with_separate_pointers(colors_ptr, indices_ptr, output_ptr, len)
 }
 
 /// Unsplit BC1 blocks, putting them back into standard interleaved format from a separated color/index format
@@ -191,6 +191,6 @@ pub(crate) unsafe fn untransform_with_separate_pointers(
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        portable32::u32_detransform_with_separate_pointers(colors_ptr, indices_ptr, output_ptr, len)
+        portable32::u32_untransform_with_separate_pointers(colors_ptr, indices_ptr, output_ptr, len)
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/portable32.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/portable32.rs
@@ -5,14 +5,14 @@ use core::ptr::{read_unaligned, write_unaligned};
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
-pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 8 == 0);
 
     // Get pointers to the color and index sections
     let colours_ptr = input_ptr as *const u32;
     let indices_ptr = input_ptr.add(len / 2) as *const u32;
 
-    u32_detransform_with_separate_pointers(colours_ptr, indices_ptr, output_ptr, len);
+    u32_untransform_with_separate_pointers(colours_ptr, indices_ptr, output_ptr, len);
 }
 
 /// # Safety
@@ -22,7 +22,7 @@ pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, 
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 8
 #[inline]
-pub(crate) unsafe fn u32_detransform_with_separate_pointers(
+pub(crate) unsafe fn u32_untransform_with_separate_pointers(
     mut colours_ptr: *const u32,
     mut indices_ptr: *const u32,
     mut output_ptr: *mut u8,
@@ -56,12 +56,12 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform, "u32")]
+    #[case(u32_untransform, "u32")]
     fn test_portable32_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
     ) {
         // 8 bytes processed per main loop iteration (* 2 / 8 == 2)
-        run_standard_untransform_unaligned_test(detransform_fn, 2, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 2, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/sse2.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/standard/untransform/sse2.rs
@@ -1,4 +1,4 @@
-use crate::transform::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transform::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 /// # Safety
@@ -7,7 +7,7 @@ use core::arch::asm;
 /// - output_ptr must be valid for writes of len bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub(crate) unsafe fn unpck_detransform_unroll_2(
+pub(crate) unsafe fn unpck_untransform_unroll_2(
     input_ptr: *const u8,
     output_ptr: *mut u8,
     len: usize,
@@ -16,7 +16,7 @@ pub(crate) unsafe fn unpck_detransform_unroll_2(
     // Process as many 64-byte blocks as possible
     let indices_ptr = input_ptr.add(len / 2);
     let colors_ptr = input_ptr;
-    unpck_detransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
+    unpck_untransform_unroll_2_with_components(output_ptr, len, indices_ptr, colors_ptr);
 }
 
 /// # Safety
@@ -26,7 +26,7 @@ pub(crate) unsafe fn unpck_detransform_unroll_2(
 /// - colors_ptr must be valid for reads of len/2 bytes
 #[allow(unused_assignments)]
 #[target_feature(enable = "sse2")]
-pub(crate) unsafe fn unpck_detransform_unroll_2_with_components(
+pub(crate) unsafe fn unpck_untransform_unroll_2_with_components(
     mut output_ptr: *mut u8,
     len: usize,
     mut indices_in: *const u8,
@@ -87,7 +87,7 @@ pub(crate) unsafe fn unpck_detransform_unroll_2_with_components(
 
     // Process any remaining elements after the aligned blocks
     let remaining = len - aligned_len;
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         colors_in as *const u32,
         indices_in as *const u32,
         output_ptr,
@@ -101,9 +101,9 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(unpck_detransform_unroll_2, "unpck_unroll_2")]
-    fn test_sse2_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    #[case(unpck_untransform_unroll_2, "unpck_unroll_2")]
+    fn test_sse2_unaligned(#[case] untransform_fn: StandardTransformFn, #[case] impl_name: &str) {
         // 64 bytes processed per main loop iteration (* 2 / 8 == 16)
-        run_standard_untransform_unaligned_test(detransform_fn, 16, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 16, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/with_recorrelate/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/with_recorrelate/mod.rs
@@ -5,7 +5,7 @@
 //! applying YCoCg recorrelation to the color endpoints. This combines two operations into
 //! a single optimized pass for improved performance.
 //!
-//! Below is a description of the detransformation process.
+//! Below is a description of the untransformation process.
 //! For transformation, swap the `output` and `input`.
 //!
 //! ## Input Format

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/with_split_colour/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/with_split_colour/mod.rs
@@ -1,10 +1,10 @@
 //! # Unsplit Split Colour-Split Blocks Module
 //!
 //! This module provides optimized functions for combining split color data and block indices
-//! back into standard BC1 (DXT1) compressed texture blocks. This is part of the detransformation
+//! back into standard BC1 (DXT1) compressed texture blocks. This is part of the untransformation
 //! process that reverses the lossless transformation applied to BC1 data.
 //!
-//! Below is a description of the detransformation process.
+//! Below is a description of the untransformation process.
 //! For transformation, swap the `output` and `input`.
 //!
 //! ## Input Format

--- a/projects/core/dxt-lossless-transform-bc1/src/transform/with_split_colour_and_recorr/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc1/src/transform/with_split_colour_and_recorr/mod.rs
@@ -5,7 +5,7 @@
 //! optimized step. This eliminates the need for intermediate memory copies by performing both
 //! decorrelation and unsplitting operations directly.
 //!
-//! Below is a description of the detransformation process.
+//! Below is a description of the untransformation process.
 //! For transformation, swap the `output` and `input`.
 //!
 //! ## Input Format

--- a/projects/core/dxt-lossless-transform-bc2/benches/untransform_standard/portable32.rs
+++ b/projects/core/dxt-lossless-transform-bc2/benches/untransform_standard/portable32.rs
@@ -4,7 +4,7 @@ use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform(
+        u32_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc2/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/lib.rs
@@ -14,7 +14,7 @@ extern crate std;
 #[cfg(feature = "experimental")]
 pub mod experimental;
 
-/// Provides optimized routines to transform/detransform into various forms of the lossless transform.
+/// Provides optimized routines to transform/untransform into various forms of the lossless transform.
 pub mod transforms;
 
 pub mod util;

--- a/projects/core/dxt-lossless-transform-bc2/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/test_prelude.rs
@@ -166,8 +166,8 @@ pub(crate) fn run_standard_transform_unaligned_test(
 // Helper functions for untransform tests
 // --------------------------------------
 
-/// Executes an unaligned detransform test for unsplit operations.
-/// Tests a transform→detransform roundtrip with deliberately misaligned buffers.
+/// Executes an unaligned untransform test for unsplit operations.
+/// Tests a transform→untransform roundtrip with deliberately misaligned buffers.
 ///
 /// The `max_blocks` parameter should equal twice the number of bytes processed in one main loop
 /// iteration of the SIMD implementation being tested (i.e., bytes processed × 2 ÷ 16).

--- a/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx2.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx2.rs
@@ -1,4 +1,4 @@
-use crate::transforms::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transforms::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 #[allow(clippy::unusual_byte_groupings)]
@@ -192,7 +192,7 @@ pub(crate) unsafe fn avx2_shuffle_with_components(
     let remaining_len = len - aligned_len;
     if remaining_len > 0 {
         // Pointers `alpha_ptr`, `colors_ptr`, `indices_ptr`, and `output_ptr` have been updated by the asm block
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             alpha_ptr as *const u64, // Final alpha pointer from asm (or initial if aligned_len == 0)
             colors_ptr as *const u32, // Final colors pointer from asm (or initial)
             indices_ptr as *const u32, // Final indices pointer from asm (or initial)
@@ -372,7 +372,7 @@ pub(crate) unsafe fn avx2_shuffle_with_components(
     let remaining_len = len - aligned_len;
     if remaining_len > 0 {
         // Pointers `alpha_ptr`, `colors_ptr`, `indices_ptr`, and `output_ptr` have been updated by the asm block
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             alpha_ptr as *const u64, // Final alpha pointer from asm (or initial if aligned_len == 0)
             colors_ptr as *const u32, // Final colors pointer from asm (or initial)
             indices_ptr as *const u32, // Final indices pointer from asm (or initial)
@@ -389,12 +389,12 @@ mod tests {
 
     #[rstest]
     #[case::avx2_shuffle(avx2_shuffle, "avx2_shuffle")]
-    fn test_avx2_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    fn test_avx2_unaligned(#[case] untransform_fn: StandardTransformFn, #[case] impl_name: &str) {
         if !has_avx2() {
             return;
         }
 
         // AVX2 implementation processes 128 bytes per iteration, so max_blocks = 128 * 2 / 16 = 16
-        run_standard_untransform_unaligned_test(detransform_fn, 16, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 16, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx512.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/avx512.rs
@@ -1,4 +1,4 @@
-use crate::transforms::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transforms::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
@@ -171,7 +171,7 @@ pub(crate) unsafe fn avx512_shuffle_with_components_intrinsics(
     let remaining_len = len - aligned_len;
     if remaining_len > 0 {
         // Pointers `alpha_ptr`, `colors_ptr`, `indices_ptr`, and `output_ptr` have been updated by the asm block
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             alpha_ptr as *const u64, // Final alpha pointer from asm (or initial if aligned_len == 0)
             colors_ptr as *const u32, // Final colors pointer from asm (or initial)
             indices_ptr as *const u32, // Final indices pointer from asm (or initial)
@@ -348,12 +348,12 @@ mod tests {
     #[rstest]
     #[case::avx512_shuffle(avx512_shuffle, "avx512_shuffle")]
     #[case::avx512_shuffle_intrinsics(avx512_shuffle_intrinsics, "avx512_shuffle_intrinsics")]
-    fn test_avx512_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    fn test_avx512_unaligned(#[case] untransform_fn: StandardTransformFn, #[case] impl_name: &str) {
         if !has_avx512f() {
             return;
         }
 
         // AVX512 implementation processes 256 bytes per iteration, so max_blocks = 256 * 2 / 16 = 32
-        run_standard_untransform_unaligned_test(detransform_fn, 32, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 32, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/mod.rs
@@ -56,7 +56,7 @@ unsafe fn unsplit_blocks_bc2_x86(input_ptr: *const u8, output_ptr: *mut u8, len:
     }
 
     // Fallback to portable implementation
-    portable32::u32_detransform(input_ptr, output_ptr, len)
+    portable32::u32_untransform(input_ptr, output_ptr, len)
 }
 
 /// Transform BC2 data from separated alpha/color/index format back to standard interleaved format
@@ -79,7 +79,7 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        portable32::u32_detransform(input_ptr, output_ptr, len)
+        portable32::u32_untransform(input_ptr, output_ptr, len)
     }
 }
 
@@ -171,7 +171,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     }
 
     // Fallback to portable implementation
-    portable32::u32_detransform_with_separate_pointers(
+    portable32::u32_untransform_with_separate_pointers(
         alphas_ptr,
         colors_ptr,
         indices_ptr,
@@ -214,7 +214,7 @@ pub unsafe fn unsplit_block_with_separate_pointers(
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        portable32::u32_detransform_with_separate_pointers(
+        portable32::u32_untransform_with_separate_pointers(
             alphas_ptr,
             colors_ptr,
             indices_ptr,
@@ -229,8 +229,8 @@ pub unsafe fn unsplit_block_with_separate_pointers(
 #[allow(clippy::missing_safety_doc)]
 #[allow(missing_docs)]
 pub mod bench_exports {
-    pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-        super::portable32::u32_detransform(input_ptr, output_ptr, len)
+    pub unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+        super::portable32::u32_untransform(input_ptr, output_ptr, len)
     }
 
     #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]

--- a/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/portable32.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/portable32.rs
@@ -5,7 +5,7 @@ use core::ptr::{read_unaligned, write_unaligned};
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Get pointers to the alpha, color, index sections.
@@ -13,7 +13,7 @@ pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, 
     let colours_ptr = input_ptr.add(len / 2) as *const u32;
     let indices_ptr = (colours_ptr as *const u8).add(len / 4) as *const u32;
 
-    u32_detransform_with_separate_pointers(alphas_ptr, colours_ptr, indices_ptr, output_ptr, len);
+    u32_untransform_with_separate_pointers(alphas_ptr, colours_ptr, indices_ptr, output_ptr, len);
 }
 
 /// # Safety
@@ -23,7 +23,7 @@ pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, 
 /// - `indices_ptr` must point to valid `u32` data for `len / 4` bytes.
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub(crate) unsafe fn u32_detransform_with_separate_pointers(
+pub(crate) unsafe fn u32_untransform_with_separate_pointers(
     mut alphas_ptr: *const u64,
     mut colours_ptr: *const u32,
     mut indices_ptr: *const u32,
@@ -60,12 +60,12 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform, "no_unroll")]
+    #[case(u32_untransform, "no_unroll")]
     fn test_portable32_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
     ) {
         // Portable implementation processes 16 bytes per iteration, so max_blocks = 16 * 2 / 16 = 2
-        run_standard_untransform_unaligned_test(detransform_fn, 2, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 2, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/sse2.rs
+++ b/projects/core/dxt-lossless-transform-bc2/src/transforms/standard/untransform/sse2.rs
@@ -1,4 +1,4 @@
-use crate::transforms::standard::untransform::portable32::u32_detransform_with_separate_pointers;
+use crate::transforms::standard::untransform::portable32::u32_untransform_with_separate_pointers;
 use core::arch::asm;
 
 /// # Safety
@@ -124,7 +124,7 @@ pub(crate) unsafe fn shuffle_with_components(
     let remaining_len = len - aligned_len;
     if remaining_len > 0 {
         // Pointers `input_ptr`, `colors_ptr`, `indices_ptr`, and `output_ptr` have been updated by the asm block
-        u32_detransform_with_separate_pointers(
+        u32_untransform_with_separate_pointers(
             alpha_ptr as *const u64,   // Final alpha pointer from asm
             colors_ptr as *const u32,  // Final colors pointer from asm
             indices_ptr as *const u32, // Final indices pointer from asm
@@ -141,11 +141,11 @@ mod tests {
 
     #[rstest]
     #[case::shuffle(shuffle, "shuffle")]
-    fn test_sse2_unaligned(#[case] detransform_fn: StandardTransformFn, #[case] impl_name: &str) {
+    fn test_sse2_unaligned(#[case] untransform_fn: StandardTransformFn, #[case] impl_name: &str) {
         if !has_sse2() {
             return;
         }
         // SSE2 implementation processes 64 bytes per iteration, so max_blocks = 64 * 2 / 16 = 8
-        run_standard_untransform_unaligned_test(detransform_fn, 8, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, 8, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/avx512.rs
+++ b/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/avx512.rs
@@ -1,12 +1,12 @@
 use criterion::{black_box, BenchmarkId};
 use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::{
-    avx512_detransform, avx512_detransform_32_vbmi, avx512_detransform_32_vl,
+    avx512_untransform, avx512_untransform_32_vbmi, avx512_untransform_32_vl,
 };
 use safe_allocator_api::RawAlloc;
 
 fn bench_avx512_32_vbmi(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        avx512_detransform_32_vbmi(
+        avx512_untransform_32_vbmi(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -16,7 +16,7 @@ fn bench_avx512_32_vbmi(b: &mut criterion::Bencher, input: &RawAlloc, output: &m
 
 fn bench_avx512_32_vl(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        avx512_detransform_32_vl(
+        avx512_untransform_32_vl(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -26,7 +26,7 @@ fn bench_avx512_32_vl(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut
 
 fn bench_avx512_64(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        avx512_detransform(
+        avx512_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/portable32.rs
+++ b/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/portable32.rs
@@ -4,7 +4,7 @@ use safe_allocator_api::RawAlloc;
 
 fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform(
+        u32_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -14,7 +14,7 @@ fn bench_portable32(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut R
 
 fn bench_portable32_v2(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform_v2(
+        u32_untransform_v2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/portable64.rs
+++ b/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/portable64.rs
@@ -1,10 +1,10 @@
 use criterion::{black_box, BenchmarkId};
-use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::u64_detransform;
+use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::u64_untransform;
 use safe_allocator_api::RawAlloc;
 
 fn bench_portable64(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u64_detransform(
+        u64_untransform(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/sse2.rs
+++ b/projects/core/dxt-lossless-transform-bc3/benches/untransform_standard/sse2.rs
@@ -1,12 +1,12 @@
 use criterion::{black_box, BenchmarkId};
 use dxt_lossless_transform_bc3::transforms::standard::untransform::bench::{
-    u32_detransform_sse2, u64_detransform_sse2,
+    u32_untransform_sse2, u64_untransform_sse2,
 };
 use safe_allocator_api::RawAlloc;
 
 fn bench_u64_sse(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u64_detransform_sse2(
+        u64_untransform_sse2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),
@@ -16,7 +16,7 @@ fn bench_u64_sse(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawA
 
 fn bench_u32_sse(b: &mut criterion::Bencher, input: &RawAlloc, output: &mut RawAlloc) {
     b.iter(|| unsafe {
-        u32_detransform_sse2(
+        u32_untransform_sse2(
             black_box(input.as_ptr()),
             black_box(output.as_mut_ptr()),
             black_box(input.len()),

--- a/projects/core/dxt-lossless-transform-bc3/src/lib.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/lib.rs
@@ -14,7 +14,7 @@ extern crate std;
 #[cfg(feature = "experimental")]
 pub mod experimental;
 
-/// Provides optimized routines to transform/detransform into various forms of the lossless transform.
+/// Provides optimized routines to transform/untransform into various forms of the lossless transform.
 pub mod transforms;
 
 pub mod util;

--- a/projects/core/dxt-lossless-transform-bc3/src/test_prelude.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/test_prelude.rs
@@ -183,8 +183,8 @@ pub(crate) fn run_standard_transform_unaligned_test(
 // Helper functions for untransform tests
 // --------------------------------------
 
-/// Executes an unaligned detransform test for unsplit operations.
-/// Tests a transform→detransform roundtrip with deliberately misaligned buffers.
+/// Executes an unaligned untransform test for unsplit operations.
+/// Tests a transform→untransform roundtrip with deliberately misaligned buffers.
 ///
 /// The `max_blocks` parameter should equal twice the number of bytes processed in one main loop
 /// iteration of the SIMD implementation being tested (i.e., bytes processed × 2 ÷ 16).

--- a/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/mod.rs
@@ -7,42 +7,42 @@ pub mod portable;
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub mod sse2;
 
-pub unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    portable::u32_detransform(input_ptr, output_ptr, len)
+pub unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    portable::u32_untransform(input_ptr, output_ptr, len)
 }
 
-pub unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    super::portable::u32_detransform_v2(input_ptr, output_ptr, len)
+pub unsafe fn u32_untransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::portable::u32_untransform_v2(input_ptr, output_ptr, len)
 }
 
-pub unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    portable::u64_detransform(input_ptr, output_ptr, len)
-}
-
-#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    sse2::u32_detransform_sse2(input_ptr, output_ptr, len)
+pub unsafe fn u64_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    portable::u64_untransform(input_ptr, output_ptr, len)
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn u64_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    super::sse2::u64_detransform_sse2(input_ptr, output_ptr, len)
+pub unsafe fn u32_untransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    sse2::u32_untransform_sse2(input_ptr, output_ptr, len)
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+pub unsafe fn u64_untransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::sse2::u64_untransform_sse2(input_ptr, output_ptr, len)
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn avx512_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    super::avx512::avx512_detransform(input_ptr, output_ptr, len)
+pub unsafe fn avx512_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_untransform(input_ptr, output_ptr, len)
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn avx512_detransform_32_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    super::avx512::avx512_detransform_32_vbmi(input_ptr, output_ptr, len)
+pub unsafe fn avx512_untransform_32_vbmi(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_untransform_32_vbmi(input_ptr, output_ptr, len)
 }
 
 #[cfg(feature = "nightly")]
 #[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-pub unsafe fn avx512_detransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
-    super::avx512::avx512_detransform_32_vl(input_ptr, output_ptr, len)
+pub unsafe fn avx512_untransform_32_vl(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+    super::avx512::avx512_untransform_32_vl(input_ptr, output_ptr, len)
 }

--- a/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/portable.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/portable.rs
@@ -1,11 +1,11 @@
-use crate::transforms::standard::untransform::portable::u32_detransform_with_separate_pointers;
+use crate::transforms::standard::untransform::portable::u32_untransform_with_separate_pointers;
 
 /// # Safety
 ///
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     // Set up input pointers for each section
@@ -15,7 +15,7 @@ pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, 
     let index_byte_in_ptr = input_ptr.add(len / 16 * 12) as *const u32;
     let current_output_ptr = output_ptr;
 
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         alpha_byte_in_ptr,
         alpha_bit_in_ptr,
         color_byte_in_ptr,
@@ -30,7 +30,7 @@ pub(crate) unsafe fn u32_detransform(input_ptr: *const u8, output_ptr: *mut u8, 
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
-pub(crate) unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u64_untransform(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     const BYTES_PER_ITERATION: usize = 32;
     let aligned_len = len - (len % BYTES_PER_ITERATION);
@@ -102,7 +102,7 @@ pub(crate) unsafe fn u64_detransform(input_ptr: *const u8, output_ptr: *mut u8, 
     }
 
     // Process remaining bytes if necessary
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         alpha_byte_in_ptr as *const u16,
         alpha_bit_in_ptr,
         color_byte_in_ptr as *const u32,
@@ -118,14 +118,14 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform, "u32", 2)]
-    #[case(u64_detransform, "u64", 2)]
+    #[case(u32_untransform, "u32", 2)]
+    #[case(u64_untransform, "u64", 2)]
     fn test_portable_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
         // For portable: processes 16 bytes (1 block) per iteration, so max_blocks = 16 bytes × 2 ÷ 16 = 2
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/sse2.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/bench/sse2.rs
@@ -4,7 +4,7 @@ use core::arch::x86::*;
 use core::arch::x86_64::*;
 use core::arch::*;
 
-use crate::transforms::standard::untransform::portable::u32_detransform_with_separate_pointers;
+use crate::transforms::standard::untransform::portable::u32_untransform_with_separate_pointers;
 
 /// # Safety
 ///
@@ -12,7 +12,7 @@ use crate::transforms::standard::untransform::portable::u32_detransform_with_sep
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
 #[target_feature(enable = "sse2")]
-pub(crate) unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_untransform_sse2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
 
     const BYTES_PER_ITERATION: usize = 64;
@@ -85,13 +85,13 @@ pub(crate) unsafe fn u32_detransform_sse2(input_ptr: *const u8, output_ptr: *mut
         }
     }
 
-    // Convert pointers to the types expected by u32_detransform_with_separate_pointers
+    // Convert pointers to the types expected by u32_untransform_with_separate_pointers
     let alpha_byte_in_ptr_u16 = alpha_byte_in_ptr as *const u16;
     let alpha_bit_in_ptr_u16 = alpha_bit_in_ptr as *const u16;
     let color_byte_in_ptr_u32 = color_byte_in_ptr as *const u32;
     let index_byte_in_ptr_u32 = index_byte_in_ptr as *const u32;
 
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         alpha_byte_in_ptr_u16,
         alpha_bit_in_ptr_u16,
         color_byte_in_ptr_u32,
@@ -122,13 +122,13 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform_sse2, "u32", 8)]
+    #[case(u32_untransform_sse2, "u32", 8)]
     fn test_sse2_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
         // For SSE2: processes 64 bytes (4 blocks) per iteration, so max_blocks = 64 bytes × 2 ÷ 16 = 8
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/mod.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/mod.rs
@@ -18,7 +18,7 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
         #[cfg(feature = "nightly")]
         #[cfg(target_arch = "x86_64")]
         if dxt_lossless_transform_common::cpu_detect::has_avx512vbmi() {
-            avx512::avx512_detransform(input_ptr, output_ptr, len);
+            avx512::avx512_untransform(input_ptr, output_ptr, len);
             return;
         }
     }
@@ -28,7 +28,7 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
         #[cfg(target_arch = "x86_64")]
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512vbmi") {
-            avx512::avx512_detransform(input_ptr, output_ptr, len);
+            avx512::avx512_untransform(input_ptr, output_ptr, len);
             return;
         }
     }
@@ -37,12 +37,12 @@ unsafe fn unsplit_blocks_x86(input_ptr: *const u8, output_ptr: *mut u8, len: usi
     // On i686, this is slower, so skipped.
     #[cfg(target_arch = "x86_64")]
     {
-        sse2::u64_detransform_sse2(input_ptr, output_ptr, len);
+        sse2::u64_untransform_sse2(input_ptr, output_ptr, len);
     }
 
     #[cfg(not(target_arch = "x86_64"))]
     {
-        portable::u32_detransform_v2(input_ptr, output_ptr, len);
+        portable::u32_untransform_v2(input_ptr, output_ptr, len);
     }
 }
 
@@ -66,7 +66,7 @@ pub unsafe fn unsplit_blocks(input_ptr: *const u8, output_ptr: *mut u8, len: usi
 
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
-        portable::u32_detransform_v2(input_ptr, output_ptr, len)
+        portable::u32_untransform_v2(input_ptr, output_ptr, len)
     }
 }
 
@@ -85,7 +85,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
         #[cfg(feature = "nightly")]
         #[cfg(target_arch = "x86_64")]
         if dxt_lossless_transform_common::cpu_detect::has_avx512vbmi() {
-            avx512::avx512_detransform_separate_components(
+            avx512::avx512_untransform_separate_components(
                 alpha_byte_ptr,
                 alpha_bit_ptr,
                 color_byte_ptr,
@@ -102,7 +102,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
         #[cfg(target_arch = "x86_64")]
         #[cfg(feature = "nightly")]
         if cfg!(target_feature = "avx512vbmi") {
-            avx512::avx512_detransform_separate_components(
+            avx512::avx512_untransform_separate_components(
                 alpha_byte_ptr,
                 alpha_bit_ptr,
                 color_byte_ptr,
@@ -118,7 +118,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
     // On i686, this is slower, so skipped.
     #[cfg(target_arch = "x86_64")]
     {
-        sse2::u64_detransform_sse2_separate_components(
+        sse2::u64_untransform_sse2_separate_components(
             alpha_byte_ptr as *const u64,
             alpha_bit_ptr as *const u64,
             color_byte_ptr as *const core::arch::x86_64::__m128i,
@@ -130,7 +130,7 @@ unsafe fn unsplit_block_with_separate_pointers_x86(
 
     #[cfg(target_arch = "x86")]
     {
-        portable::u32_detransform_with_separate_pointers(
+        portable::u32_untransform_with_separate_pointers(
             alpha_byte_ptr as *const u16,
             alpha_bit_ptr as *const u16,
             color_byte_ptr as *const u32,
@@ -179,7 +179,7 @@ pub unsafe fn unsplit_block_with_separate_pointers(
     #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
     {
         // Cast pointers to types expected by portable implementation
-        portable::u32_detransform_with_separate_pointers(
+        portable::u32_untransform_with_separate_pointers(
             alpha_byte_ptr as *const u16,
             alpha_bit_ptr as *const u16,
             color_byte_ptr as *const u32,

--- a/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/portable.rs
+++ b/projects/core/dxt-lossless-transform-bc3/src/transforms/standard/untransform/portable.rs
@@ -4,7 +4,7 @@
 ///
 /// - input_ptr must be valid for reads of len bytes
 /// - output_ptr must be valid for writes of len bytes
-pub(crate) unsafe fn u32_detransform_with_separate_pointers(
+pub(crate) unsafe fn u32_untransform_with_separate_pointers(
     mut alpha_byte_in_ptr: *const u16,
     mut alpha_bit_in_ptr: *const u16,
     mut color_byte_in_ptr: *const u32,
@@ -42,7 +42,7 @@ pub(crate) unsafe fn u32_detransform_with_separate_pointers(
 /// - output_ptr must be valid for writes of len bytes
 /// - len must be divisible by 16
 #[cfg_attr(target_arch = "x86_64", allow(dead_code))] // x86_64 does not use this path.
-pub(crate) unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
+pub(crate) unsafe fn u32_untransform_v2(input_ptr: *const u8, output_ptr: *mut u8, len: usize) {
     debug_assert!(len % 16 == 0);
     const BYTES_PER_ITERATION: usize = 32;
     let aligned_len = len - (len % BYTES_PER_ITERATION);
@@ -104,7 +104,7 @@ pub(crate) unsafe fn u32_detransform_v2(input_ptr: *const u8, output_ptr: *mut u
     }
 
     // Process remaining bytes if necessary
-    u32_detransform_with_separate_pointers(
+    u32_untransform_with_separate_pointers(
         alpha_byte_in_ptr as *const u16,
         alpha_bit_in_ptr,
         color_byte_in_ptr,
@@ -120,13 +120,13 @@ mod tests {
     use crate::test_prelude::*;
 
     #[rstest]
-    #[case(u32_detransform_v2, "u32_v2", 2)]
+    #[case(u32_untransform_v2, "u32_v2", 2)]
     fn test_portable_unaligned(
-        #[case] detransform_fn: StandardTransformFn,
+        #[case] untransform_fn: StandardTransformFn,
         #[case] impl_name: &str,
         #[case] max_blocks: usize,
     ) {
         // For portable: processes 16 bytes (1 block) per iteration, so max_blocks = 16 bytes × 2 ÷ 16 = 2
-        run_standard_untransform_unaligned_test(detransform_fn, max_blocks, impl_name);
+        run_standard_untransform_unaligned_test(untransform_fn, max_blocks, impl_name);
     }
 }

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_bc1/benchmark.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_bc1/benchmark.rs
@@ -46,7 +46,7 @@ pub(crate) fn handle_benchmark_command(cmd: BenchmarkCmd) -> Result<(), Transfor
 
     let input_path = &cmd.input_directory;
     println!(
-        "Benchmarking BC1 decompress+detransform performance for files in: {} (recursive)",
+        "Benchmarking BC1 decompress+untransform performance for files in: {} (recursive)",
         input_path.display()
     );
     println!("Iterations per file: {}", cmd.iterations);
@@ -322,7 +322,7 @@ unsafe fn process_scenario(
             config.compression_algorithm,
         )?;
 
-        // Detransform
+        // Untransform
         untransform_bc1_with_settings(
             decompressed_data.as_ptr(),
             final_output.as_mut_ptr(),
@@ -343,8 +343,8 @@ unsafe fn process_scenario(
         }
     });
 
-    // Benchmark detransform
-    let (_, detransform_time) = measure_time(|| {
+    // Benchmark untransform
+    let (_, untransform_time) = measure_time(|| {
         for _ in 0..config.iterations {
             untransform_bc1_with_settings(
                 decompressed_data.as_ptr(),
@@ -357,13 +357,13 @@ unsafe fn process_scenario(
 
     // Average the times over iterations
     let avg_decompress_time = decompress_time / config.iterations;
-    let avg_detransform_time = detransform_time / config.iterations;
+    let avg_untransform_time = untransform_time / config.iterations;
 
     Ok(Some(BenchmarkScenarioResult::new(
         scenario_name.to_string(),
         len_bytes,
         avg_decompress_time,
-        avg_detransform_time,
+        avg_untransform_time,
     )))
 }
 
@@ -420,6 +420,6 @@ unsafe fn process_untransformed_scenario(
         scenario_name.to_string(),
         len_bytes,
         avg_decompress_time,
-        Duration::ZERO, // No detransform time for untransformed scenario
+        Duration::ZERO, // No untransform time for untransformed scenario
     )))
 }

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_bc1/benchmark_determine_best.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_bc1/benchmark_determine_best.rs
@@ -167,13 +167,13 @@ unsafe fn process_determine_best_scenario(
     // Average the time over iterations
     let avg_execution_time = execution_time / config.iterations;
 
-    // For this benchmark, we consider the entire determine_best_transform_details as "detransform"
+    // For this benchmark, we consider the entire determine_best_transform_details as "untransform"
     // and set decompress time to 0, as we're only measuring the algorithm performance
     Ok(Some(BenchmarkScenarioResult::new(
         scenario_name.to_string(),
         len_bytes,
         Duration::ZERO,     // No decompress time for this specific benchmark
-        avg_execution_time, // All time is considered "detransform" time
+        avg_execution_time, // All time is considered "untransform" time
     )))
 }
 
@@ -203,8 +203,8 @@ fn print_file_result_throughput(result: &BenchmarkResult) {
     println!("   📊 File size: {file_size_mib:.2} MiB");
 
     for scenario in &result.scenarios {
-        let execution_time_ms = scenario.detransform_time.as_secs_f64() * 1000.0;
-        let throughput = scenario.detransform_throughput;
+        let execution_time_ms = scenario.untransform_time.as_secs_f64() * 1000.0;
+        let throughput = scenario.untransform_throughput;
         println!(
             "   ⚡ {}: {execution_time_ms:.3} ms ({throughput:.2})",
             scenario.scenario_name

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_bc1/mod.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_bc1/mod.rs
@@ -80,7 +80,7 @@ pub struct CompressionStatsCmd {
 }
 
 #[derive(FromArgs, Debug)]
-/// Benchmark BC1 transform and detransform performance on files in a directory
+/// Benchmark BC1 transform and untransform performance on files in a directory
 #[argh(subcommand, name = "benchmark")]
 pub struct BenchmarkCmd {
     /// input directory path to benchmark (recursively)

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/mod.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/mod.rs
@@ -1,5 +1,5 @@
-pub mod detransform;
 pub mod transform;
+pub mod untransform;
 
 #[cfg(feature = "debug-bc1")]
 pub mod debug_bc1;

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/untransform/mod.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/untransform/mod.rs
@@ -11,9 +11,9 @@ use std::{
 };
 
 #[derive(FromArgs, Debug)]
-/// Detransform DDS files (Demo CLI - use API for production)
-#[argh(subcommand, name = "detransform")]
-pub struct DetransformCmd {
+/// Untransform DDS files (Demo CLI - use API for production)
+#[argh(subcommand, name = "untransform")]
+pub struct UntransformCmd {
     /// input directory path
     #[argh(option, from_str_fn(canonicalize_cli_path))]
     pub input: PathBuf,
@@ -23,8 +23,8 @@ pub struct DetransformCmd {
     pub output: PathBuf,
 }
 
-pub fn handle_detransform_command(cmd: DetransformCmd) -> Result<(), Box<dyn std::error::Error>> {
-    println!("=== DXT Lossless Detransform CLI Demo ===");
+pub fn handle_untransform_command(cmd: UntransformCmd) -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== DXT Lossless Untransform CLI Demo ===");
     println!("Note: This CLI is for demonstration purposes only.");
     println!("For production use, integrate the API directly into your application.\n");
 
@@ -52,7 +52,7 @@ pub fn handle_detransform_command(cmd: DetransformCmd) -> Result<(), Box<dyn std
         Throughput::from_bytes_per_sec(0)
     };
 
-    println!("\n=== Detransform Complete ===");
+    println!("\n=== Untransform Complete ===");
     println!("Time taken: {elapsed:.2?}");
     println!("Data processed: {data_size}");
     println!("Throughput: {throughput}");

--- a/projects/tools/dxt-lossless-transform-cli/src/main.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/main.rs
@@ -20,7 +20,7 @@ struct TopLevel {
 #[argh(subcommand)]
 enum Commands {
     Transform(commands::transform::TransformCmd),
-    Detransform(commands::detransform::DetransformCmd),
+    Untransform(commands::untransform::UntransformCmd),
     #[cfg(feature = "debug-bc7")]
     DebugBc7(commands::debug_bc7::DebugCmd),
     #[cfg(feature = "debug-bc1")]
@@ -34,8 +34,8 @@ fn main() -> Result<(), Box<dyn Error>> {
         Commands::Transform(cmd) => {
             commands::transform::handle_transform_command(cmd)?;
         }
-        Commands::Detransform(cmd) => {
-            commands::detransform::handle_detransform_command(cmd)?;
+        Commands::Untransform(cmd) => {
+            commands::untransform::handle_untransform_command(cmd)?;
         }
         #[cfg(feature = "debug-bc7")]
         Commands::DebugBc7(cmd) => {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated all user-facing terminology from "detransform" to "untransform" across documentation, command-line interface, and API outputs for improved consistency.
  * Renamed related structs, functions, type aliases, and command-line options to reflect the new terminology.
  * No changes to logic, algorithms, or performance; all updates are naming and documentation clarifications.

* **Documentation**
  * Revised documentation and help text to use "untransform" consistently in descriptions, examples, and benchmark outputs.

* **Style**
  * Updated printed messages, variable names, and comments to align with the new "untransform" terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->