### PR TITLE
Added: BC2 High Level API

### DIFF
--- a/projects/api/dxt-lossless-transform-bc1-api/src/c_api/mod.rs
+++ b/projects/api/dxt-lossless-transform-bc1-api/src/c_api/mod.rs
@@ -17,7 +17,11 @@
 //! #include <stdlib.h>
 //!
 //! // Your BC1 texture data (8 bytes per BC1 block)
-//! uint8_t bc1_data[] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0};
+//! uint8_t bc1_data[] = {
+//!     0x12, 0x34,                                      // Color0 (RGB565)
+//!     0x56, 0x78,                                      // Color1 (RGB565)
+//!     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+//! };
 //! uint8_t transformed_data[8];
 //!
 //! // Create and configure manual transform builder
@@ -47,7 +51,11 @@
 //! #include <stdlib.h>
 //!
 //! // Your transformed BC1 data (after decompression)
-//! uint8_t transformed_data[] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0};
+//! uint8_t transformed_data[] = {
+//!     0x12, 0x34,                                      // Color0 (RGB565)
+//!     0x56, 0x78,                                      // Color1 (RGB565)
+//!     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+//! };
 //! uint8_t restored_data[8];
 //!
 //! // Create builder with SAME settings used for original transform
@@ -77,7 +85,11 @@
 //! #include <stdlib.h>
 //!
 //! // Your BC1 texture data
-//! uint8_t bc1_data[] = {0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0};
+//! uint8_t bc1_data[] = {
+//!     0x12, 0x34,                                      // Color0 (RGB565)
+//!     0x56, 0x78,                                      // Color1 (RGB565)
+//!     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+//! };
 //! uint8_t transformed_data[8];
 //!
 //! // Create manual transform builder to receive the selected settings

--- a/projects/api/dxt-lossless-transform-bc2-api/Cargo.toml
+++ b/projects/api/dxt-lossless-transform-bc2-api/Cargo.toml
@@ -34,6 +34,11 @@ nightly = [
     "dxt-lossless-transform-api-common/nightly",
     "safe-allocator-api/nightly",
 ]
+# Enable C exports
+c-exports = [
+    "dxt-lossless-transform-api-common/c-exports",
+    "dxt-lossless-transform-bc2/c-exports",
+]
 
 [dependencies]
 dxt-lossless-transform-bc2 = { workspace = true, default-features = false }

--- a/projects/api/dxt-lossless-transform-bc2-api/src/c_api/error.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/c_api/error.rs
@@ -1,0 +1,172 @@
+//! C API error handling for BC2 operations.
+
+use crate::error::Bc2Error;
+use core::ffi::c_char;
+use dxt_lossless_transform_bc2::{
+    Bc2AutoTransformError, Bc2ValidationError, DetermineBestTransformError,
+};
+
+/// C-compatible error codes for BC2 operations.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dltbc2ErrorCode {
+    /// Operation succeeded
+    Success = 0,
+    /// Invalid input length: Length must be divisible by 16 (BC2 block size)
+    InvalidLength = 1,
+    /// Output buffer too small for the operation
+    OutputBufferTooSmall = 2,
+    /// Memory allocation failed
+    AllocationFailed = 3,
+    /// Size estimation failed during transform optimization
+    SizeEstimationFailed = 4,
+    /// Null pointer provided for data parameter
+    NullDataPointer = 5,
+    /// Null pointer provided for DltSizeEstimator parameter
+    NullEstimatorPointer = 6,
+    /// Null pointer provided for Dltbc2TransformSettings parameter
+    NullTransformSettingsPointer = 7,
+    /// Null pointer provided for input parameter
+    NullInputPointer = 8,
+    /// Null pointer provided for output buffer parameter
+    NullOutputBufferPointer = 9,
+    /// Null pointer provided for Dltbc2ManualTransformBuilder parameter
+    NullManualTransformBuilderPointer = 10,
+    /// Null pointer provided for Dltbc2EstimateSettingsBuilder parameter
+    NullBuilderPointer = 11,
+    /// Null pointer provided for manual builder output parameter
+    NullManualBuilderOutputPointer = 12,
+}
+
+/// C-compatible Result type for BC2 operations.
+#[repr(C)]
+pub struct Dltbc2Result {
+    /// Error code (0 = success, non-zero = error)
+    pub error_code: Dltbc2ErrorCode,
+}
+
+impl Dltbc2Result {
+    /// Create a success result
+    pub const fn success() -> Self {
+        Self {
+            error_code: Dltbc2ErrorCode::Success,
+        }
+    }
+
+    /// Create an error result from an error code
+    pub const fn from_error_code(error_code: Dltbc2ErrorCode) -> Self {
+        Self { error_code }
+    }
+
+    /// Check if the result is successful
+    pub fn is_success(&self) -> bool {
+        matches!(self.error_code, Dltbc2ErrorCode::Success)
+    }
+}
+
+impl<T> From<Result<T, Bc2Error>> for Dltbc2Result {
+    fn from(result: Result<T, Bc2Error>) -> Self {
+        match result {
+            Ok(_) => Self::success(),
+            Err(e) => e.into(),
+        }
+    }
+}
+
+impl<E> From<Bc2Error<E>> for Dltbc2Result
+where
+    E: core::fmt::Debug,
+{
+    fn from(error: Bc2Error<E>) -> Self {
+        let error_code = match error {
+            Bc2Error::InvalidLength(_) => Dltbc2ErrorCode::InvalidLength,
+            Bc2Error::OutputBufferTooSmall { .. } => Dltbc2ErrorCode::OutputBufferTooSmall,
+            Bc2Error::AllocationFailed => Dltbc2ErrorCode::AllocationFailed,
+            Bc2Error::SizeEstimationFailed(_) => Dltbc2ErrorCode::SizeEstimationFailed,
+        };
+        Self::from_error_code(error_code)
+    }
+}
+
+impl From<Bc2ValidationError> for Dltbc2Result {
+    fn from(error: Bc2ValidationError) -> Self {
+        let error_code = match error {
+            Bc2ValidationError::InvalidLength(_) => Dltbc2ErrorCode::InvalidLength,
+            Bc2ValidationError::OutputBufferTooSmall { .. } => {
+                Dltbc2ErrorCode::OutputBufferTooSmall
+            }
+        };
+        Self::from_error_code(error_code)
+    }
+}
+
+impl<E> From<Bc2AutoTransformError<E>> for Dltbc2Result
+where
+    E: core::fmt::Debug,
+{
+    fn from(error: Bc2AutoTransformError<E>) -> Self {
+        let error_code = match error {
+            Bc2AutoTransformError::InvalidLength(_) => Dltbc2ErrorCode::InvalidLength,
+            Bc2AutoTransformError::OutputBufferTooSmall { .. } => {
+                Dltbc2ErrorCode::OutputBufferTooSmall
+            }
+            Bc2AutoTransformError::DetermineBestTransform(inner) => match inner {
+                DetermineBestTransformError::SizeEstimationError(_) => {
+                    Dltbc2ErrorCode::SizeEstimationFailed
+                }
+                DetermineBestTransformError::AllocateError(_) => Dltbc2ErrorCode::AllocationFailed,
+            },
+        };
+        Self::from_error_code(error_code)
+    }
+}
+
+/// Get a null-terminated string description of the error code.
+///
+/// The returned string is a static string literal that does not need to be freed.
+///
+/// # Safety
+/// This function is safe to call with any error code value.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_error_message(error_code: Dltbc2ErrorCode) -> *const c_char {
+    match error_code {
+        Dltbc2ErrorCode::Success => c"Success".as_ptr() as *const c_char,
+        Dltbc2ErrorCode::InvalidLength => {
+            c"Invalid input length: Length must be divisible by 16 (BC2 block size)".as_ptr()
+                as *const c_char
+        }
+        Dltbc2ErrorCode::OutputBufferTooSmall => {
+            c"Output buffer too small for the operation".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::AllocationFailed => c"Memory allocation failed".as_ptr() as *const c_char,
+        Dltbc2ErrorCode::SizeEstimationFailed => {
+            c"Size estimation failed during transform optimization".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::NullDataPointer => {
+            c"Null pointer provided for data parameter".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::NullEstimatorPointer => {
+            c"Null pointer provided for DltSizeEstimator parameter".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::NullTransformSettingsPointer => {
+            c"Null pointer provided for Dltbc2TransformSettings parameter".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::NullInputPointer => {
+            c"Null pointer provided for input parameter".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::NullOutputBufferPointer => {
+            c"Null pointer provided for output parameter".as_ptr() as *const c_char
+        }
+        Dltbc2ErrorCode::NullManualTransformBuilderPointer => {
+            c"Null pointer provided for Dltbc2ManualTransformBuilder parameter".as_ptr()
+                as *const c_char
+        }
+        Dltbc2ErrorCode::NullBuilderPointer => {
+            c"Null pointer provided for Dltbc2EstimateSettingsBuilder parameter".as_ptr()
+                as *const c_char
+        }
+        Dltbc2ErrorCode::NullManualBuilderOutputPointer => {
+            c"Null pointer provided for manual builder output parameter".as_ptr() as *const c_char
+        }
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/c_api/mod.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/c_api/mod.rs
@@ -1,0 +1,266 @@
+//! # C API (FFI) Documentation
+//!
+//! *Note: The C API is only available when the `c-exports` feature is enabled.*
+//!
+//! The `c-exports` feature enables C-compatible FFI exports for using this library from C, C++, or other languages that support C FFI. The C API provides two categories of functions with different trade-offs.
+//!
+//! ## Example Usage
+//!
+//! **⚠️ Disclaimer: The following C examples are AI-generated and have not been tested by humans. They are provided for reference only and may require modification for actual use.**
+//!
+//! **📝 Note: The transform operation should be performed *before* compression, and untransform should be performed *after* decompression.**
+//!
+//! ### Basic Transform Operation
+//!
+//! ```c
+//! #include <stdio.h>
+//! #include <stdlib.h>
+//!
+//! // Your BC2 texture data (16 bytes per BC2 block)
+//! uint8_t bc2_data[] = {
+//!     0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,  // Alpha data (8 bytes)
+//!     0x12, 0x34,                                      // Color0 (RGB565)
+//!     0x56, 0x78,                                      // Color1 (RGB565)
+//!     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+//! };
+//! uint8_t transformed_data[16];
+//!
+//! // Create and configure manual transform builder
+//! Dltbc2ManualTransformBuilder* builder = dltbc2_new_ManualTransformBuilder();
+//! dltbc2_ManualTransformBuilder_decorrelation_mode(builder, 1); // Variant1
+//! dltbc2_ManualTransformBuilder_split_colour_endpoints(builder, true);
+//!
+//! // Transform the data
+//! Dltbc2Error result = dltbc2_ManualTransformBuilder_build_and_transform(
+//!     builder, bc2_data, transformed_data, sizeof(bc2_data));
+//!
+//! if (result == DLTBC2_SUCCESS) {
+//!     printf("Transform successful!\n");
+//!     // Now compress 'transformed_data' with your compressor...
+//! } else {
+//!     printf("Transform failed\n");
+//! }
+//!
+//! // Clean up
+//! dltbc2_free_ManualTransformBuilder(builder);
+//! ```
+//!
+//! ### Untransform Operation (After Decompression)
+//!
+//! ```c
+//! #include <stdio.h>
+//! #include <stdlib.h>
+//!
+//! // Your transformed BC2 data (after decompression)
+//! uint8_t transformed_data[] = {
+//!     0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,  // Alpha data (8 bytes)
+//!     0x12, 0x34,                                      // Color0 (RGB565)
+//!     0x56, 0x78,                                      // Color1 (RGB565)
+//!     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+//! };
+//! uint8_t restored_data[16];
+//!
+//! // Create builder with SAME settings used for original transform
+//! Dltbc2ManualTransformBuilder* builder = dltbc2_new_ManualTransformBuilder();
+//! dltbc2_ManualTransformBuilder_decorrelation_mode(builder, 1); // Variant1
+//! dltbc2_ManualTransformBuilder_split_colour_endpoints(builder, true);
+//!
+//! // Restore original BC2 data
+//! Dltbc2Error result = dltbc2_ManualTransformBuilder_build_and_untransform(
+//!     builder, transformed_data, restored_data, sizeof(transformed_data));
+//!
+//! if (result == DLTBC2_SUCCESS) {
+//!     printf("Untransform successful!\n");
+//!     // 'restored_data' now contains original BC2 data
+//! } else {
+//!     printf("Untransform failed\n");
+//! }
+//!
+//! // Clean up
+//! dltbc2_free_ManualTransformBuilder(builder);
+//! ```
+//!
+//! ### Determine Best Transform Options (Automatic)
+//!
+//! ```c
+//! #include <stdio.h>
+//! #include <stdlib.h>
+//!
+//! // Your BC2 texture data
+//! uint8_t bc2_data[] = {
+//!     0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,  // Alpha data (8 bytes)
+//!     0x12, 0x34,                                      // Color0 (RGB565)
+//!     0x56, 0x78,                                      // Color1 (RGB565)
+//!     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+//! };
+//! uint8_t transformed_data[16];
+//!
+//! // Create manual transform builder to receive the selected settings
+//! Dltbc2ManualTransformBuilder* settings_builder = dltbc2_new_ManualTransformBuilder();
+//! // Create auto transform builder for optimization
+//! Dltbc2AutoTransformBuilder* builder = dltbc2_new_AutoTransformBuilder();
+//!
+//! // Configure analysis (optional - false is default for faster analysis)
+//! dltbc2_AutoTransformBuilder_use_all_decorrelation_modes(builder, false);
+//!
+//! // Analyze data and determine best transform options using ZStd estimator
+//! Dltbc2Error result = dltbc2_AutoTransformBuilder_build_and_transform_with_zstd_estimator(
+//!     builder, bc2_data, transformed_data, sizeof(bc2_data), 6, settings_builder);
+//!
+//! if (result == DLTBC2_SUCCESS) {
+//!     printf("Transform with best settings successful!\n");
+//!     // 'transformed_data' now contains the transformed data
+//!     // 'settings_builder' contains the transform details for later untransform
+//!     // Now compress 'transformed_data' with your compressor...
+//! } else {
+//!     printf("Analysis failed\n");
+//! }
+//!
+//! // Clean up
+//! dltbc2_free_AutoTransformBuilder(builder);
+//! dltbc2_free_ManualTransformBuilder(settings_builder);
+//! ```
+//!
+//! ## ABI-Stable Functions (Recommended)
+//!
+//! These functions use opaque contexts and builder patterns that maintain ABI stability across versions, making them safe for production use.
+//!
+//! ### Manual Transform Builder Functions
+//!
+//! The manual transform builder is an opaque object that stores BC2 transform configuration. Use these functions for safe, ABI-stable transform operations:
+//!
+//! - **`dltbc2_new_ManualTransformBuilder()`** - Create a new manual transform builder with default settings
+//! - **`dltbc2_free_ManualTransformBuilder(builder)`** - Free a manual transform builder (required to avoid memory leaks)
+//! - **`dltbc2_clone_ManualTransformBuilder(builder)`** - Create a copy of an existing builder
+//!
+//! ### Manual Builder Configuration Functions
+//!
+//! Configure the manual transform builder before performing operations:
+//!
+//! - **`dltbc2_ManualTransformBuilder_decorrelation_mode(builder, mode)`** - Set color decorrelation mode (YCoCg variants)
+//! - **`dltbc2_ManualTransformBuilder_split_colour_endpoints(builder, split)`** - Enable/disable color endpoint splitting
+//! - **`dltbc2_ManualTransformBuilder_reset(builder)`** - Reset builder to default values
+//!
+//! ### Transform Operations
+//!
+//! Perform the actual BC2 data transformation:
+//!
+//! - **`dltbc2_ManualTransformBuilder_build_and_transform(builder, input, output, input_len)`** - Transform BC2 data for better compression
+//! - **`dltbc2_ManualTransformBuilder_build_and_untransform(builder, input, output, input_len)`** - Restore original BC2 data after decompression
+//!
+//! ### Automatic Transform Optimization Functions
+//!
+//! Analyze your data to determine the best transform settings automatically:
+//!
+//! - **`dltbc2_new_AutoTransformBuilder()`** - Create a builder for automatic optimization
+//! - **`dltbc2_AutoTransformBuilder_use_all_decorrelation_modes(builder, use_all)`** - Configure analysis thoroughness  
+//! - **`dltbc2_AutoTransformBuilder_build_and_transform_with_zstd_estimator(builder, input, output, input_len, compression_level, settings_builder)`** - Analyze data, determine best settings, and apply transformation in one operation
+//! - **`dltbc2_free_AutoTransformBuilder(builder)`** - Free the builder
+//!
+//! ## ABI-Unstable Functions (Advanced Users)
+//!
+//! ⚠️ **For advanced users only**: Functions prefixed with `dltbc2_unstable_*` accept transform details directly. These provide maximum performance by avoiding builder overhead but may break between versions if structures change. **Production code should use the ABI-stable builder patterns above.**
+//!
+//! The unstable functions have been moved to the core crate and are available in `dxt_lossless_transform_bc2::c_api` when the `c_api` feature is enabled. They include:
+//!
+//! - **`dltbc2_unstable_transform(...)`** - Transform BC2 data with explicit settings (ABI-unstable)
+//! - **`dltbc2_unstable_untransform(...)`** - Restore BC2 data with explicit settings (ABI-unstable)  
+//! - **`dltbc2_unstable_transform_auto(...)`** - Analyze data, determine best settings, and apply transformation in one operation (ABI-unstable)
+//!
+//! See the core crate documentation for details and migration guidance.
+//!
+//! ## Error Handling
+//!
+//! All functions return `Dltbc2Error` which contains error codes:
+//! - `DLTBC2_SUCCESS` (0) for success, non-zero for various error conditions
+//! - Use error handling appropriate for your application
+//!
+//! For detailed documentation of all C API functions, see the [C API documentation](https://docs.rs/dxt-lossless-transform-bc2-api/latest/dxt_lossless_transform_bc2_api/c_api/index.html) (requires `c-exports` feature).
+
+// Module declarations - mirrors the structure of the non-C API
+pub mod error;
+pub mod transform;
+
+use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;
+use dxt_lossless_transform_bc2::{Bc2TransformSettings, Bc2UntransformSettings};
+
+/// FFI-safe version of [`Bc2TransformSettings`] for C API.
+///
+/// This struct mirrors the internal [`Bc2TransformSettings`] but is guaranteed
+/// to have stable ABI layout for C interoperability.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Dltbc2TransformSettings {
+    /// The decorrelation mode that was used to decorrelate the colors.
+    pub decorrelation_mode: YCoCgVariant,
+    /// Whether color endpoints are split.
+    pub split_colour_endpoints: bool,
+}
+
+/// FFI-safe version of [`Bc2UntransformSettings`] for C API.
+///
+/// This struct mirrors the internal [`Bc2UntransformSettings`] but is guaranteed
+/// to have stable ABI layout for C interoperability.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct Dltbc2UntransformSettings {
+    /// The decorrelation mode that was used to decorrelate the colors.
+    pub decorrelation_mode: YCoCgVariant,
+    /// Whether color endpoints are split.
+    pub split_colour_endpoints: bool,
+}
+
+impl Default for Dltbc2TransformSettings {
+    fn default() -> Self {
+        Self {
+            decorrelation_mode: YCoCgVariant::Variant1,
+            split_colour_endpoints: true,
+        }
+    }
+}
+
+impl Default for Dltbc2UntransformSettings {
+    fn default() -> Self {
+        Self {
+            decorrelation_mode: YCoCgVariant::Variant1,
+            split_colour_endpoints: true,
+        }
+    }
+}
+
+// Conversion implementations
+impl From<Bc2TransformSettings> for Dltbc2TransformSettings {
+    fn from(details: Bc2TransformSettings) -> Self {
+        Self {
+            decorrelation_mode: YCoCgVariant::from_internal_variant(details.decorrelation_mode),
+            split_colour_endpoints: details.split_colour_endpoints,
+        }
+    }
+}
+
+impl From<Dltbc2TransformSettings> for Bc2TransformSettings {
+    fn from(details: Dltbc2TransformSettings) -> Self {
+        Self {
+            decorrelation_mode: details.decorrelation_mode.to_internal_variant(),
+            split_colour_endpoints: details.split_colour_endpoints,
+        }
+    }
+}
+
+impl From<Bc2UntransformSettings> for Dltbc2UntransformSettings {
+    fn from(details: Bc2UntransformSettings) -> Self {
+        Self {
+            decorrelation_mode: YCoCgVariant::from_internal_variant(details.decorrelation_mode),
+            split_colour_endpoints: details.split_colour_endpoints,
+        }
+    }
+}
+
+impl From<Dltbc2UntransformSettings> for Bc2UntransformSettings {
+    fn from(details: Dltbc2UntransformSettings) -> Self {
+        Self {
+            decorrelation_mode: details.decorrelation_mode.to_internal_variant(),
+            split_colour_endpoints: details.split_colour_endpoints,
+        }
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/c_api/transform/auto_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/c_api/transform/auto_transform_builder.rs
@@ -1,0 +1,671 @@
+//! BC2 auto transform builder for C API.
+//!
+//! This module provides ABI-stable functions for configuring BC2 auto transform builder
+//! in a convenient builder pattern that mirrors the Rust API structure.
+
+use crate::c_api::error::{Dltbc2ErrorCode, Dltbc2Result};
+use crate::c_api::transform::manual_transform_builder::Dltbc2ManualTransformBuilder;
+use alloc::boxed::Box;
+use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
+
+/// Opaque handle for BC2 auto transform builder.
+///
+/// This builder allows configuring options for BC2 transformation with automatic optimization.
+///
+/// **Usage Pattern:**
+/// 1. Create builder with [`dltbc2_new_AutoTransformBuilder`]
+/// 2. Configure with [`dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes`]  
+/// 3. Transform with [`dltbc2_AutoTransformBuilder_Transform`] (returns configured manual builder)
+/// 4. Use returned manual builder for untransformation
+/// 5. Free both builders when done
+///
+/// The builder can be reused multiple times and must be explicitly freed with
+/// [`dltbc2_free_AutoTransformBuilder`].
+///
+/// # Remarks
+/// This type corresponds to [`crate::Bc2AutoTransformBuilder`] in the Rust API.
+///
+/// # cbindgen Opaque Type Rule
+/// Per cbindgen documentation (<https://github.com/mozilla/cbindgen/blob/master/docs.md>):
+/// "If a type is determined to have a guaranteed layout, a full definition will be emitted in the header.
+/// If the type doesn't have a guaranteed layout, only a forward declaration will be emitted. This may be
+/// fine if the type is intended to be passed around opaquely and by reference."
+///
+/// This struct intentionally lacks `#[repr(C)]` to ensure it generates as an opaque forward declaration.
+pub struct Dltbc2AutoTransformBuilder {
+    estimator: DltSizeEstimator,
+    use_all_decorrelation_modes: bool,
+}
+
+/// Create a new BC2 auto transform builder with the provided estimator.
+///
+/// The estimator should have its compression level and other parameters already configured.
+/// This allows for more flexible usage patterns where different estimators can have
+/// completely different configuration approaches.
+///
+/// The returned builder must be freed with [`dltbc2_free_AutoTransformBuilder`].
+///
+/// # Parameters
+/// - `estimator`: The size estimator to use for finding the best possible transform.
+///   This will test different transform configurations and choose the one that results
+///   in the smallest estimated compressed size according to this estimator.
+///
+/// # Returns
+/// A pointer to a new builder, or null if allocation fails.
+///
+/// # Safety
+/// - `estimator` must be a valid pointer to a [`DltSizeEstimator`] with valid function pointers
+/// - The estimator's context and functions must remain valid for the lifetime of the builder
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2AutoTransformBuilder::new`] in the Rust API.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_new_AutoTransformBuilder(
+    estimator: *const DltSizeEstimator,
+) -> *mut Dltbc2AutoTransformBuilder {
+    if estimator.is_null() {
+        return core::ptr::null_mut();
+    }
+
+    // Copy the estimator (DltSizeEstimator is copyable - function pointers and raw pointers are Copy)
+    let estimator_copy = unsafe { core::ptr::read(estimator) };
+
+    let builder_impl = Box::new(Dltbc2AutoTransformBuilder {
+        estimator: estimator_copy,
+        use_all_decorrelation_modes: false,
+    });
+
+    Box::into_raw(builder_impl)
+}
+
+/// Free a BC2 auto transform builder.
+///
+/// # Safety
+/// - `builder` must be a valid pointer returned by [`dltbc2_new_AutoTransformBuilder`]
+/// - `builder` must not have been freed already
+/// - After calling this function, `builder` becomes invalid
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_free_AutoTransformBuilder(
+    builder: *mut Dltbc2AutoTransformBuilder,
+) {
+    if !builder.is_null() {
+        unsafe {
+            drop(Box::from_raw(builder));
+        }
+    }
+}
+
+/// Set whether to use all decorrelation modes during optimization.
+///
+/// When `false` (default), only tests common configurations for faster optimization.
+/// When `true`, tests all decorrelation modes for potentially better compression
+/// at the cost of twice as long optimization time.
+///
+/// **Note**: The typical improvement from testing all decorrelation modes is <0.1% in practice.
+/// For better compression gains, it's recommended to use a compression level on the
+/// estimator (e.g., ZStandard estimator) closer to your final compression level instead.
+///
+/// # Parameters
+/// - `builder`: The builder to configure
+/// - `use_all`: Whether to test all decorrelation modes
+///
+/// # Returns
+/// A [`Dltbc2Result`] indicating success or containing an error.
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2AutoTransformBuilder`]
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2AutoTransformBuilder::use_all_decorrelation_modes`] in the Rust API.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(
+    builder: *mut Dltbc2AutoTransformBuilder,
+    use_all: bool,
+) -> Dltbc2Result {
+    if builder.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullBuilderPointer);
+    }
+
+    let builder_impl = unsafe { &mut *builder };
+    builder_impl.use_all_decorrelation_modes = use_all;
+    Dltbc2Result::success()
+}
+
+/// Transform BC2 data using automatically determined optimal settings and return a configured manual builder.
+///
+/// This function determines optimal transform settings using the configured estimator,
+/// applies the transformation to the input data, and outputs a pre-configured
+/// manual transform builder for untransformation.
+///
+/// # Parameters
+/// - `builder`: The configured auto builder
+/// - `data`: Pointer to BC2 data to transform
+/// - `data_len`: Length of input data in bytes (must be divisible by 16)
+/// - `output`: Pointer to output buffer where transformed data will be written
+/// - `output_len`: Length of output buffer in bytes (must be at least `data_len`)
+/// - `out_manual_builder`: Output pointer where the configured manual builder will be written.
+///   On success, this will be set to a valid pointer that must be freed with [`dltbc2_free_ManualTransformBuilder`].
+///   On error, this will be set to null.
+///
+/// # Returns
+/// A [`Dltbc2Result`] indicating success or containing an error code.
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2AutoTransformBuilder`]
+/// - `data` must be valid for reads of `data_len` bytes
+/// - `output` must be valid for writes of `output_len` bytes
+/// - `out_manual_builder` must be a valid pointer to write the result
+/// - The estimator associated with the builder must remain valid for the duration of the call
+///
+/// # Examples
+///
+/// ```c
+/// // Create auto transform builder with estimator
+/// Dltbc2AutoTransformBuilder* auto_builder = dltbc2_new_AutoTransformBuilder(estimator);
+/// dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(auto_builder, false);
+///
+/// // Transform and get configured manual builder
+/// Dltbc2ManualTransformBuilder* manual_builder = NULL;
+/// Dltbc2Result result = dltbc2_AutoTransformBuilder_Transform(
+///     auto_builder, bc2_data, sizeof(bc2_data),
+///     transformed_data, sizeof(transformed_data), &manual_builder);
+///
+/// if (result.error_code == DLTBC2_SUCCESS) {
+///     // Later, untransform using the returned manual builder
+///     Dltbc2Result untransform_result = dltbc2_ManualTransformBuilder_Untransform(
+///         transformed_data, sizeof(transformed_data),
+///         restored_data, sizeof(restored_data), manual_builder);
+///
+///     // Clean up
+///     dltbc2_free_ManualTransformBuilder(manual_builder);
+/// }
+/// dltbc2_free_AutoTransformBuilder(auto_builder);
+/// ```
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2AutoTransformBuilder::transform`] in the Rust API.
+///
+/// [`dltbc2_free_ManualTransformBuilder`]: crate::c_api::transform::manual_transform_builder::dltbc2_free_ManualTransformBuilder
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_AutoTransformBuilder_Transform(
+    builder: *mut Dltbc2AutoTransformBuilder,
+    data: *const u8,
+    data_len: usize,
+    output: *mut u8,
+    output_len: usize,
+    out_manual_builder: *mut *mut Dltbc2ManualTransformBuilder,
+) -> Dltbc2Result {
+    // Validate required pointers
+    if builder.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullBuilderPointer);
+    }
+    if data.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullDataPointer);
+    }
+    if output.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullOutputBufferPointer);
+    }
+    if out_manual_builder.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullManualBuilderOutputPointer);
+    }
+
+    // Get settings from builder
+    let builder_impl = unsafe { &*builder };
+
+    // Create input and output slices
+    let input_slice = unsafe { core::slice::from_raw_parts(data, data_len) };
+    let output_slice = unsafe { core::slice::from_raw_parts_mut(output, output_len) };
+
+    // Create the Rust API builder with the stored configuration
+    let rust_auto_builder = crate::transform::Bc2AutoTransformBuilder::new(&builder_impl.estimator)
+        .use_all_decorrelation_modes(builder_impl.use_all_decorrelation_modes);
+
+    // Transform using the Rust API
+    match rust_auto_builder.transform(input_slice, output_slice) {
+        Ok(manual_builder) => {
+            // Create the C API wrapper for the manual builder
+            let inner = Box::new(
+                crate::c_api::transform::manual_transform_builder::Dltbc2ManualTransformBuilder {
+                    builder: manual_builder,
+                },
+            );
+
+            // Write the result to the output pointer
+            unsafe {
+                *out_manual_builder = Box::into_raw(inner);
+            }
+
+            Dltbc2Result::success()
+        }
+        Err(error) => {
+            // On failure, ensure the output pointer is null
+            unsafe {
+                *out_manual_builder = core::ptr::null_mut();
+            }
+
+            // Convert the Rust API error to C API result using the existing From implementation
+            error.into()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    /// Test helper: Create a dummy size estimator for testing
+    fn create_dummy_estimator() -> DltSizeEstimator {
+        unsafe extern "C" fn dummy_max_compressed_size(
+            _context: *mut c_void,
+            len_bytes: usize,
+            out_size: *mut usize,
+        ) -> u32 {
+            unsafe {
+                *out_size = len_bytes; // Just return input size
+            }
+            0 // Success
+        }
+
+        unsafe extern "C" fn dummy_estimate_compressed_size(
+            _context: *mut c_void,
+            _input_ptr: *const u8,
+            len_bytes: usize,
+            _output_ptr: *mut u8,
+            _output_len: usize,
+            out_size: *mut usize,
+        ) -> u32 {
+            unsafe {
+                *out_size = len_bytes; // Just return input size
+            }
+            0 // Success
+        }
+
+        DltSizeEstimator {
+            context: ptr::null_mut(),
+            max_compressed_size: dummy_max_compressed_size,
+            estimate_compressed_size: dummy_estimate_compressed_size,
+        }
+    }
+
+    /// Helper function to create sample BC2 test data (1 block = 16 bytes)
+    fn create_test_bc2_data() -> Vec<u8> {
+        vec![
+            // Alpha data (8 bytes - 4-bit per pixel)
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            // Color data (8 bytes - BC1-like)
+            0x00, 0xF8, // Color0: Red in RGB565 (0xF800)
+            0x00, 0x00, // Color1: Black (0x0000)
+            0x00, 0x00, 0x00, 0x00, // Indices: all pointing to Color0
+        ]
+    }
+
+    #[test]
+    fn test_dltbc2_new_auto_transform_builder() {
+        let estimator = create_dummy_estimator();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            // Clean up
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_new_auto_transform_builder_null_estimator() {
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(ptr::null());
+            assert!(builder.is_null());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_free_auto_transform_builder_null_pointer() {
+        unsafe {
+            // Should not crash when freeing null pointer
+            dltbc2_free_AutoTransformBuilder(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_set_use_all_decorrelation_modes() {
+        let estimator = create_dummy_estimator();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            // Test setting use_all_decorrelation_modes to true
+            let result1 = dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(builder, true);
+            assert_eq!(result1.error_code, Dltbc2ErrorCode::Success);
+            assert!(result1.is_success());
+
+            // Test setting use_all_decorrelation_modes to false
+            let result2 = dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(builder, false);
+            assert_eq!(result2.error_code, Dltbc2ErrorCode::Success);
+            assert!(result2.is_success());
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_set_use_all_decorrelation_modes_null_builder() {
+        unsafe {
+            let result =
+                dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(ptr::null_mut(), true);
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullBuilderPointer);
+            assert!(!result.is_success());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_basic() {
+        let estimator = create_dummy_estimator();
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len()];
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                builder,
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut manual_builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::Success);
+            assert!(result.is_success());
+            assert!(!manual_builder.is_null());
+
+            // Clean up
+            dltbc2_free_AutoTransformBuilder(builder);
+
+            use crate::c_api::transform::manual_transform_builder::dltbc2_free_ManualTransformBuilder;
+            dltbc2_free_ManualTransformBuilder(manual_builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_null_builder() {
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len()];
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                ptr::null_mut(),
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut manual_builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullBuilderPointer);
+            assert!(!result.is_success());
+            assert!(manual_builder.is_null());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_null_data() {
+        let estimator = create_dummy_estimator();
+        let mut output = vec![0u8; 16];
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                builder,
+                ptr::null(),
+                16,
+                output.as_mut_ptr(),
+                output.len(),
+                &mut manual_builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullDataPointer);
+            assert!(!result.is_success());
+            assert!(manual_builder.is_null());
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_null_output() {
+        let estimator = create_dummy_estimator();
+        let test_data = create_test_bc2_data();
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                builder,
+                test_data.as_ptr(),
+                test_data.len(),
+                ptr::null_mut(),
+                16,
+                &mut manual_builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullOutputBufferPointer);
+            assert!(!result.is_success());
+            assert!(manual_builder.is_null());
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_null_manual_builder_output() {
+        let estimator = create_dummy_estimator();
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len()];
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                builder,
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                ptr::null_mut(),
+            );
+
+            assert_eq!(
+                result.error_code,
+                Dltbc2ErrorCode::NullManualBuilderOutputPointer
+            );
+            assert!(!result.is_success());
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_invalid_length() {
+        let estimator = create_dummy_estimator();
+        let test_data = [0u8; 15]; // Not divisible by 16
+        let mut output = vec![0u8; 15];
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                builder,
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut manual_builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::InvalidLength);
+            assert!(!result.is_success());
+            assert!(manual_builder.is_null());
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_transform_output_too_small() {
+        let estimator = create_dummy_estimator();
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len() - 1]; // Too small
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            let result = dltbc2_AutoTransformBuilder_Transform(
+                builder,
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                &mut manual_builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::OutputBufferTooSmall);
+            assert!(!result.is_success());
+            assert!(manual_builder.is_null());
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_full_workflow() {
+        let estimator = create_dummy_estimator();
+        let test_data = create_test_bc2_data();
+        let mut transformed = vec![0u8; test_data.len()];
+        let mut restored = vec![0u8; test_data.len()];
+        let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+        unsafe {
+            let auto_builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!auto_builder.is_null());
+
+            // Configure auto builder
+            let config_result =
+                dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(auto_builder, false);
+            assert_eq!(config_result.error_code, Dltbc2ErrorCode::Success);
+
+            // Transform using auto builder (this returns a configured manual builder)
+            let transform_result = dltbc2_AutoTransformBuilder_Transform(
+                auto_builder,
+                test_data.as_ptr(),
+                test_data.len(),
+                transformed.as_mut_ptr(),
+                transformed.len(),
+                &mut manual_builder,
+            );
+
+            assert_eq!(transform_result.error_code, Dltbc2ErrorCode::Success);
+            assert!(!manual_builder.is_null());
+
+            // Use the returned manual builder to untransform
+            use crate::c_api::transform::manual_transform_builder::dltbc2_ManualTransformBuilder_Untransform;
+            let untransform_result = dltbc2_ManualTransformBuilder_Untransform(
+                transformed.as_ptr(),
+                transformed.len(),
+                restored.as_mut_ptr(),
+                restored.len(),
+                manual_builder,
+            );
+
+            assert_eq!(untransform_result.error_code, Dltbc2ErrorCode::Success);
+            // Note: In practice, we'd expect restored == test_data, but with our dummy estimator,
+            // the transform might not be a perfect identity
+
+            // Clean up
+            dltbc2_free_AutoTransformBuilder(auto_builder);
+
+            use crate::c_api::transform::manual_transform_builder::dltbc2_free_ManualTransformBuilder;
+            dltbc2_free_ManualTransformBuilder(manual_builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_auto_transform_builder_with_different_settings() {
+        let estimator = create_dummy_estimator();
+        let test_data = create_test_bc2_data();
+
+        unsafe {
+            let builder = dltbc2_new_AutoTransformBuilder(&estimator);
+            assert!(!builder.is_null());
+
+            // Test with use_all_decorrelation_modes = false
+            {
+                let config_result =
+                    dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(builder, false);
+                assert_eq!(config_result.error_code, Dltbc2ErrorCode::Success);
+
+                let mut output = vec![0u8; test_data.len()];
+                let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+                let result = dltbc2_AutoTransformBuilder_Transform(
+                    builder,
+                    test_data.as_ptr(),
+                    test_data.len(),
+                    output.as_mut_ptr(),
+                    output.len(),
+                    &mut manual_builder,
+                );
+
+                assert_eq!(result.error_code, Dltbc2ErrorCode::Success);
+                assert!(!manual_builder.is_null());
+
+                use crate::c_api::transform::manual_transform_builder::dltbc2_free_ManualTransformBuilder;
+                dltbc2_free_ManualTransformBuilder(manual_builder);
+            }
+
+            // Test with use_all_decorrelation_modes = true
+            {
+                let config_result =
+                    dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(builder, true);
+                assert_eq!(config_result.error_code, Dltbc2ErrorCode::Success);
+
+                let mut output = vec![0u8; test_data.len()];
+                let mut manual_builder: *mut Dltbc2ManualTransformBuilder = ptr::null_mut();
+
+                let result = dltbc2_AutoTransformBuilder_Transform(
+                    builder,
+                    test_data.as_ptr(),
+                    test_data.len(),
+                    output.as_mut_ptr(),
+                    output.len(),
+                    &mut manual_builder,
+                );
+
+                assert_eq!(result.error_code, Dltbc2ErrorCode::Success);
+                assert!(!manual_builder.is_null());
+
+                use crate::c_api::transform::manual_transform_builder::dltbc2_free_ManualTransformBuilder;
+                dltbc2_free_ManualTransformBuilder(manual_builder);
+            }
+
+            dltbc2_free_AutoTransformBuilder(builder);
+        }
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/c_api/transform/manual_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/c_api/transform/manual_transform_builder.rs
@@ -1,0 +1,840 @@
+//! BC2 manual transform builder for C API.
+//!
+//! This module provides ABI-stable functions for managing and configuring BC2 manual transform builder
+//! through a builder pattern. The builder stores BC2 transform configuration and must be
+//! explicitly freed. These functions offer a stable interface that is guaranteed
+//! to remain compatible across library versions.
+//!
+//! For users requiring maximum performance and willing to accept potential breaking
+//! changes, see the core crate functions directly.
+
+use crate::{
+    c_api::error::{Dltbc2ErrorCode, Dltbc2Result},
+    transform::Bc2ManualTransformBuilder,
+};
+use alloc::boxed::Box;
+use core::{ptr, slice};
+use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;
+
+// =============================================================================
+// Type Definitions
+// =============================================================================
+
+/// Opaque manual transform builder type for BC2 transform operations.
+///
+/// This builder stores the current transform configuration and must be:
+///
+/// - Created with [`dltbc2_new_ManualTransformBuilder()`]
+/// - Modified using the builder functions
+/// - Passed to transform operations
+/// - Freed with [`dltbc2_free_ManualTransformBuilder()`] when no longer needed
+///
+/// The builder is NOT thread-safe and should not be shared between threads.
+/// Each thread should create its own builder.
+///
+/// # cbindgen Opaque Type Rule
+/// Per cbindgen documentation (<https://github.com/mozilla/cbindgen/blob/master/docs.md>):
+/// "If a type is determined to have a guaranteed layout, a full definition will be emitted in the header.
+/// If the type doesn't have a guaranteed layout, only a forward declaration will be emitted. This may be
+/// fine if the type is intended to be passed around opaquely and by reference."
+///
+/// This struct intentionally lacks `#[repr(C)]` to ensure it generates as an opaque forward declaration.
+pub struct Dltbc2ManualTransformBuilder {
+    pub(crate) builder: Bc2ManualTransformBuilder,
+}
+
+/// Get mutable access to the manual transform builder.
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+pub(crate) unsafe fn get_manual_builder_mut(
+    builder: *mut Dltbc2ManualTransformBuilder,
+) -> &'static mut Dltbc2ManualTransformBuilder {
+    debug_assert!(!builder.is_null());
+    unsafe { &mut *builder }
+}
+
+// =============================================================================
+// Lifecycle Functions
+// =============================================================================
+
+/// Create a new BC2 manual transform builder with default settings.
+///
+/// The returned builder must be freed with [`dltbc2_free_ManualTransformBuilder()`] when no longer needed.
+///
+/// # Returns
+/// A pointer to a newly allocated manual transform builder, or null if allocation fails.
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2ManualTransformBuilder::new`] in the Rust API.
+#[unsafe(no_mangle)]
+pub extern "C" fn dltbc2_new_ManualTransformBuilder() -> *mut Dltbc2ManualTransformBuilder {
+    let inner = Box::new(Dltbc2ManualTransformBuilder {
+        builder: crate::transform::Bc2ManualTransformBuilder::new(),
+    });
+
+    Box::into_raw(inner)
+}
+
+/// Free a BC2 manual transform builder.
+///
+/// # Safety
+/// - `builder` must be a valid pointer returned by [`dltbc2_new_ManualTransformBuilder()`]
+/// - `builder` must not have been freed already
+/// - After calling this function, `builder` becomes invalid
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_free_ManualTransformBuilder(
+    builder: *mut Dltbc2ManualTransformBuilder,
+) {
+    if !builder.is_null() {
+        unsafe {
+            drop(Box::from_raw(builder));
+        }
+    }
+}
+
+/// Clone a BC2 manual transform builder.
+///
+/// Creates a new builder with the same settings as the source builder.
+/// The returned builder must be freed independently.
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+///
+/// # Returns
+/// A pointer to a newly allocated manual transform builder with the same settings, or null if allocation fails.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_clone_ManualTransformBuilder(
+    builder: *const Dltbc2ManualTransformBuilder,
+) -> *mut Dltbc2ManualTransformBuilder {
+    if builder.is_null() {
+        return ptr::null_mut();
+    }
+
+    let inner = unsafe { &*builder };
+    let cloned = Box::new(Dltbc2ManualTransformBuilder {
+        builder: inner.builder,
+    });
+
+    Box::into_raw(cloned)
+}
+
+// =============================================================================
+// Configuration Functions
+// =============================================================================
+
+/// Set the decorrelation mode for the builder.
+///
+/// Controls the YCoCg-R color space decorrelation variant used for transformation.
+/// Different variants can provide varying compression ratios depending on the texture content.
+///
+/// **Note**: When manually testing decorrelation modes, the typical improvement from
+/// using different variants is <0.1% in practice. For better compression gains,
+/// it's recommended to use a compression level on the estimator (e.g., ZStandard estimator)
+/// closer to your final compression level instead.
+///
+/// For automatic optimization, consider using [`dltbc2_AutoTransformBuilder_Transform`] instead.
+///
+/// [`dltbc2_AutoTransformBuilder_Transform`]: crate::c_api::transform::auto_transform_builder::dltbc2_AutoTransformBuilder_Transform
+///
+/// # Parameters
+/// - `builder`: The BC2 manual builder to modify
+/// - `mode`: The decorrelation mode to use
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2ManualTransformBuilder::decorrelation_mode`] in the Rust API.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_ManualTransformBuilder_SetDecorrelationMode(
+    builder: *mut Dltbc2ManualTransformBuilder,
+    mode: YCoCgVariant,
+) {
+    if builder.is_null() {
+        return;
+    }
+
+    let inner = unsafe { get_manual_builder_mut(builder) };
+    inner.builder = inner.builder.decorrelation_mode(mode);
+}
+
+/// Set whether to split colour endpoints for the builder.
+///
+/// This setting controls whether BC2 texture color endpoints are separated during processing,
+/// which can improve compression efficiency for many textures.
+///
+/// **File Size**: This setting reduces file size around 78% of the time.
+///
+/// For automatic optimization, consider using [`dltbc2_AutoTransformBuilder_Transform`] instead.
+///
+/// [`dltbc2_AutoTransformBuilder_Transform`]: crate::c_api::transform::auto_transform_builder::dltbc2_AutoTransformBuilder_Transform
+///
+/// # Parameters
+/// - `builder`: The BC2 manual builder to modify
+/// - `split`: Whether to split colour endpoints
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2ManualTransformBuilder::split_colour_endpoints`] in the Rust API.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(
+    builder: *mut Dltbc2ManualTransformBuilder,
+    split: bool,
+) {
+    if builder.is_null() {
+        return;
+    }
+
+    let inner = unsafe { get_manual_builder_mut(builder) };
+    inner.builder = inner.builder.split_colour_endpoints(split);
+}
+
+/// Reset the builder to default settings.
+///
+/// # Parameters
+/// - `builder`: The BC2 manual builder to reset
+///
+/// # Safety
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_ManualTransformBuilder_ResetToDefaults(
+    builder: *mut Dltbc2ManualTransformBuilder,
+) {
+    if builder.is_null() {
+        return;
+    }
+
+    let inner = unsafe { get_manual_builder_mut(builder) };
+    inner.builder = crate::transform::Bc2ManualTransformBuilder::new();
+}
+
+// =============================================================================
+// Transform Operations
+// =============================================================================
+
+/// Transform BC2 data using the settings configured in the builder.
+///
+/// This function applies the transformation directly using the settings stored in the
+/// provided builder without any optimization or testing of different configurations.
+///
+/// # Parameters
+/// - `input`: Pointer to the BC2 data to transform
+/// - `input_len`: Length of input data in bytes (must be divisible by 16)
+/// - `output`: Pointer to the output buffer where transformed data will be written
+/// - `output_len`: Length of output buffer in bytes (must be at least `input_len`)
+/// - `builder`: The manual transform builder containing the settings to use
+///
+/// # Returns
+/// A [`Dltbc2Result`] indicating success or containing an error.
+///
+/// # Safety
+/// - `input` must be valid for reads of `input_len` bytes
+/// - `output` must be valid for writes of `output_len` bytes
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+///
+/// # Examples
+///
+/// ```c
+/// // Create and configure manual transform builder
+/// Dltbc2ManualTransformBuilder* builder = dltbc2_new_ManualTransformBuilder();
+/// dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCOCG_VARIANT_1);
+/// dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(builder, true);
+///
+/// // Transform the data
+/// Dltbc2Result result = dltbc2_ManualTransformBuilder_Transform(
+///     bc2_data, sizeof(bc2_data),
+///     transformed_data, sizeof(transformed_data),
+///     builder);
+/// ```
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2ManualTransformBuilder::transform`] in the Rust API.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_ManualTransformBuilder_Transform(
+    input: *const u8,
+    input_len: usize,
+    output: *mut u8,
+    output_len: usize,
+    builder: *mut Dltbc2ManualTransformBuilder,
+) -> Dltbc2Result {
+    // Validate pointers
+    if input.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullDataPointer);
+    }
+    if output.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullOutputBufferPointer);
+    }
+    if builder.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullManualTransformBuilderPointer);
+    }
+
+    // Create slices from raw pointers
+    let input_slice = unsafe { slice::from_raw_parts(input, input_len) };
+    let output_slice = unsafe { slice::from_raw_parts_mut(output, output_len) };
+
+    // Get the builder and perform transformation using its method
+    let builder_inner = unsafe { get_manual_builder_mut(builder) };
+
+    // Perform the transformation using the builder's method
+    match builder_inner.builder.transform(input_slice, output_slice) {
+        Ok(()) => Dltbc2Result::success(),
+        Err(e) => e.into(),
+    }
+}
+
+/// Untransform BC2 data using the settings configured in the builder.
+///
+/// This function reverses the transformation applied by [`dltbc2_ManualTransformBuilder_Transform`],
+/// restoring the original BC2 data. The builder must contain the same settings that were
+/// used for the original transformation.
+///
+/// # Parameters
+/// - `input`: Pointer to the transformed BC2 data to untransform
+/// - `input_len`: Length of input data in bytes (must be divisible by 16)
+/// - `output`: Pointer to the output buffer where the original BC2 data will be written
+/// - `output_len`: Length of output buffer in bytes (must be at least `input_len`)
+/// - `builder`: The manual transform builder containing the untransform settings to use
+///
+/// # Returns
+/// A [`Dltbc2Result`] indicating success or containing an error.
+///
+/// # Safety
+/// - `input` must be valid for reads of `input_len` bytes
+/// - `output` must be valid for writes of `output_len` bytes
+/// - `builder` must be a valid pointer to a [`Dltbc2ManualTransformBuilder`]
+/// - The builder must contain the same settings used for the original transformation
+///
+/// # Examples
+///
+/// ```c
+/// // Use the same builder that was used for transform
+/// Dltbc2Result result = dltbc2_ManualTransformBuilder_Untransform(
+///     transformed_data, sizeof(transformed_data),
+///     restored_data, sizeof(restored_data),
+///     builder);
+/// ```
+///
+/// # Remarks
+/// This function corresponds to [`crate::Bc2ManualTransformBuilder::untransform`] in the Rust API.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn dltbc2_ManualTransformBuilder_Untransform(
+    input: *const u8,
+    input_len: usize,
+    output: *mut u8,
+    output_len: usize,
+    builder: *mut Dltbc2ManualTransformBuilder,
+) -> Dltbc2Result {
+    // Validate pointers
+    if input.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullDataPointer);
+    }
+    if output.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullOutputBufferPointer);
+    }
+    if builder.is_null() {
+        return Dltbc2Result::from_error_code(Dltbc2ErrorCode::NullManualTransformBuilderPointer);
+    }
+
+    // Create slices from raw pointers
+    let input_slice = unsafe { slice::from_raw_parts(input, input_len) };
+    let output_slice = unsafe { slice::from_raw_parts_mut(output, output_len) };
+
+    // Get the builder and perform untransformation using its method
+    let builder_inner = unsafe { get_manual_builder_mut(builder) };
+
+    // Perform the untransformation using the builder's method
+    match builder_inner.builder.untransform(input_slice, output_slice) {
+        Ok(()) => Dltbc2Result::success(),
+        Err(e) => e.into(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_prelude::*;
+
+    /// Helper function to create sample BC2 test data (1 block = 16 bytes)
+    fn create_test_bc2_data() -> Vec<u8> {
+        vec![
+            // Alpha data (8 bytes - 4-bit per pixel)
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            // Color data (8 bytes - BC1-like)
+            0x00, 0xF8, // Color0: Red in RGB565 (0xF800)
+            0x00, 0x00, // Color1: Black (0x0000)
+            0x00, 0x00, 0x00, 0x00, // Indices: all pointing to Color0
+        ]
+    }
+
+    #[test]
+    fn test_dltbc2_new_manual_transform_builder() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        // Clean up
+        unsafe {
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_free_manual_transform_builder_null_pointer() {
+        // Should not crash when freeing null pointer
+        unsafe {
+            dltbc2_free_ManualTransformBuilder(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_clone_manual_transform_builder() {
+        let original = dltbc2_new_ManualTransformBuilder();
+        assert!(!original.is_null());
+
+        unsafe {
+            // Configure the original builder
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(original, YCoCgVariant::Variant1);
+            dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(original, true);
+
+            // Clone the builder
+            let cloned = dltbc2_clone_ManualTransformBuilder(original);
+            assert!(!cloned.is_null());
+
+            // Both builders should work independently
+            let test_data = create_test_bc2_data();
+            let mut output1 = vec![0u8; test_data.len()];
+            let mut output2 = vec![0u8; test_data.len()];
+
+            let result1 = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output1.as_mut_ptr(),
+                output1.len(),
+                original,
+            );
+            assert_eq!(result1.error_code, Dltbc2ErrorCode::Success);
+
+            let result2 = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output2.as_mut_ptr(),
+                output2.len(),
+                cloned,
+            );
+            assert_eq!(result2.error_code, Dltbc2ErrorCode::Success);
+
+            // Outputs should be identical since both builders have same settings
+            assert_eq!(output1, output2);
+
+            // Clean up
+            dltbc2_free_ManualTransformBuilder(original);
+            dltbc2_free_ManualTransformBuilder(cloned);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_clone_manual_transform_builder_null_pointer() {
+        unsafe {
+            let cloned = dltbc2_clone_ManualTransformBuilder(ptr::null());
+            assert!(cloned.is_null());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_set_decorrelation_mode() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        unsafe {
+            // Should not crash with valid builder
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCoCgVariant::Variant1);
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCoCgVariant::Variant2);
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCoCgVariant::Variant3);
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCoCgVariant::None);
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_set_decorrelation_mode_null_pointer() {
+        unsafe {
+            // Should not crash with null pointer
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(
+                ptr::null_mut(),
+                YCoCgVariant::Variant1,
+            );
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_set_split_colour_endpoints() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        unsafe {
+            // Should not crash with valid builder
+            dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(builder, true);
+            dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(builder, false);
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_set_split_colour_endpoints_null_pointer() {
+        unsafe {
+            // Should not crash with null pointer
+            dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(ptr::null_mut(), true);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_reset_to_defaults() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        unsafe {
+            // Configure with non-default settings
+            dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCoCgVariant::Variant1);
+            dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(builder, true);
+
+            // Reset to defaults
+            dltbc2_ManualTransformBuilder_ResetToDefaults(builder);
+
+            // Should still be usable after reset
+            let test_data = create_test_bc2_data();
+            let mut output = vec![0u8; test_data.len()];
+
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                builder,
+            );
+            assert_eq!(result.error_code, Dltbc2ErrorCode::Success);
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_reset_to_defaults_null_pointer() {
+        unsafe {
+            // Should not crash with null pointer
+            dltbc2_ManualTransformBuilder_ResetToDefaults(ptr::null_mut());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_transform_basic() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len()];
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::Success);
+            assert!(result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_transform_null_input() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let mut output = vec![0u8; 16];
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                ptr::null(),
+                16,
+                output.as_mut_ptr(),
+                output.len(),
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullDataPointer);
+            assert!(!result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_transform_null_output() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = create_test_bc2_data();
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                ptr::null_mut(),
+                16,
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullOutputBufferPointer);
+            assert!(!result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_transform_null_builder() {
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len()];
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                ptr::null_mut(),
+            );
+
+            assert_eq!(
+                result.error_code,
+                Dltbc2ErrorCode::NullManualTransformBuilderPointer
+            );
+            assert!(!result.is_success());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_transform_invalid_length() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = [0u8; 15]; // Not divisible by 16
+        let mut output = vec![0u8; 15];
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::InvalidLength);
+            assert!(!result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_transform_output_too_small() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len() - 1]; // Too small
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::OutputBufferTooSmall);
+            assert!(!result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_untransform_basic() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = create_test_bc2_data();
+        let mut transformed = vec![0u8; test_data.len()];
+        let mut restored = vec![0u8; test_data.len()];
+
+        unsafe {
+            // Transform
+            let result1 = dltbc2_ManualTransformBuilder_Transform(
+                test_data.as_ptr(),
+                test_data.len(),
+                transformed.as_mut_ptr(),
+                transformed.len(),
+                builder,
+            );
+            assert_eq!(result1.error_code, Dltbc2ErrorCode::Success);
+
+            // Untransform
+            let result2 = dltbc2_ManualTransformBuilder_Untransform(
+                transformed.as_ptr(),
+                transformed.len(),
+                restored.as_mut_ptr(),
+                restored.len(),
+                builder,
+            );
+            assert_eq!(result2.error_code, Dltbc2ErrorCode::Success);
+            assert!(result2.is_success());
+
+            // Should restore original data
+            assert_eq!(restored, test_data);
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_untransform_null_input() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let mut output = vec![0u8; 16];
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Untransform(
+                ptr::null(),
+                16,
+                output.as_mut_ptr(),
+                output.len(),
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullDataPointer);
+            assert!(!result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_untransform_null_output() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = create_test_bc2_data();
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Untransform(
+                test_data.as_ptr(),
+                test_data.len(),
+                ptr::null_mut(),
+                16,
+                builder,
+            );
+
+            assert_eq!(result.error_code, Dltbc2ErrorCode::NullOutputBufferPointer);
+            assert!(!result.is_success());
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_untransform_null_builder() {
+        let test_data = create_test_bc2_data();
+        let mut output = vec![0u8; test_data.len()];
+
+        unsafe {
+            let result = dltbc2_ManualTransformBuilder_Untransform(
+                test_data.as_ptr(),
+                test_data.len(),
+                output.as_mut_ptr(),
+                output.len(),
+                ptr::null_mut(),
+            );
+
+            assert_eq!(
+                result.error_code,
+                Dltbc2ErrorCode::NullManualTransformBuilderPointer
+            );
+            assert!(!result.is_success());
+        }
+    }
+
+    #[test]
+    fn test_dltbc2_manual_transform_builder_round_trip_with_settings() {
+        let builder = dltbc2_new_ManualTransformBuilder();
+        assert!(!builder.is_null());
+
+        let test_data = create_test_bc2_data();
+
+        unsafe {
+            // Test different decorrelation modes
+            for variant in [
+                YCoCgVariant::None,
+                YCoCgVariant::Variant1,
+                YCoCgVariant::Variant2,
+                YCoCgVariant::Variant3,
+            ] {
+                for split_colours in [false, true] {
+                    // Configure builder
+                    dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, variant);
+                    dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(builder, split_colours);
+
+                    let mut transformed = vec![0u8; test_data.len()];
+                    let mut restored = vec![0u8; test_data.len()];
+
+                    // Transform
+                    let result1 = dltbc2_ManualTransformBuilder_Transform(
+                        test_data.as_ptr(),
+                        test_data.len(),
+                        transformed.as_mut_ptr(),
+                        transformed.len(),
+                        builder,
+                    );
+                    assert_eq!(
+                        result1.error_code,
+                        Dltbc2ErrorCode::Success,
+                        "Transform failed for variant {variant:?}, split_colours {split_colours}",
+                    );
+
+                    // Untransform
+                    let result2 = dltbc2_ManualTransformBuilder_Untransform(
+                        transformed.as_ptr(),
+                        transformed.len(),
+                        restored.as_mut_ptr(),
+                        restored.len(),
+                        builder,
+                    );
+                    assert_eq!(
+                        result2.error_code,
+                        Dltbc2ErrorCode::Success,
+                        "Untransform failed for variant {variant:?}, split_colours {split_colours}",
+                    );
+
+                    // Should restore original data
+                    assert_eq!(
+                        restored, test_data,
+                        "Round-trip failed for variant {variant:?}, split_colours {split_colours}",
+                    );
+                }
+            }
+
+            dltbc2_free_ManualTransformBuilder(builder);
+        }
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/c_api/transform/mod.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/c_api/transform/mod.rs
@@ -1,0 +1,72 @@
+//! C API bindings for BC2 transform operations.
+//!
+//! This module provides C-compatible FFI exports for BC2 transform functionality with a focus
+//! on ABI stability and ease of use from C/C++ code. The API is designed to closely mirror
+//! the Rust API structure while providing C-compatible interfaces.
+//!
+//! ## API Structure
+//!
+//! ### Manual Transform Builder
+//! - [`manual_transform_builder::Dltbc2ManualTransformBuilder`] - Direct equivalent of Rust's [`crate::Bc2ManualTransformBuilder`]
+//! - Allows precise control over transform parameters like decorrelation mode and color endpoint splitting
+//! - Use when you know the optimal settings for your use case
+//!
+//! ### Auto Transform Builder  
+//! - [`auto_transform_builder::Dltbc2AutoTransformBuilder`] - Direct equivalent of Rust's [`crate::Bc2AutoTransformBuilder`]
+//! - Automatically finds optimal transform settings using a size estimator
+//! - [`dltbc2_AutoTransformBuilder_Transform`] returns a configured manual builder (like Rust API)
+//!
+//! [`dltbc2_AutoTransformBuilder_Transform`]: crate::c_api::transform::auto_transform_builder::dltbc2_AutoTransformBuilder_Transform
+//!
+//! ## Usage Patterns
+//!
+//! ### Pattern 1: Auto Transform
+//! ```c
+//! // Create auto builder and configure
+//! Dltbc2AutoTransformBuilder* auto_builder = dltbc2_new_AutoTransformBuilder(estimator);
+//! dltbc2_AutoTransformBuilder_SetUseAllDecorrelationModes(auto_builder, false);
+//!
+//! // Transform and get configured manual builder
+//! Dltbc2ManualTransformBuilder* manual_builder =
+//!     dltbc2_AutoTransformBuilder_Transform(
+//!         auto_builder, data, data_len, output, output_len);
+//!
+//! // Use manual builder for untransformation
+//! dltbc2_ManualTransformBuilder_Untransform(/*...*/);
+//!
+//! // Cleanup
+//! dltbc2_free_ManualTransformBuilder(manual_builder);
+//! dltbc2_free_AutoTransformBuilder(auto_builder);
+//! ```
+//!
+//! ### Pattern 2: Manual Transform
+//! ```c
+//! // Create and configure manual builder
+//! Dltbc2ManualTransformBuilder* builder = dltbc2_new_ManualTransformBuilder();
+//! dltbc2_ManualTransformBuilder_SetDecorrelationMode(builder, YCOCG_VARIANT_1);
+//! dltbc2_ManualTransformBuilder_SetSplitColourEndpoints(builder, true);
+//!
+//! // Transform and untransform
+//! dltbc2_ManualTransformBuilder_Transform(/*...*/);
+//! dltbc2_ManualTransformBuilder_Untransform(/*...*/);
+//!
+//! // Cleanup
+//! dltbc2_free_ManualTransformBuilder(builder);
+//! ```
+//!
+//! ## Builder Modules (ABI-Stable)
+//!
+//! - [`auto_transform_builder`] - Builder pattern for automatic optimization settings
+//! - [`manual_transform_builder`] - Builder pattern for manual transform configuration
+//!
+//! ## Unstable Functions (ABI-Unstable)
+//!
+//! For advanced users requiring maximum performance, unstable functions are available
+//! in the core crate at `dxt_lossless_transform_bc2::c_api`. These functions may have
+//! breaking changes between versions without major version bumps.
+//!
+//! **Production code should use the ABI-stable builder patterns above.**
+
+// Builder modules (stable, recommended)
+pub mod auto_transform_builder;
+pub mod manual_transform_builder;

--- a/projects/api/dxt-lossless-transform-bc2-api/src/error.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/error.rs
@@ -1,0 +1,68 @@
+//! Error types for BC2 transform operations.
+
+use alloc::string::String;
+use dxt_lossless_transform_bc2::{
+    Bc2AutoTransformError, Bc2ValidationError, DetermineBestTransformError,
+};
+use thiserror::Error;
+
+/// Errors that can occur during BC2 transform operations.
+#[derive(Debug, Error)]
+pub enum Bc2Error<E = String>
+where
+    E: core::fmt::Debug,
+{
+    /// The input data length is invalid (must be divisible by 16).
+    #[error("Invalid input length: {0} bytes. Length must be divisible by 16 (BC2 block size).")]
+    InvalidLength(usize),
+
+    /// The output buffer is too small for the operation.
+    #[error("Output buffer too small: need {needed} bytes, but only {actual} bytes available.")]
+    OutputBufferTooSmall {
+        /// The required size in bytes
+        needed: usize,
+        /// The actual size in bytes  
+        actual: usize,
+    },
+
+    /// Memory allocation failed.
+    #[error("Memory allocation failed")]
+    AllocationFailed,
+
+    /// Size estimation failed during transform optimization.
+    #[error("Size estimation failed: {0:?}")]
+    SizeEstimationFailed(E),
+}
+
+// Internal conversion functions to avoid exposing core types in public From traits
+// The types below are unstable, but ours have to be stable.
+impl<E> Bc2Error<E>
+where
+    E: core::fmt::Debug,
+{
+    /// Convert from core validation error (internal use only)
+    pub(crate) fn from_validation_error(err: Bc2ValidationError) -> Self {
+        match err {
+            Bc2ValidationError::InvalidLength(len) => Bc2Error::InvalidLength(len),
+            Bc2ValidationError::OutputBufferTooSmall { needed, actual } => {
+                Bc2Error::OutputBufferTooSmall { needed, actual }
+            }
+        }
+    }
+
+    /// Convert from core auto transform error (internal use only)
+    pub(crate) fn from_auto_transform_error(err: Bc2AutoTransformError<E>) -> Self {
+        match err {
+            Bc2AutoTransformError::InvalidLength(len) => Bc2Error::InvalidLength(len),
+            Bc2AutoTransformError::OutputBufferTooSmall { needed, actual } => {
+                Bc2Error::OutputBufferTooSmall { needed, actual }
+            }
+            Bc2AutoTransformError::DetermineBestTransform(transform_err) => match transform_err {
+                DetermineBestTransformError::AllocateError(_) => Bc2Error::AllocationFailed,
+                DetermineBestTransformError::SizeEstimationError(est_err) => {
+                    Bc2Error::SizeEstimationFailed(est_err)
+                }
+            },
+        }
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/lib.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/lib.rs
@@ -1,1 +1,26 @@
+#![doc = include_str!("../README.MD")]
+#![no_std]
+#![warn(missing_docs)]
 
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(test)]
+pub mod test_prelude;
+
+// Module declarations
+pub mod error;
+pub mod transform;
+
+#[cfg(feature = "c-exports")]
+pub mod c_api;
+
+// Re-export main functionality at crate root
+pub use error::Bc2Error;
+
+// Re-export BUILDERS (stable, recommended)
+pub use transform::{Bc2AutoTransformBuilder, Bc2ManualTransformBuilder};
+
+// Re-export only essential types (YCoCgVariant for builder configuration)
+pub use transform::YCoCgVariant;

--- a/projects/api/dxt-lossless-transform-bc2-api/src/test_prelude.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/test_prelude.rs
@@ -1,0 +1,21 @@
+//! Common test imports and utilities for BC2 API tests
+//!
+//! This module provides a common prelude for test modules to avoid
+//! duplicate imports across the codebase.
+#![allow(unused_imports)]
+
+// External crate declaration for no_std compatibility
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+// Re-export commonly used alloc types for tests
+pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
+
+// Re-export std items for tests that need them
+pub use std::{ffi::c_void, is_x86_feature_detected, ptr};
+
+// External crates commonly used in API tests
+#[cfg(feature = "c-exports")]
+pub use dxt_lossless_transform_api_common::c_api::size_estimation::DltSizeEstimator;
+pub use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;

--- a/projects/api/dxt-lossless-transform-bc2-api/src/transform/auto_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/transform/auto_transform_builder.rs
@@ -1,0 +1,209 @@
+//! Builder pattern implementation for BC2 automatic transform optimization.
+
+use super::YCoCgVariant;
+use crate::{Bc2Error, Bc2ManualTransformBuilder};
+use dxt_lossless_transform_api_common::estimate::SizeEstimationOperations;
+use dxt_lossless_transform_bc2::{Bc2EstimateSettings, transform_bc2_auto_safe};
+
+/// Automatic BC2 transform optimization builder.
+///
+/// Uses a size estimator to automatically determine the best transform settings
+/// for optimal compression. Ideal when you want the best compression without
+/// manual tuning.
+///
+/// For manual control over transform parameters, use [`crate::Bc2ManualTransformBuilder`].
+pub struct Bc2AutoTransformBuilder<T>
+where
+    T: SizeEstimationOperations,
+{
+    settings: Bc2EstimateSettings<T>,
+}
+
+impl<T> Bc2AutoTransformBuilder<T>
+where
+    T: SizeEstimationOperations,
+{
+    /// Create a new automatic transform builder with the provided estimator.
+    ///
+    /// The estimator should have its compression level and other parameters already configured.
+    /// This allows for more flexible usage patterns where different estimators can have
+    /// completely different configuration approaches.
+    ///
+    /// # Parameters
+    /// - `estimator`: The size estimator to use for finding the best possible transform.
+    ///   This will test different transform configurations and choose the one that results
+    ///   in the smallest estimated compressed size according to this estimator.
+    pub fn new(estimator: T) -> Self {
+        Self {
+            settings: Bc2EstimateSettings {
+                size_estimator: estimator,
+                use_all_decorrelation_modes: false, // Default value
+            },
+        }
+    }
+
+    /// Create a new automatic transform builder with the provided estimator.
+    ///
+    /// This is a variant of [`Self::new`] that is preconfigured with the settings that
+    /// maximize compression at the cost of (much) slower optimization time.
+    ///
+    /// You should use [`Self::new`] under most cases; the gains here are typically
+    /// less than 0.1% in practice (negligible).
+    ///
+    /// # Parameters
+    /// - `estimator`: The size estimator to use for finding the best possible transform.
+    ///   This will test different transform configurations and choose the one that results
+    ///   in the smallest estimated compressed size according to this estimator.
+    pub fn new_ultra(estimator: T) -> Self {
+        Self {
+            settings: Bc2EstimateSettings {
+                size_estimator: estimator,
+                use_all_decorrelation_modes: true,
+            },
+        }
+    }
+
+    /// Set whether to use all decorrelation modes.
+    ///
+    /// When `false` (default), only tests common configurations for faster optimization.
+    /// When `true`, tests all decorrelation modes for potentially better compression
+    /// at the cost of twice as long optimization time.
+    ///
+    /// **Note**: The typical improvement from testing all decorrelation modes is <0.1% in practice.
+    /// For better compression gains, it's recommended to use a compression level on the
+    /// estimator (e.g., ZStandard estimator) closer to your final compression level instead.
+    pub fn use_all_decorrelation_modes(mut self, use_all: bool) -> Self {
+        self.settings.use_all_decorrelation_modes = use_all;
+        self
+    }
+
+    /// Transform BC2 data with automatically optimized settings and return a builder for untransformation.
+    ///
+    /// This method determines the best transform settings using the configured estimator,
+    /// applies the transformation to the input data, and returns a pre-configured
+    /// [`Bc2ManualTransformBuilder`] that can be used to untransform the data later.
+    ///
+    /// # Parameters
+    /// - `input`: The BC2 data to transform
+    /// - `output`: The output buffer where transformed data will be written
+    ///
+    /// # Returns
+    /// A [`Bc2ManualTransformBuilder`] configured with the optimal settings used for transformation.
+    ///
+    /// # Errors
+    /// Returns [`Bc2Error`] if the optimization or transformation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_bc2_api::Bc2AutoTransformBuilder;
+    /// use dxt_lossless_transform_ltu::LosslessTransformUtilsSizeEstimation;
+    /// # use dxt_lossless_transform_bc2_api::Bc2Error;
+    /// # use dxt_lossless_transform_ltu::LosslessTransformUtilsError;
+    ///
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let bc2_data = vec![0u8; 16]; // 1 BC2 block
+    /// let mut transformed = vec![0u8; 16];
+    /// let mut restored = vec![0u8; 16];
+    ///
+    /// // Create LTU estimator for fast size estimation
+    /// let estimator = LosslessTransformUtilsSizeEstimation::new();
+    ///
+    /// // Transform with optimal settings and get builder for untransformation
+    /// let untransform_builder = Bc2AutoTransformBuilder::new(estimator)
+    ///     .use_all_decorrelation_modes(false)
+    ///     .transform(&bc2_data, &mut transformed)?;
+    ///
+    /// // Later, untransform using the returned builder
+    /// untransform_builder.untransform(&transformed, &mut restored)?;
+    /// # assert_eq!(bc2_data, restored); // Verify round-trip works
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn transform(
+        &self,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<Bc2ManualTransformBuilder, Bc2Error<T::Error>>
+    where
+        T::Error: core::fmt::Debug,
+    {
+        // Use the configured settings directly
+        let optimal_settings = transform_bc2_auto_safe(input, output, &self.settings)
+            .map_err(Bc2Error::from_auto_transform_error)?;
+
+        // Return a manual builder configured with these optimal settings
+        Ok(Bc2ManualTransformBuilder::new()
+            .decorrelation_mode(YCoCgVariant::from_internal_variant(
+                optimal_settings.decorrelation_mode,
+            ))
+            .split_colour_endpoints(optimal_settings.split_colour_endpoints))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dxt_lossless_transform_api_common::estimate::SizeEstimationOperations;
+
+    /// Dummy estimator for testing
+    struct DummyEstimator;
+
+    impl SizeEstimationOperations for DummyEstimator {
+        type Error = &'static str;
+
+        fn max_compressed_size(&self, _len_bytes: usize) -> Result<usize, Self::Error> {
+            Ok(0)
+        }
+
+        unsafe fn estimate_compressed_size(
+            &self,
+            _input_ptr: *const u8,
+            len_bytes: usize,
+            _output_ptr: *mut u8,
+            _output_len: usize,
+        ) -> Result<usize, Self::Error> {
+            Ok(len_bytes)
+        }
+    }
+
+    #[test]
+    fn test_auto_transform_builder_transform() {
+        // Create minimal BC2 block data (16 bytes per block)
+        let bc2_data = [
+            // Alpha data (8 bytes - 4-bit per pixel)
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            // Color data (8 bytes - BC1-like)
+            0x00, 0xF8, // Color0: Red in RGB565 (0xF800)
+            0x00, 0x00, // Color1: Black (0x0000)
+            0x00, 0x00, 0x00, 0x00, // Indices: all pointing to Color0
+        ];
+        let mut transformed = [0u8; 16];
+
+        let result = Bc2AutoTransformBuilder::new(DummyEstimator)
+            .use_all_decorrelation_modes(false)
+            .transform(&bc2_data, &mut transformed);
+
+        assert!(
+            result.is_ok(),
+            "transform should not fail with valid BC2 data"
+        );
+
+        // Verify we can use the returned builder for untransformation
+        let untransform_builder = result.unwrap();
+        let mut restored = [0u8; 16];
+        let untransform_result = untransform_builder.untransform(&transformed, &mut restored);
+        assert!(untransform_result.is_ok(), "untransform should succeed");
+    }
+
+    #[test]
+    fn test_auto_transform_builder_construction() {
+        // Test that builder can be constructed with an estimator
+        let _builder = Bc2AutoTransformBuilder::new(DummyEstimator);
+
+        // Test builder method chaining
+        let _builder_with_options = Bc2AutoTransformBuilder::new(DummyEstimator)
+            .use_all_decorrelation_modes(true)
+            .use_all_decorrelation_modes(false);
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/transform/manual_transform_builder.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/transform/manual_transform_builder.rs
@@ -1,0 +1,224 @@
+//! Builder pattern implementation for BC2 manual transform configuration.
+
+use super::YCoCgVariant;
+use crate::Bc2Error;
+use dxt_lossless_transform_bc2::{
+    Bc2TransformSettings, Bc2UntransformSettings, transform_bc2_with_settings_safe,
+    untransform_bc2_with_settings_safe,
+};
+
+/// Manual BC2 transform configuration builder.
+///
+/// Allows precise control over transform parameters like decorrelation mode
+/// and color endpoint splitting. Ideal when you know what settings work
+/// best for your specific use case.
+///
+/// For automatic optimization, use [`crate::Bc2AutoTransformBuilder`].
+#[derive(Debug, Clone, Copy)]
+pub struct Bc2ManualTransformBuilder {
+    settings: Bc2TransformSettings,
+}
+
+impl Bc2ManualTransformBuilder {
+    /// Create a new manual transform builder.
+    pub fn new() -> Self {
+        Self {
+            settings: Bc2TransformSettings::default(),
+        }
+    }
+
+    /// Get the current transform settings.
+    ///
+    /// **Internal API**: This method exposes internal transform settings from the unstable core crate.
+    /// This is not intended for public use and may change or be removed in future versions.
+    ///
+    /// Returns a copy of the current transform settings configured on this builder.
+    #[doc(hidden)]
+    pub fn get_settings(&self) -> Bc2TransformSettings {
+        self.settings
+    }
+
+    /// Set the decorrelation mode.
+    ///
+    /// Controls the YCoCg-R color space decorrelation variant used for transformation.
+    /// Different variants can provide varying compression ratios depending on the texture content.
+    ///
+    /// **Note**: When manually testing decorrelation modes, the typical improvement from
+    /// using different variants is <0.1% in practice. For better compression gains,
+    /// it's recommended to use a compression level on the estimator (e.g., ZStandard estimator)
+    /// closer to your final compression level instead.
+    ///
+    /// For automatic optimization, consider using [`crate::Bc2AutoTransformBuilder`] instead.
+    pub fn decorrelation_mode(mut self, mode: YCoCgVariant) -> Self {
+        self.settings.decorrelation_mode = mode.to_internal_variant();
+        self
+    }
+
+    /// Set whether to split colour endpoints.
+    ///
+    /// This setting controls whether BC2 texture color endpoints are separated during processing,
+    /// which can improve compression efficiency for many textures.
+    ///
+    /// **File Size**: This setting reduces file size around 78% of the time.
+    ///
+    /// For automatic optimization, consider using [`crate::Bc2AutoTransformBuilder`] instead.
+    pub fn split_colour_endpoints(mut self, split: bool) -> Self {
+        self.settings.split_colour_endpoints = split;
+        self
+    }
+
+    /// Transform BC2 data using the configured settings.
+    ///
+    /// # Parameters
+    /// - `input`: The BC2 data to transform
+    /// - `output`: The output buffer where transformed data will be written
+    ///
+    /// # Returns
+    /// Ok(()) on success, or an error on failure.
+    ///
+    /// # Errors
+    /// Returns [`Bc2Error`] if the transformation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_bc2_api::{Bc2ManualTransformBuilder, YCoCgVariant};
+    /// # use dxt_lossless_transform_bc2_api::Bc2Error;
+    ///
+    /// # fn main() -> Result<(), Bc2Error> {
+    /// let bc2_data = vec![0u8; 16]; // 1 BC2 block
+    /// let mut transformed = vec![0u8; 16];
+    /// let mut restored = vec![0u8; 16];
+    ///
+    /// let builder = Bc2ManualTransformBuilder::new()
+    ///     .decorrelation_mode(YCoCgVariant::Variant1)
+    ///     .split_colour_endpoints(true);
+    ///
+    /// // Transform
+    /// builder.transform(&bc2_data, &mut transformed)?;
+    ///
+    /// // Later, untransform with the same builder
+    /// builder.untransform(&transformed, &mut restored)?;
+    /// # assert_eq!(bc2_data, restored); // Verify round-trip works
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn transform(&self, input: &[u8], output: &mut [u8]) -> Result<(), Bc2Error> {
+        transform_bc2_with_settings_safe(input, output, self.settings)
+            .map_err(Bc2Error::from_validation_error)
+    }
+
+    /// Untransform BC2 data using the configured settings.
+    ///
+    /// This method reverses the transformation applied by [`transform`](Self::transform),
+    /// using the same configuration that was used for the original transformation.
+    ///
+    /// # Parameters
+    /// - `input`: The transformed BC2 data to untransform
+    /// - `output`: The output buffer where original BC2 data will be written
+    ///
+    /// # Returns
+    /// Ok(()) on success, or an error on failure.
+    ///
+    /// # Errors
+    /// Returns [`Bc2Error`] if the untransformation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use dxt_lossless_transform_bc2_api::{Bc2ManualTransformBuilder, YCoCgVariant};
+    /// # use dxt_lossless_transform_bc2_api::Bc2Error;
+    ///
+    /// # fn main() -> Result<(), Bc2Error> {
+    /// let transformed_data = vec![0u8; 16]; // 1 transformed BC2 block
+    /// let mut output = vec![0u8; 16];
+    ///
+    /// let builder = Bc2ManualTransformBuilder::new()
+    ///     .decorrelation_mode(YCoCgVariant::Variant1)
+    ///     .split_colour_endpoints(true);
+    ///
+    /// builder.untransform(&transformed_data, &mut output)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn untransform(&self, input: &[u8], output: &mut [u8]) -> Result<(), Bc2Error> {
+        let untransform_settings: Bc2UntransformSettings = self.settings;
+        untransform_bc2_with_settings_safe(input, output, untransform_settings)
+            .map_err(Bc2Error::from_validation_error)
+    }
+}
+
+impl Default for Bc2ManualTransformBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_manual_transform_builder_transform() {
+        // Create minimal BC2 block data (16 bytes per block)
+        let bc2_data = [
+            // Alpha data (8 bytes - 4-bit per pixel)
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            // Color data (8 bytes - BC1-like)
+            0x00, 0xF8, // Color0: Red in RGB565 (0xF800)
+            0x00, 0x00, // Color1: Black (0x0000)
+            0x00, 0x00, 0x00, 0x00, // Indices: all pointing to Color0
+        ];
+        let mut output = [0u8; 16];
+
+        let builder = Bc2ManualTransformBuilder::new()
+            .decorrelation_mode(YCoCgVariant::Variant1)
+            .split_colour_endpoints(true);
+
+        let result = builder.transform(&bc2_data, &mut output);
+
+        assert!(
+            result.is_ok(),
+            "transform should not fail with valid BC2 data"
+        );
+    }
+
+    #[test]
+    fn test_manual_transform_builder_round_trip() {
+        // First transform some data
+        let bc2_data = [
+            // Alpha data (8 bytes - 4-bit per pixel)
+            0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+            // Color data (8 bytes - BC1-like)
+            0x00, 0xF8, // Color0: Red in RGB565 (0xF800)
+            0x00, 0x00, // Color1: Black (0x0000)
+            0x00, 0x00, 0x00, 0x00, // Indices: all pointing to Color0
+        ];
+        let mut transformed = [0u8; 16];
+        let mut restored = [0u8; 16];
+
+        let builder = Bc2ManualTransformBuilder::new()
+            .decorrelation_mode(YCoCgVariant::Variant1)
+            .split_colour_endpoints(true);
+
+        // Transform
+        let transform_result = builder.transform(&bc2_data, &mut transformed);
+        assert!(
+            transform_result.is_ok(),
+            "Transform should not fail with valid BC2 data"
+        );
+
+        // Untransform with same settings
+        let untransform_result = builder.untransform(&transformed, &mut restored);
+        assert!(
+            untransform_result.is_ok(),
+            "Untransform should not fail with valid transformed data"
+        );
+
+        // Verify round-trip
+        assert_eq!(
+            bc2_data, restored,
+            "Round-trip transform/untransform should restore original data"
+        );
+    }
+}

--- a/projects/api/dxt-lossless-transform-bc2-api/src/transform/mod.rs
+++ b/projects/api/dxt-lossless-transform-bc2-api/src/transform/mod.rs
@@ -1,0 +1,25 @@
+//! BC2 Transform API
+//!
+//! This module provides high-level builders for BC2 texture transformation:
+//!
+//! ## Automatic Optimization
+//! - [`Bc2AutoTransformBuilder`] - Automatically finds the best transform settings by testing different configurations and choosing the one that results in the smallest estimated compressed size
+//!
+//! ## Manual Configuration  
+//! - [`Bc2ManualTransformBuilder`] - Allows precise control over transform parameters
+//!
+//! ## Clean API Design
+//! The API uses builders that provide a clean interface while using internal types from the core crate directly.
+//!
+//! ## Block Size Note
+//! BC2 blocks are 16 bytes (8 bytes alpha + 8 bytes color data), unlike BC1 which uses 8 bytes per block.
+
+pub(crate) mod auto_transform_builder;
+pub(crate) mod manual_transform_builder;
+
+// Re-export the builders
+pub use auto_transform_builder::Bc2AutoTransformBuilder;
+pub use manual_transform_builder::Bc2ManualTransformBuilder;
+
+// Re-export stable API types for configuration
+pub use dxt_lossless_transform_api_common::reexports::color_565::YCoCgVariant;

--- a/projects/extensions/estimators/dxt-lossless-transform-ltu/src/c_api.rs
+++ b/projects/extensions/estimators/dxt-lossless-transform-ltu/src/c_api.rs
@@ -167,7 +167,11 @@ fn create_c_size_estimator(ltu: Box<LosslessTransformUtilsSizeEstimation>) -> Dl
 /// let bc1_estimate_builder = unsafe { dltbc1_new_EstimateOptionsBuilder() };
 ///
 /// // Your BC1 texture data (8 bytes per BC1 block)
-/// let bc1_data = [0x12, 0x34, 0x56, 0x78, 0x9A, 0xBC, 0xDE, 0xF0];
+/// let bc1_data = [
+///     0x12, 0x34,                                      // Color0 (RGB565)
+///     0x56, 0x78,                                      // Color1 (RGB565)
+///     0x9A, 0xBC, 0xDE, 0xF0                           // Color indices (4 bytes)
+/// ];
 ///
 /// // Determine optimal settings using LTU for fast estimation
 /// let result = unsafe {


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a C-compatible API for BC2 texture transform operations, including manual and automatic transform builders, with robust error handling and stable ABI for C/C++ integration.
  * Added support for configuring transform parameters such as decorrelation mode and color endpoint splitting, and for automatic optimization using a size estimator.
  * Provided comprehensive error codes and error message retrieval for C consumers.

* **Documentation**
  * Improved and expanded C API documentation and example code, including clearer byte array formatting and detailed usage instructions for both BC1 and BC2 APIs.

* **Chores**
  * Added internal test utilities and module organization to support maintainability and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->