### PR TITLE
Added: Dds file length and pixel format support

### DIFF
--- a/.claude/commands/generate-prp.md
+++ b/.claude/commands/generate-prp.md
@@ -51,6 +51,9 @@ cargo check --all-features
 
 # Unit Tests
 cargo test --all-features
+
+# Big Endian Testing (if cross is available)
+cross test --package dxt-lossless-transform-dds --target powerpc64-unknown-linux-gnu
 ```
 
 *** CRITICAL AFTER YOU ARE DONE RESEARCHING AND EXPLORING THE CODEBASE BEFORE YOU START WRITING THE PRP ***

--- a/.claude/prp/templates/prp_base.md
+++ b/.claude/prp/templates/prp_base.md
@@ -199,6 +199,7 @@ cargo test test_new_feature -- --nocapture  # For specific test with output
 - [ ] No compilation errors: `cargo check`
 - [ ] Documentation builds: `cargo doc`
 - [ ] Code is formatted: `cargo fmt`
+- [ ] Big endian testing passes (if `cross` is available): `cross test --package dxt-lossless-transform-dds --target powerpc64-unknown-linux-gnu`
 - [ ] Manual test successful: [specific cargo run command]
 - [ ] Error cases handled gracefully with proper Result types
 - [ ] Safety documentation complete for unsafe code

--- a/.cursor/rules/default.mdc
+++ b/.cursor/rules/default.mdc
@@ -92,6 +92,7 @@ When building the `dxt-lossless-transform-cli` project, enable all features exce
 2. **Check Lints**: Run `cargo clippy --workspace --all-features -- -D warnings` to catch any warnings or issues
 3. **Verify Documentation**: Run `cargo doc --workspace --all-features` to check for documentation errors
 4. **Fix Documentation Links**: For any broken doc links, use the proper format: `` [`function_name`]: crate::function_name `` (e.g., `` [`dltbc1_free_ManualTransformBuilder`]: crate::dltbc1_free_ManualTransformBuilder ``)
-5. **Format Code**: Run `cargo fmt --all` as the final step to ensure consistent formatting
+5. **Big Endian Testing**: If `cross` is installed, run `cross test --package dxt-lossless-transform-dds --target powerpc64-unknown-linux-gnu` to test big endian compatibility (skip if `cross` is not available)
+6. **Format Code**: Run `cargo fmt --all` as the final step to ensure consistent formatting
 
 These steps are mandatory and must be completed successfully before considering any change complete.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,3 +88,18 @@ may change between versions.
 ## Compilation
 
 When building the `dxt-lossless-transform-cli` project, enable all features except for `nightly`, unless asked.
+
+## Testing Requirements
+
+### Post-Change Verification
+
+**CRITICAL: After making any code changes, ALWAYS perform these verification steps in order:**
+
+1. **Run Tests**: Execute `cargo test --all-features` to ensure all functionality works correctly
+2. **Check Lints**: Run `cargo clippy --workspace --all-features -- -D warnings` to catch any warnings or issues
+3. **Verify Documentation**: Run `cargo doc --workspace --all-features` to check for documentation errors
+4. **Fix Documentation Links**: For any broken doc links, use the proper format: `` [`function_name`]: crate::function_name `` (e.g., `` [`dltbc1_free_ManualTransformBuilder`]: crate::dltbc1_free_ManualTransformBuilder ``)
+5. **Big Endian Testing**: If `cross` is installed, run `cross test --package dxt-lossless-transform-dds --target powerpc64-unknown-linux-gnu` to test big endian compatibility (skip if `cross` is not available)
+6. **Format Code**: Run `cargo fmt --all` as the final step to ensure consistent formatting
+
+These steps are mandatory and must be completed successfully before considering any change complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ When building the `dxt-lossless-transform-cli` project, enable all features exce
 2. **Check Lints**: Run `cargo clippy --workspace --all-features -- -D warnings` to catch any warnings or issues
 3. **Verify Documentation**: Run `cargo doc --workspace --all-features` to check for documentation errors
 4. **Fix Documentation Links**: For any broken doc links, use the proper format: `` [`function_name`]: crate::function_name `` (e.g., `` [`dltbc1_free_ManualTransformBuilder`]: crate::dltbc1_free_ManualTransformBuilder ``)
-5. **Format Code**: Run `cargo fmt --all` as the final step to ensure consistent formatting
+5. **Big Endian Testing**: If `cross` is installed, run `cross test --package dxt-lossless-transform-dds --target powerpc64-unknown-linux-gnu` to test big endian compatibility (skip if `cross` is not available)
+6. **Format Code**: Run `cargo fmt --all` as the final step to ensure consistent formatting
 
 These steps are mandatory and must be completed successfully before considering any change complete.
 

--- a/projects/api/dxt-lossless-transform-file-formats-api/Cargo.toml
+++ b/projects/api/dxt-lossless-transform-file-formats-api/Cargo.toml
@@ -60,6 +60,7 @@ lightweight-mmap = { version = "0.7.0", optional = true }
 [dev-dependencies]
 rstest = "0.25"
 tempfile = "3.8"
+endian-writer = { version = "2.2" }
 dxt-lossless-transform-dds = { workspace = true, default-features = true }
 dxt-lossless-transform-ltu = { workspace = true, default-features = true }
 dxt-lossless-transform-bc1-api = { workspace = true, default-features = true } 

--- a/projects/api/dxt-lossless-transform-file-formats-api/README.md
+++ b/projects/api/dxt-lossless-transform-file-formats-api/README.md
@@ -191,9 +191,11 @@ let bundle = TransformBundle::<LosslessTransformUtilsSizeEstimation>::new()
 
 To add support for new texture file formats, implement the handler traits.
 
-Look at `DdsHandler` from `dxt-lossless-transform-dds` crate for inspiration.
+**📖 For complete implementation guidance with step-by-step instructions, examples, and security considerations, see the [`FileFormatHandler`] trait documentation.**
 
-### Basic Handler
+Look at `DdsHandler` from `dxt-lossless-transform-dds` crate for a complete reference implementation.
+
+### Basic Handler Overview
 
 All handlers must implement [`FileFormatHandler`]:
 
@@ -214,22 +216,31 @@ impl FileFormatHandler for MyFormatHandler {
         T: SizeEstimationOperations,
         T::Error: core::fmt::Debug,
     {
-        // 0. Validate input & output buffer are large enough.
-        // 1. Parse your file format header
-        // 2. Detect BCx format (BC1, BC2, BC3, BC6H, BC7)
-        // 3. Find texture data portion
-        // 4. Call bundle.dispatch_transform() to process the texture data
-        // 5. Embed Transformheader in original file header (usually by overwriting the 'MAGIC Header')
+        // 1. Buffer Size Validation
+        // 2. Parse File Header
+        // 3. Validate Texture Data Length (CRITICAL FOR SECURITY)
+        // 4. Copy File Headers
+        // 5. Transform Texture Data
+        // 6. Preserve Leftover Data
+        // 7. Embed Transform Metadata
+        
+        // See FileFormatHandler trait documentation for complete 
+        // implementation steps with examples and security guidance
         todo!()
     }
 
     fn untransform(&self, input: &[u8], output: &mut [u8]) -> TransformResult<()> {
-        // 0. Validate input & output buffer are large enough.
-        // 1. Read the TransformHeader from the file header
-        // 2. Parse your file format header with embedded transform data
-        // 3. Extract transform details and texture data
-        // 4. Call dispatch_untransform() to restore the texture data
-        // 5. Restore original file header in output
+        // 1. Buffer Size Validation
+        // 2. Read Transform Header
+        // 3. Parse File Header (Ignoring Magic)
+        // 4. Validate Texture Data Length (CRITICAL FOR SECURITY)
+        // 5. Restore Original Magic Header
+        // 6. Copy Remaining Headers
+        // 7. Untransform Texture Data
+        // 8. Preserve Leftover Data
+        
+        // See FileFormatHandler trait documentation for complete 
+        // implementation steps with examples and security guidance
         todo!()
     }
 }

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/error.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/error.rs
@@ -19,7 +19,7 @@ pub enum FormatHandlerError {
     #[error("Unknown file format")]
     UnknownFileFormat,
 
-    /// Could not parse input file header during transform operation
+    /// Could not parse input file header during transform operation because the data is invalid/wrong.
     #[error("Invalid input file header during transform")]
     InvalidInputFileHeader,
 
@@ -42,6 +42,10 @@ pub enum FormatHandlerError {
     /// Input buffer is too short for the operation
     #[error("Input buffer too short: required at least {required} bytes, got {actual} bytes")]
     InputTooShort { required: usize, actual: usize },
+
+    /// Input buffer is too short for the texture size stated in the file header
+    #[error("Input buffer too short for stated texture size in header: required {required} bytes for texture data, got {actual} bytes")]
+    InputTooShortForStatedTextureSize { required: usize, actual: usize },
 }
 
 /// Errors that can occur during core transform operations

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/handlers/file_format_handler.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/handlers/file_format_handler.rs
@@ -18,6 +18,298 @@ use dxt_lossless_transform_api_common::estimate::SizeEstimationOperations;
 /// especially when your code may be used in web applications or other security-sensitive contexts.
 /// Such validation may be feature-gated but should be enabled by default.
 ///
+/// ## Implementation Checklist
+///
+/// Follow these steps when implementing transform and untransform operations:
+///
+/// **Reference Implementation**: See the DDS handler implementation in the `dxt-lossless-transform-dds` crate
+/// for a complete example of how to implement this trait following all the recommended patterns.
+///
+/// **Note**: While this checklist provides a general framework, some steps may vary depending on the specific
+/// file format. For example, the location of the magic header, header structure, and safety requirements
+/// for metadata embedding may differ between formats.
+///
+/// ### Transform Bundle Implementation Steps
+///
+/// ✅ **1. Buffer Size Validation**
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::*;
+///
+/// # fn example(input: &[u8], output: &mut [u8]) -> TransformResult<()> {
+/// if output.len() < input.len() {
+///     return Err(FormatHandlerError::OutputBufferTooSmall {
+///         required: input.len(),
+///         actual: output.len()
+///     }.into());
+/// }
+/// Ok(())
+/// # }
+/// ```
+///
+/// ✅ **2. Parse File Header**
+/// - Parse the original file header to extract format information
+/// - Return `FormatHandlerError::InvalidInputFileHeader` if parsing fails
+/// - Extract `data_offset` (where texture data starts) and calculate `data_length`
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::*;
+///
+/// // Example from DDS implementation approach:
+/// use dxt_lossless_transform_dds::dds::parse_dds::{DdsInfo, DdsFormat, parse_dds};
+///
+/// # fn example(input: &[u8]) -> TransformResult<DdsInfo> {
+/// // Example from DDS implementation approach:
+/// let info = parse_dds(input)
+///     .ok_or(FormatHandlerError::InvalidInputFileHeader)?;
+///
+/// let data_offset = info.data_offset as usize;
+/// let data_length = info.data_length as usize;
+///
+/// Ok(info)
+/// # }
+/// ```
+///
+/// ✅ **3. Validate Texture Data Length**
+///
+/// ⚠️ Don't blindly trust the file headers, validate there are enough bytes left in the file
+/// to contain the claimed texture data size.
+///
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::*;
+///
+/// # fn example(input: &[u8], data_offset: usize, data_length: usize) -> TransformResult<()> {
+/// let total_required = data_offset + data_length;
+/// if input.len() < total_required {
+///     return Err(FormatHandlerError::InputTooShortForStatedTextureSize {
+///         required: total_required,
+///         actual: input.len(),
+///     }.into());
+/// }
+/// Ok(())
+/// # }
+/// ```
+///
+/// ✅ **4. Copy File Headers**
+/// ```no_run
+/// # fn example(input: &[u8], output: &mut [u8], data_offset: usize) {
+/// // Copy all header data up to where texture data begins
+/// output[..data_offset].copy_from_slice(&input[..data_offset]);
+/// # }
+/// ```
+///
+/// ✅ **5. Transform Texture Data**
+/// - Convert format to transform format
+/// - Call [`crate::dispatch_transform`] with texture data only (not headers)
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::{*, embed::*};
+/// use dxt_lossless_transform_api_common::estimate::SizeEstimationOperations;
+/// use core::fmt::Debug;
+///
+/// // Example from DDS implementation approach:
+/// use dxt_lossless_transform_dds::dds::parse_dds::DdsFormat;
+///
+/// # fn example<T>(
+/// #     transform_format: TransformFormat,
+/// #     input: &[u8],
+/// #     output: &mut [u8],
+/// #     bundle: &TransformBundle<T>,
+/// #     data_offset: usize,
+/// #     data_length: usize
+/// # ) -> TransformResult<TransformHeader>
+/// # where
+/// #     T: SizeEstimationOperations,
+/// #     T::Error: Debug
+/// # {
+/// // Example from DDS implementation:
+/// let header = dispatch_transform(
+///     transform_format,
+///     &input[data_offset..data_offset + data_length],
+///     &mut output[data_offset..data_offset + data_length],
+///     bundle,
+/// )?;
+/// Ok(header)
+/// # }
+/// ```
+///
+/// **Note**: The exact format conversion logic may vary by file format.
+///
+/// ✅ **6. Preserve Leftover Data**
+///
+/// 📓 Even if the file format itself has no extra data after the raw texture data, some
+/// 'clever' programmers may try to put extra data anyway, so make sure to copy it.
+///
+/// ```no_run
+/// # fn example(input: &[u8], output: &mut [u8], data_offset: usize, data_length: usize) {
+/// // Copy any data that exists after the texture data
+/// let leftover_start = data_offset + data_length;
+/// if input.len() > leftover_start {
+///     output[leftover_start..].copy_from_slice(&input[leftover_start..]);
+/// }
+/// # }
+/// ```
+///
+/// ✅ **7. Embed Transform Metadata**
+/// - Overwrite magic header/signature with transform metadata
+/// - Use safe pointer operations with proper bounds checking
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::{*, embed::*};
+///
+/// # fn example(header: TransformHeader, output: &mut [u8]) {
+/// // Example from DDS implementation:
+/// // SAFETY: output.as_mut_ptr() is valid for writes of at least TRANSFORM_HEADER_SIZE bytes because:
+/// // 1. We validated output.len() >= input.len() above
+/// // 2. parse_dds succeeded, guaranteeing input has valid DDS structure (minimum 128 bytes)
+/// // 3. Therefore output has at least 128 bytes, which is >= TRANSFORM_HEADER_SIZE bytes required for the header
+/// unsafe {
+///     header.write_to_ptr(output.as_mut_ptr());
+/// }
+/// # }
+/// ```
+///
+/// **Note**: Safety requirements and embedding location may vary by file format.
+///
+/// ### Untransform Implementation Steps
+///
+/// ✅ **1. Buffer Size Validation**
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::{*, embed::*};
+///
+/// # fn example(input: &[u8], output: &mut [u8]) -> TransformResult<()> {
+/// if input.len() < TRANSFORM_HEADER_SIZE {
+///     return Err(FormatHandlerError::InputTooShort {
+///         required: TRANSFORM_HEADER_SIZE,
+///         actual: input.len()
+///     }.into());
+/// }
+/// if output.len() < input.len() {
+///     return Err(FormatHandlerError::OutputBufferTooSmall {
+///         required: input.len(),
+///         actual: output.len()
+///     }.into());
+/// }
+/// Ok(())
+/// # }
+/// ```
+///
+/// ✅ **2. Read Transform Header**
+/// - Extract transform metadata from the first 4 bytes
+/// - Use safe pointer operations with proper bounds checking
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::{*, embed::*};
+///
+/// # fn example(input: &[u8]) -> TransformHeader {
+/// // Example from DDS implementation:
+/// // SAFETY: input.as_ptr() is valid for reads of at least TRANSFORM_HEADER_SIZE bytes because we validated
+/// // input.len() >= TRANSFORM_HEADER_SIZE above. The input slice guarantees pointer validity.
+/// let header = unsafe { TransformHeader::read_from_ptr(input.as_ptr()) };
+/// header
+/// # }
+/// ```
+///
+/// ✅ **3. Parse File Header (Ignoring Magic)**
+/// - Parse the file header while ignoring the overwritten magic bytes
+/// - Return `FormatHandlerError::InvalidRestoredFileHeader` if parsing fails
+/// - Extract `data_offset` and calculate `data_length`
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::*;
+///
+/// // Example from DDS implementation approach:
+/// use dxt_lossless_transform_dds::dds::parse_dds::{DdsInfo, DdsFormat, parse_dds_ignore_magic};
+///
+/// # fn example(input: &[u8]) -> TransformResult<DdsInfo> {
+/// // Example from DDS implementation approach:
+/// // Parse header while ignoring the first 4 bytes (transform metadata)
+/// let info = parse_dds_ignore_magic(input)
+///     .ok_or(FormatHandlerError::InvalidRestoredFileHeader)?;
+///
+/// let data_offset = info.data_offset as usize;
+/// let data_length = info.data_length as usize;
+///
+/// Ok(info)
+/// # }
+///
+/// // Format-specific parsing function that ignores overwritten magic
+/// # fn parse_file_format_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
+/// // Skip first 4 bytes (transform metadata), validate rest of structure
+/// // This implementation is completely format-dependent
+/// #     todo!("Implement based on your file format, ignoring first 4 bytes")
+/// # }
+/// ```
+///
+/// ✅ **4. Validate Texture Data Length**
+///
+/// ⚠️ Don't blindly trust the file headers, validate there are enough bytes left in the file
+/// to contain the claimed texture data size.
+///
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::*;
+///
+/// # fn example(input: &[u8], data_offset: usize, data_length: usize) -> TransformResult<()> {
+///     let total_required = data_offset + data_length;
+///     if input.len() < total_required {
+///         return Err(FormatHandlerError::InputTooShortForStatedTextureSize {
+///             required: total_required,
+///             actual: input.len(),
+///         }.into());
+///     }
+///     Ok(())
+/// # }
+/// ```
+///
+/// ✅ **5. Restore Original Magic Header**
+/// ```no_run
+/// # fn example(output: &mut [u8]) {
+/// // Example: DDS magic header (format-specific)
+/// const ORIGINAL_MAGIC: u32 = 0x44445320; // "DDS " in little-endian
+/// output[0..4].copy_from_slice(&ORIGINAL_MAGIC.to_ne_bytes());
+/// # }
+/// ```
+///
+/// ✅ **6. Copy Remaining Headers**
+/// ```no_run
+/// # fn example(input: &[u8], output: &mut [u8], data_offset: usize) {
+/// // Copy header data from byte 4 (after magic) to where texture data begins
+/// output[4..data_offset].copy_from_slice(&input[4..data_offset]);
+/// # }
+/// ```
+///
+/// ✅ **7. Untransform Texture Data**
+/// - Call [`crate::dispatch_untransform`] with texture data only (not headers)
+/// ```no_run
+/// use dxt_lossless_transform_file_formats_api::{*, embed::*};
+///
+/// # fn example(
+/// #     header: TransformHeader,
+/// #     input: &[u8],
+/// #     output: &mut [u8],
+/// #     data_offset: usize,
+/// #     data_length: usize
+/// # ) -> TransformResult<()> {
+/// // Example from DDS implementation:
+/// dispatch_untransform(
+///     header,
+///     &input[data_offset..data_offset + data_length],
+///     &mut output[data_offset..data_offset + data_length],
+/// )?;
+/// Ok(())
+/// # }
+/// ```
+///
+/// ✅ **8. Preserve Leftover Data**
+///
+/// 📓 Even if the file format itself has no extra data after the raw texture data, some
+/// 'clever' programmers may try to put extra data anyway, so make sure to copy it, same
+/// way you did during the transform operation itself.
+///
+/// ```no_run
+/// # fn example(input: &[u8], output: &mut [u8], data_offset: usize, data_length: usize) {
+/// // Copy any data that exists after the texture data
+/// let leftover_start = data_offset + data_length;
+/// if input.len() > leftover_start {
+///     output[leftover_start..].copy_from_slice(&input[leftover_start..]);
+/// }
+/// # }
+/// ```
+///
 /// ## Header Replacement Strategy
 ///
 /// When implementing this trait, you'll need to decide what part of the file header to replace
@@ -34,11 +326,16 @@ use dxt_lossless_transform_api_common::estimate::SizeEstimationOperations;
 pub trait FileFormatHandler: Send + Sync {
     /// Transform the input buffer to output buffer using the provided transform bundle.
     ///
+    /// **Follow the complete Transform Bundle Implementation Steps documented in the trait documentation.**
+    ///
     /// The handler will:
-    /// 1. Parse the header to obtain necessary information
-    /// 2. Copy headers to output
-    /// 3. Use the appropriate builder from the bundle based on detected BCx format
-    /// 4. Embed transform details in the output header
+    /// 1. Validate buffer sizes
+    /// 2. Parse the header to obtain necessary information
+    /// 3. Validate input buffer contains sufficient data for declared texture dimensions
+    /// 4. Copy headers to output
+    /// 5. Transform texture data using the appropriate builder from the bundle
+    /// 6. Preserve any leftover data after texture data
+    /// 7. Embed transform metadata in the output header
     ///
     /// # Parameters
     ///
@@ -49,9 +346,11 @@ pub trait FileFormatHandler: Send + Sync {
     /// # Returns
     ///
     /// Ok(()) on success, or an error if:
-    /// - There's an error parsing the header (etc.)
-    /// - No appropriate builder is provided in the bundle
-    /// - Transform operation fails (e.g. invalid data, etc.)
+    /// - Output buffer is smaller than input buffer
+    /// - Invalid or corrupted file header
+    /// - Input buffer is too short for the texture dimensions declared in the header
+    /// - No appropriate builder is provided in the bundle for the detected format
+    /// - Transform operation fails (e.g. invalid texture data, etc.)
     fn transform_bundle<T>(
         &self,
         input: &[u8],
@@ -64,10 +363,17 @@ pub trait FileFormatHandler: Send + Sync {
 
     /// Untransform the input buffer to output buffer.
     ///
+    /// **Follow the complete Untransform Implementation Steps documented in the trait documentation.**
+    ///
     /// The handler will:
-    /// 1. Extract transform details from the header
-    /// 2. Restore the original file format header
-    /// 3. Dispatch to the appropriate untransform function
+    /// 1. Validate buffer sizes
+    /// 2. Read transform metadata from the header
+    /// 3. Parse the file header (ignoring overwritten magic bytes)
+    /// 4. Validate input buffer contains sufficient data for declared texture dimensions
+    /// 5. Restore the original file format magic header
+    /// 6. Copy remaining headers
+    /// 7. Untransform texture data
+    /// 8. Preserve any leftover data after texture data
     ///
     /// # Parameters
     ///
@@ -77,7 +383,10 @@ pub trait FileFormatHandler: Send + Sync {
     /// # Returns
     ///
     /// Ok(()) on success, or an error if:
-    /// - The header is invalid or corrupted
+    /// - Input buffer is too short to contain transform header
+    /// - Output buffer is smaller than input buffer
+    /// - The restored file header is invalid or corrupted
+    /// - Input buffer is too short for the texture dimensions declared in the header
     /// - Untransform operation fails
     fn untransform(&self, input: &[u8], output: &mut [u8]) -> TransformResult<()>;
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/Cargo.toml
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/Cargo.toml
@@ -27,6 +27,7 @@ debug-block-extraction = ["std", "dxt-lossless-transform-file-formats-debug"]
 [dependencies]
 dxt-lossless-transform-api-common = { workspace = true, default-features = false }
 dxt-lossless-transform-file-formats-api = { workspace = true, default-features = false }
+endian-writer = { version = "2.2" }
 
 # Optional debug dependency
 dxt-lossless-transform-file-formats-debug = { workspace = true, default-features = false, optional = true }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -1,3 +1,6 @@
+//! DDS format constants and definitions
+#![allow(dead_code)]
+
 /// Magic header for DDS files
 pub(crate) const DDS_MAGIC: u32 = 0x44445320_u32.to_be();
 
@@ -35,6 +38,64 @@ pub(crate) const DXGI_FORMAT_BC7_TYPELESS: u32 = 97_u32.to_le();
 pub(crate) const DXGI_FORMAT_BC7_UNORM: u32 = 98_u32.to_le();
 pub(crate) const DXGI_FORMAT_BC7_UNORM_SRGB: u32 = 99_u32.to_le();
 
+// Additional uncompressed DXGI formats
+pub(crate) const DXGI_FORMAT_R8G8B8A8_TYPELESS: u32 = 27_u32.to_le();
+pub(crate) const DXGI_FORMAT_R8G8B8A8_UNORM: u32 = 28_u32.to_le();
+pub(crate) const DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: u32 = 29_u32.to_le();
+pub(crate) const DXGI_FORMAT_R8G8B8A8_UINT: u32 = 30_u32.to_le();
+pub(crate) const DXGI_FORMAT_R8G8B8A8_SNORM: u32 = 31_u32.to_le();
+pub(crate) const DXGI_FORMAT_R8G8B8A8_SINT: u32 = 32_u32.to_le();
+
+pub(crate) const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87_u32.to_le();
+pub(crate) const DXGI_FORMAT_B8G8R8A8_TYPELESS: u32 = 90_u32.to_le();
+pub(crate) const DXGI_FORMAT_B8G8R8A8_UNORM_SRGB: u32 = 91_u32.to_le();
+
 // Size of the regular DDS header
 pub(crate) const DDS_HEADER_SIZE: usize = 0x80;
 pub(crate) const DX10_HEADER_SIZE: usize = 20;
+
+// DDS header field offsets for data length calculation
+pub(crate) const DDS_FLAGS_OFFSET: usize = 0x08;
+pub(crate) const DDS_HEIGHT_OFFSET: usize = 0x0C;
+pub(crate) const DDS_WIDTH_OFFSET: usize = 0x10;
+pub(crate) const DDS_MIPMAP_COUNT_OFFSET: usize = 0x1C;
+
+// DDS pixel format offsets (within the 32-byte DDSPIXELFORMAT structure at offset 0x4C)
+pub(crate) const DDS_PIXELFORMAT_OFFSET: usize = 0x4C;
+pub(crate) const DDS_PIXELFORMAT_FLAGS_OFFSET: usize = 0x50;
+pub(crate) const DDS_PIXELFORMAT_RGBBITCOUNT_OFFSET: usize = 0x58;
+
+// DDS header flags
+pub(crate) const DDSD_CAPS: u32 = 0x1;
+pub(crate) const DDSD_HEIGHT: u32 = 0x2;
+pub(crate) const DDSD_WIDTH: u32 = 0x4;
+pub(crate) const DDSD_PIXELFORMAT: u32 = 0x1000;
+pub(crate) const DDSD_LINEARSIZE: u32 = 0x80000;
+pub(crate) const DDSD_MIPMAPCOUNT: u32 = 0x20000;
+
+// DDS pixel format flags
+pub(crate) const DDPF_ALPHAPIXELS: u32 = 0x1;
+pub(crate) const DDPF_ALPHA: u32 = 0x2;
+pub(crate) const DDPF_FOURCC: u32 = 0x4;
+pub(crate) const DDPF_RGB: u32 = 0x40;
+pub(crate) const DDPF_YUV: u32 = 0x200;
+pub(crate) const DDPF_LUMINANCE: u32 = 0x20000;
+
+// DDS pixel format mask offsets (within the 32-byte DDSPIXELFORMAT structure at offset 0x4C)
+pub(crate) const DDS_PIXELFORMAT_RBITMASK_OFFSET: usize = 0x5C;
+pub(crate) const DDS_PIXELFORMAT_GBITMASK_OFFSET: usize = 0x60;
+pub(crate) const DDS_PIXELFORMAT_BBITMASK_OFFSET: usize = 0x64;
+pub(crate) const DDS_PIXELFORMAT_ABITMASK_OFFSET: usize = 0x68;
+
+// Common pixel format bit masks (verified with TexConv)
+// R8G8B8A8_UNORM: R=byte0, G=byte1, B=byte2, A=byte3 (0xAABBGGRR)
+pub(crate) const RGBA8888_RED_MASK: u32 = 0x000000FF;
+pub(crate) const RGBA8888_GREEN_MASK: u32 = 0x0000FF00;
+pub(crate) const RGBA8888_BLUE_MASK: u32 = 0x00FF0000;
+pub(crate) const RGBA8888_ALPHA_MASK: u32 = 0xFF000000;
+
+// B8G8R8A8_UNORM: R=byte2, G=byte1, B=byte0, A=byte3 (0xAAGGRRBB)
+pub(crate) const ARGB8888_RED_MASK: u32 = 0x00FF0000;
+pub(crate) const ARGB8888_GREEN_MASK: u32 = 0x0000FF00;
+pub(crate) const ARGB8888_BLUE_MASK: u32 = 0x000000FF;
+pub(crate) const ARGB8888_ALPHA_MASK: u32 = 0xFF000000;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -2,53 +2,53 @@
 #![allow(dead_code)]
 
 /// Magic header for DDS files
-pub(crate) const DDS_MAGIC: u32 = 0x44445320_u32.to_be();
+pub(crate) const DDS_MAGIC: u32 = 0x20534444; // 'DDS ' in little-endian
 
 /// Offset of the FOURCC header used in DX9 and below.
 pub(crate) const FOURCC_OFFSET: usize = 0x54;
 
-pub(crate) const FOURCC_DXT1: u32 = 0x31545844_u32.to_le(); // 'DXT1'
-pub(crate) const FOURCC_DXT2: u32 = 0x32545844_u32.to_le(); // 'DXT2'
-pub(crate) const FOURCC_DXT3: u32 = 0x33545844_u32.to_le(); // 'DXT3'
-pub(crate) const FOURCC_DXT4: u32 = 0x34545844_u32.to_le(); // 'DXT4'
-pub(crate) const FOURCC_DXT5: u32 = 0x35545844_u32.to_le(); // 'DXT5'
-pub(crate) const FOURCC_DX10: u32 = 0x30315844_u32.to_le(); // 'DX10'
+pub(crate) const FOURCC_DXT1: u32 = 0x31545844; // 'DXT1' in little-endian
+pub(crate) const FOURCC_DXT2: u32 = 0x32545844; // 'DXT2' in little-endian
+pub(crate) const FOURCC_DXT3: u32 = 0x33545844; // 'DXT3' in little-endian
+pub(crate) const FOURCC_DXT4: u32 = 0x34545844; // 'DXT4' in little-endian
+pub(crate) const FOURCC_DXT5: u32 = 0x35545844; // 'DXT5' in little-endian
+pub(crate) const FOURCC_DX10: u32 = 0x30315844; // 'DX10' in little-endian
 
 /// Offset of the DXGI format header used in DX10 and above.
 pub(crate) const DX10_FORMAT_OFFSET: usize = 0x80;
 
 // DXGI format constants for DX10 header
-pub(crate) const DXGI_FORMAT_BC1_TYPELESS: u32 = 70_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC1_UNORM: u32 = 71_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC1_UNORM_SRGB: u32 = 72_u32.to_le();
+pub(crate) const DXGI_FORMAT_BC1_TYPELESS: u32 = 70;
+pub(crate) const DXGI_FORMAT_BC1_UNORM: u32 = 71;
+pub(crate) const DXGI_FORMAT_BC1_UNORM_SRGB: u32 = 72;
 
-pub(crate) const DXGI_FORMAT_BC2_TYPELESS: u32 = 73_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC2_UNORM: u32 = 74_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC2_UNORM_SRGB: u32 = 75_u32.to_le();
+pub(crate) const DXGI_FORMAT_BC2_TYPELESS: u32 = 73;
+pub(crate) const DXGI_FORMAT_BC2_UNORM: u32 = 74;
+pub(crate) const DXGI_FORMAT_BC2_UNORM_SRGB: u32 = 75;
 
-pub(crate) const DXGI_FORMAT_BC3_TYPELESS: u32 = 76_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC3_UNORM: u32 = 77_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC3_UNORM_SRGB: u32 = 78_u32.to_le();
+pub(crate) const DXGI_FORMAT_BC3_TYPELESS: u32 = 76;
+pub(crate) const DXGI_FORMAT_BC3_UNORM: u32 = 77;
+pub(crate) const DXGI_FORMAT_BC3_UNORM_SRGB: u32 = 78;
 
-pub(crate) const DXGI_FORMAT_BC6H_TYPELESS: u32 = 94_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC6H_UF16: u32 = 95_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC6H_SF16: u32 = 96_u32.to_le();
+pub(crate) const DXGI_FORMAT_BC6H_TYPELESS: u32 = 94;
+pub(crate) const DXGI_FORMAT_BC6H_UF16: u32 = 95;
+pub(crate) const DXGI_FORMAT_BC6H_SF16: u32 = 96;
 
-pub(crate) const DXGI_FORMAT_BC7_TYPELESS: u32 = 97_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC7_UNORM: u32 = 98_u32.to_le();
-pub(crate) const DXGI_FORMAT_BC7_UNORM_SRGB: u32 = 99_u32.to_le();
+pub(crate) const DXGI_FORMAT_BC7_TYPELESS: u32 = 97;
+pub(crate) const DXGI_FORMAT_BC7_UNORM: u32 = 98;
+pub(crate) const DXGI_FORMAT_BC7_UNORM_SRGB: u32 = 99;
 
 // Additional uncompressed DXGI formats
-pub(crate) const DXGI_FORMAT_R8G8B8A8_TYPELESS: u32 = 27_u32.to_le();
-pub(crate) const DXGI_FORMAT_R8G8B8A8_UNORM: u32 = 28_u32.to_le();
-pub(crate) const DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: u32 = 29_u32.to_le();
-pub(crate) const DXGI_FORMAT_R8G8B8A8_UINT: u32 = 30_u32.to_le();
-pub(crate) const DXGI_FORMAT_R8G8B8A8_SNORM: u32 = 31_u32.to_le();
-pub(crate) const DXGI_FORMAT_R8G8B8A8_SINT: u32 = 32_u32.to_le();
+pub(crate) const DXGI_FORMAT_R8G8B8A8_TYPELESS: u32 = 27;
+pub(crate) const DXGI_FORMAT_R8G8B8A8_UNORM: u32 = 28;
+pub(crate) const DXGI_FORMAT_R8G8B8A8_UNORM_SRGB: u32 = 29;
+pub(crate) const DXGI_FORMAT_R8G8B8A8_UINT: u32 = 30;
+pub(crate) const DXGI_FORMAT_R8G8B8A8_SNORM: u32 = 31;
+pub(crate) const DXGI_FORMAT_R8G8B8A8_SINT: u32 = 32;
 
-pub(crate) const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87_u32.to_le();
-pub(crate) const DXGI_FORMAT_B8G8R8A8_TYPELESS: u32 = 90_u32.to_le();
-pub(crate) const DXGI_FORMAT_B8G8R8A8_UNORM_SRGB: u32 = 91_u32.to_le();
+pub(crate) const DXGI_FORMAT_B8G8R8A8_UNORM: u32 = 87;
+pub(crate) const DXGI_FORMAT_B8G8R8A8_TYPELESS: u32 = 90;
+pub(crate) const DXGI_FORMAT_B8G8R8A8_UNORM_SRGB: u32 = 91;
 
 // Size of the regular DDS header
 pub(crate) const DDS_HEADER_SIZE: usize = 0x80;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/exports.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/exports.rs
@@ -41,6 +41,7 @@ pub unsafe extern "C" fn parse_dds(ptr: *const u8, len: usize) -> DdsInfo {
         return DdsInfo {
             format: DdsFormat::NotADds,
             data_offset: 0,
+            data_length: 0,
         };
     }
 
@@ -51,11 +52,13 @@ pub unsafe extern "C" fn parse_dds(ptr: *const u8, len: usize) -> DdsInfo {
         DdsInfo {
             format: info.format,
             data_offset: info.data_offset,
+            data_length: info.data_length,
         }
     } else {
         DdsInfo {
             format: DdsFormat::NotADds,
             data_offset: 0,
+            data_length: 0,
         }
     }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/likely_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/likely_dds.rs
@@ -8,8 +8,8 @@ use super::constants::*;
 #[inline(always)]
 pub fn likely_dds(data: &[u8]) -> bool {
     data.len() >= DDS_HEADER_SIZE
-        && u32::from_ne_bytes([data[0], data[1], data[2], data[3]]) == DDS_MAGIC
-    // from_ne_bytes has no perf impact, only for clarity, resolved to integer at compile time
+        && u32::from_le_bytes([data[0], data[1], data[2], data[3]]) == DDS_MAGIC
+    // from_le_bytes ensures correct reading on all platforms since DDS is little-endian. No perf impact, a single cmp at runtime.
 }
 
 #[cfg(test)]

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -1,4 +1,6 @@
 use super::{constants::*, likely_dds};
+use core::hint::unreachable_unchecked;
+use endian_writer::{EndianReader, LittleEndianReader};
 
 /// Defines a known data format within a DDS file; suitable for lossless transform.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -17,6 +19,10 @@ pub enum DdsFormat {
     BC3 = 4,
     BC6H = 5,
     BC7 = 6,
+    /// RGBA8888 format (32-bit with alpha)
+    RGBA8888 = 7,
+    /// ARGB8888 format (32-bit with alpha, different byte order)
+    ARGB8888 = 8,
 }
 
 /// The information of the DDS file supplied to the reader.
@@ -25,6 +31,7 @@ pub enum DdsFormat {
 pub struct DdsInfo {
     pub format: DdsFormat,
     pub data_offset: u8,
+    pub data_length: u32,
 }
 
 /// Attempts to parse a the data format of a DDS file from the given slice.
@@ -58,7 +65,9 @@ pub fn parse_dds(data: &[u8]) -> Option<DdsInfo> {
 ///
 /// # Return
 ///
-/// `None` if the length is insufficient to read the headers or format is unknown.
+/// `None` if the length is insufficient to read the headers, format is unknown or
+/// the header is invalid.
+///
 /// Otherwise, a [`DdsInfo`] with the format and data offset.
 #[inline]
 pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
@@ -68,7 +77,8 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
     }
 
     // SAFETY: We checked data.len() >= DDS_HEADER_SIZE (128), so FOURCC_OFFSET (0x54) + 4 is safe
-    let fourcc = unsafe { (data.as_ptr().add(FOURCC_OFFSET) as *const u32).read_unaligned() };
+    let mut reader = unsafe { LittleEndianReader::new(data.as_ptr()) };
+    let fourcc = unsafe { reader.read_u32_at(FOURCC_OFFSET as isize) };
 
     let (format, data_offset) = if fourcc == FOURCC_DX10 {
         // DX10 header present, ensure the data is long enough.
@@ -78,8 +88,7 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
 
         // SAFETY: We checked data.len() >= DDS_HEADER_SIZE + DX10_HEADER_SIZE (148),
         // so DX10_FORMAT_OFFSET (0x80) + 4 is safe
-        let dxgi_format =
-            unsafe { (data.as_ptr().add(DX10_FORMAT_OFFSET) as *const u32).read_unaligned() };
+        let dxgi_format = unsafe { reader.read_u32_at(DX10_FORMAT_OFFSET as isize) };
         let format = match dxgi_format {
             DXGI_FORMAT_BC1_TYPELESS | DXGI_FORMAT_BC1_UNORM | DXGI_FORMAT_BC1_UNORM_SRGB => {
                 DdsFormat::BC1
@@ -96,28 +105,250 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
             DXGI_FORMAT_BC7_TYPELESS | DXGI_FORMAT_BC7_UNORM | DXGI_FORMAT_BC7_UNORM_SRGB => {
                 DdsFormat::BC7
             }
+            DXGI_FORMAT_R8G8B8A8_TYPELESS
+            | DXGI_FORMAT_R8G8B8A8_UNORM
+            | DXGI_FORMAT_R8G8B8A8_UNORM_SRGB
+            | DXGI_FORMAT_R8G8B8A8_UINT
+            | DXGI_FORMAT_R8G8B8A8_SNORM
+            | DXGI_FORMAT_R8G8B8A8_SINT => DdsFormat::RGBA8888,
+            DXGI_FORMAT_B8G8R8A8_UNORM
+            | DXGI_FORMAT_B8G8R8A8_TYPELESS
+            | DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => DdsFormat::ARGB8888,
             _ => DdsFormat::Unknown,
         };
 
         // 148 bytes: 128 byte header + 20 byte DX10 header
         (format, DDS_HEADER_SIZE + DX10_HEADER_SIZE)
     } else {
-        // Legacy header
-        let format = match fourcc {
-            FOURCC_DXT1 => DdsFormat::BC1,
-            FOURCC_DXT2 | FOURCC_DXT3 => DdsFormat::BC2,
-            FOURCC_DXT4 | FOURCC_DXT5 => DdsFormat::BC3,
-            _ => DdsFormat::Unknown,
+        // Legacy header - check pixel format flags to determine format type
+        let pixel_flags = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_FLAGS_OFFSET as isize) };
+
+        let format = if (pixel_flags & DDPF_FOURCC) != 0 {
+            // Block-compressed format with FOURCC
+            match fourcc {
+                FOURCC_DXT1 => DdsFormat::BC1,
+                FOURCC_DXT2 | FOURCC_DXT3 => DdsFormat::BC2,
+                FOURCC_DXT4 | FOURCC_DXT5 => DdsFormat::BC3,
+                _ => DdsFormat::Unknown,
+            }
+        } else if (pixel_flags & DDPF_RGB) != 0 {
+            // Uncompressed RGB format
+            detect_uncompressed_format(data)
+        } else {
+            // Other formats (YUV, Luminance, Alpha-only, etc.) are not supported
+            DdsFormat::Unknown
         };
 
         // 128 bytes: standard header size
         (format, DDS_HEADER_SIZE)
     };
 
+    // Calculate texture data length based on format and header fields
+    let data_length = calculate_data_length(format, data).unwrap_or(0);
+
     Some(DdsInfo {
         format,
         data_offset: data_offset as u8,
+        data_length,
     })
+}
+
+/// Detects uncompressed DDS format by examining bit masks and bit count
+///
+/// # Preconditions
+///
+/// This function assumes that the DDPF_RGB flag has already been checked by the caller.
+fn detect_uncompressed_format(data: &[u8]) -> DdsFormat {
+    let mut reader = unsafe { LittleEndianReader::new(data.as_ptr()) };
+
+    // Read pixel format information
+    let pixel_flags = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_FLAGS_OFFSET as isize) };
+    let rgb_bit_count = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_RGBBITCOUNT_OFFSET as isize) };
+
+    // Read the bit masks to determine the format
+    let r_mask = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_RBITMASK_OFFSET as isize) };
+    let g_mask = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_GBITMASK_OFFSET as isize) };
+    let b_mask = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_BBITMASK_OFFSET as isize) };
+    let a_mask = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_ABITMASK_OFFSET as isize) };
+
+    match rgb_bit_count {
+        32 => {
+            // For 32-bit formats, check if alpha channel is present
+            if (pixel_flags & DDPF_ALPHAPIXELS) != 0 {
+                // Check for RGBA8888 (R8G8B8A8_UNORM)
+                if r_mask == RGBA8888_RED_MASK
+                    && g_mask == RGBA8888_GREEN_MASK
+                    && b_mask == RGBA8888_BLUE_MASK
+                    && a_mask == RGBA8888_ALPHA_MASK
+                {
+                    DdsFormat::RGBA8888
+                }
+                // Check for ARGB8888 (B8G8R8A8_UNORM)
+                else if r_mask == ARGB8888_RED_MASK
+                    && g_mask == ARGB8888_GREEN_MASK
+                    && b_mask == ARGB8888_BLUE_MASK
+                    && a_mask == ARGB8888_ALPHA_MASK
+                {
+                    DdsFormat::ARGB8888
+                } else {
+                    DdsFormat::Unknown
+                }
+            } else {
+                // 32-bit RGB format without alpha (not currently supported)
+                DdsFormat::Unknown
+            }
+        }
+        _ => {
+            // Other bit depths are not currently supported
+            DdsFormat::Unknown
+        }
+    }
+}
+
+/// Calculate texture data length for a DDS format
+#[inline(always)]
+fn calculate_data_length(format: DdsFormat, data: &[u8]) -> Option<u32> {
+    // SAFETY: We checked data.len() >= DDS_HEADER_SIZE (128) in caller, so DDS_FLAGS_OFFSET (0x10) + 4 is safe
+
+    // Read header fields using little-endian byte order
+    let mut reader = unsafe { LittleEndianReader::new(data.as_ptr()) };
+    let flags = unsafe { reader.read_u32_at(DDS_FLAGS_OFFSET as isize) };
+    let height = unsafe { reader.read_u32_at(DDS_HEIGHT_OFFSET as isize) };
+    let width = unsafe { reader.read_u32_at(DDS_WIDTH_OFFSET as isize) };
+    let raw_mipmap_count = unsafe { reader.read_u32_at(DDS_MIPMAP_COUNT_OFFSET as isize) };
+
+    // Determine mipmap count
+    let mipmap_count = if (flags & DDSD_MIPMAPCOUNT) != 0 {
+        raw_mipmap_count.max(1)
+    } else {
+        1
+    };
+
+    // For block-compressed formats, use the dimension-based calculation
+    match format {
+        DdsFormat::BC1 | DdsFormat::BC2 | DdsFormat::BC3 | DdsFormat::BC6H | DdsFormat::BC7 => {
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+        }
+        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => {
+            // 32-bit formats (4 bytes per pixel)
+            calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
+        }
+        DdsFormat::Unknown => {
+            // Try to determine from pixel format for uncompressed formats
+            calculate_uncompressed_data_length(data, width, height, mipmap_count)
+        }
+        DdsFormat::NotADds => None,
+    }
+}
+
+/// Calculate texture data length for given format and dimensions
+///
+/// This is a utility function for tests and other scenarios where you want to calculate
+/// the expected data size without parsing an actual DDS buffer.
+#[inline(always)] // Avoid double matching in release builds
+pub(crate) fn calculate_data_length_for_block_compression(
+    format: DdsFormat,
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+) -> Option<u32> {
+    // Calculate data size based on format type
+    match format {
+        DdsFormat::BC1 | DdsFormat::BC2 | DdsFormat::BC3 | DdsFormat::BC6H | DdsFormat::BC7 => {
+            // Block-compressed formats
+            let block_size = match format {
+                DdsFormat::BC1 => 8,   // DXT1: 8 bytes per 4x4 block
+                DdsFormat::BC2 => 16,  // DXT2/3: 16 bytes per 4x4 block
+                DdsFormat::BC3 => 16,  // DXT4/5: 16 bytes per 4x4 block
+                DdsFormat::BC6H => 16, // BC6H: 16 bytes per 4x4 block
+                DdsFormat::BC7 => 16,  // BC7: 16 bytes per 4x4 block
+                _ => unsafe { unreachable_unchecked() },
+            };
+
+            let mut total_size = 0u32;
+            let mut w = width;
+            let mut h = height;
+
+            for _ in 0..mipmap_count {
+                // Round up dimensions to next multiple of 4 for block compression
+                let blocks_wide = w.div_ceil(4);
+                let blocks_high = h.div_ceil(4);
+
+                // Calculate size for this mipmap level
+                let level_size = blocks_wide * blocks_high * block_size;
+                total_size = total_size.saturating_add(level_size);
+
+                // Calculate next mipmap level dimensions (minimum 1x1)
+                w = (w / 2).max(1);
+                h = (h / 2).max(1);
+            }
+
+            Some(total_size)
+        }
+        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => {
+            // 32-bit uncompressed formats
+            calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
+        }
+        DdsFormat::Unknown => {
+            // Don't make assumptions about unknown formats - return 0
+            Some(0)
+        }
+        DdsFormat::NotADds => None,
+    }
+}
+
+/// Calculate data length for uncompressed pixel formats
+fn calculate_uncompressed_data_length(
+    data: &[u8],
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+) -> Option<u32> {
+    // Read pixel format information using little-endian byte order
+    let mut reader = unsafe { LittleEndianReader::new(data.as_ptr()) };
+    let pixel_flags = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_FLAGS_OFFSET as isize) };
+    let rgb_bit_count = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_RGBBITCOUNT_OFFSET as isize) };
+
+    // Check if this is a recognized uncompressed format
+    if (pixel_flags & (DDPF_RGB | DDPF_LUMINANCE | DDPF_YUV | DDPF_ALPHA)) == 0 {
+        return None; // Not a recognized uncompressed format
+    }
+
+    // Calculate bytes per pixel from bit count
+    if !rgb_bit_count.is_multiple_of(8) {
+        return None; // Invalid bit count
+    }
+    let bytes_per_pixel = rgb_bit_count / 8;
+
+    // Use the shared function to calculate total size for all mipmap levels
+    calculate_data_length_for_pixel_formats(width, height, mipmap_count, bytes_per_pixel)
+}
+
+/// Calculate data length for uncompressed formats with given dimensions and bytes per pixel
+pub(crate) fn calculate_data_length_for_pixel_formats(
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+    bytes_per_pixel: u32,
+) -> Option<u32> {
+    if bytes_per_pixel == 0 {
+        return None;
+    }
+
+    let mut total_size = 0u32;
+    let mut w = width;
+    let mut h = height;
+
+    for _ in 0..mipmap_count {
+        let level_size = w * h * bytes_per_pixel;
+        total_size = total_size.saturating_add(level_size);
+
+        // Calculate next mipmap level dimensions (minimum 1x1)
+        w = (w / 2).max(1);
+        h = (h / 2).max(1);
+    }
+
+    Some(total_size)
 }
 
 #[cfg(test)]
@@ -126,6 +357,7 @@ mod tests {
     use crate::dds::constants::DDS_HEADER_SIZE;
     use crate::test_prelude::DDS_DX10_TOTAL_HEADER_SIZE;
     use crate::test_prelude::*;
+    use endian_writer::{EndianWriter, LittleEndianWriter};
 
     #[rstest]
     #[case(FOURCC_DXT1, DdsFormat::BC1)]
@@ -134,12 +366,12 @@ mod tests {
     #[case(FOURCC_DXT4, DdsFormat::BC3)]
     #[case(FOURCC_DXT5, DdsFormat::BC3)]
     fn parse_dds_handles_legacy_formats(#[case] fourcc: u32, #[case] expected_format: DdsFormat) {
-        let mut data = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        // Create a DDS with actual texture data for proper validation
+        let mut data = create_valid_bc1_dds_with_dimensions(4, 4, 1);
 
         // Override the FOURCC with the test case
-        unsafe {
-            (data.as_mut_ptr().add(FOURCC_OFFSET) as *mut u32).write_unaligned(fourcc);
-        }
+        let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
+        unsafe { writer.write_u32_at(fourcc, FOURCC_OFFSET as isize) };
 
         let info = parse_dds(&data).unwrap();
         assert_eq!(info.format, expected_format);
@@ -157,13 +389,15 @@ mod tests {
         #[case] expected_format: DdsFormat,
     ) {
         // Verifies can parse with ignore magic, nothing more.
-        let mut data = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        // Create a DDS with actual texture data for proper validation
+        let mut data = create_valid_bc1_dds_with_dimensions(4, 4, 1);
 
         // Override the magic and FOURCC for the test case
+        let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
         unsafe {
             // Set invalid magic header (simulating transform header)
-            (data.as_mut_ptr().add(0) as *mut u32).write_unaligned(0xDEADBEEF);
-            (data.as_mut_ptr().add(FOURCC_OFFSET) as *mut u32).write_unaligned(fourcc);
+            writer.write_u32_at(0xDEADBEEF, 0);
+            writer.write_u32_at(fourcc, FOURCC_OFFSET as isize);
         }
 
         // Regular parse_dds should fail
@@ -195,12 +429,11 @@ mod tests {
         #[case] dxgi_format: u32,
         #[case] expected_format: DdsFormat,
     ) {
-        let mut data = create_valid_bc7_dds(DDS_DX10_TOTAL_HEADER_SIZE);
+        let mut data = create_incomplete_bc7_dds(); // Header-only BC7 for testing unknown format detection
 
         // Override the DXGI format with the test case
-        unsafe {
-            (data.as_mut_ptr().add(DX10_FORMAT_OFFSET) as *mut u32).write_unaligned(dxgi_format);
-        }
+        let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
+        unsafe { writer.write_u32_at(dxgi_format, DX10_FORMAT_OFFSET as isize) };
 
         let info = parse_dds(&data).unwrap();
         assert_eq!(info.format, expected_format);
@@ -210,7 +443,7 @@ mod tests {
     #[test]
     fn parse_dds_detects_unknown_legacy_format() {
         // Test invalid legacy format
-        let unknown_legacy = create_unknown_format_dds(DDS_DX10_TOTAL_HEADER_SIZE);
+        let unknown_legacy = create_valid_unknown_format_dds(); // Valid unknown format DDS for testing
         let info = parse_dds(&unknown_legacy).unwrap();
         assert_eq!(info.format, DdsFormat::Unknown);
     }
@@ -218,10 +451,11 @@ mod tests {
     #[test]
     fn parse_dds_detects_unknown_dx10_format() {
         // Test invalid DX10 format
-        let mut unknown_dx10 = create_valid_bc7_dds(DDS_DX10_TOTAL_HEADER_SIZE);
+        let mut unknown_dx10 = create_valid_bc7_dds(); // Valid BC7 DDS for modification
+        let mut writer = unsafe { LittleEndianWriter::new(unknown_dx10.as_mut_ptr()) };
         unsafe {
-            (unknown_dx10.as_mut_ptr().add(DX10_FORMAT_OFFSET) as *mut u32)
-                .write_unaligned(0x12345678);
+            // Change DXGI format to unknown
+            writer.write_u32_at(0x12345678, DX10_FORMAT_OFFSET as isize);
         }
 
         let info = parse_dds(&unknown_dx10).unwrap();
@@ -239,26 +473,84 @@ mod tests {
     fn parse_dds_handles_data_too_short_for_dx10_header() {
         // Too short for DX10 header
         let mut data = [0u8; DDS_DX10_TOTAL_HEADER_SIZE - 1];
+        let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
         unsafe {
-            (data.as_mut_ptr().add(0) as *mut u32).write_unaligned(DDS_MAGIC);
-            (data.as_mut_ptr().add(FOURCC_OFFSET) as *mut u32).write_unaligned(FOURCC_DX10);
+            writer.write_u32_at(DDS_MAGIC, 0);
+            writer.write_u32_at(FOURCC_DX10, FOURCC_OFFSET as isize);
         }
         assert!(parse_dds(&data).is_none());
     }
 
     #[test]
     fn parse_dds_handles_unaligned_reads() {
-        // Test with data at an unaligned address to ensure read_unaligned works correctly
-        let mut buffer = [0u8; 0x81]; // DDS_HEADER_SIZE + 1 = 0x80 + 1 = 0x81
-        let data = &mut buffer[1..]; // Start at offset 1 to create misalignment
+        // Create a valid BC1 DDS file using helper functions
+        let valid_dds = create_valid_bc1_dds_with_dimensions(64, 64, 1);
 
-        unsafe {
-            (data.as_mut_ptr().add(0) as *mut u32).write_unaligned(DDS_MAGIC);
-            (data.as_mut_ptr().add(FOURCC_OFFSET) as *mut u32).write_unaligned(FOURCC_DXT1);
-        }
+        // Create a buffer with an extra byte at the start to make the DDS data misaligned
+        let mut misaligned_buffer = vec![0u8; valid_dds.len() + 1];
 
-        let info = parse_dds(data).unwrap();
+        // Copy the valid DDS data starting at offset 1 to create misalignment
+        misaligned_buffer[1..].copy_from_slice(&valid_dds);
+
+        // Test parsing the misaligned data (skip the first byte)
+        let misaligned_data = &misaligned_buffer[1..];
+
+        let info = parse_dds(misaligned_data).unwrap();
         assert_eq!(info.format, DdsFormat::BC1);
         assert_eq!(info.data_offset, DDS_HEADER_SIZE as u8);
+    }
+
+    // Data length calculation tests
+
+    #[test]
+    fn data_length_bc1_single_level_256x256() {
+        let input = create_valid_bc1_dds_with_dimensions(256, 256, 1);
+        let info = parse_dds(&input).unwrap();
+        // 256x256 = 64x64 blocks * 8 bytes = 32768 bytes
+        assert_eq!(info.data_length, 32768);
+    }
+
+    #[test]
+    fn data_length_bc1_with_mipmaps_256x256() {
+        let input = create_valid_bc1_dds_with_dimensions(256, 256, 9);
+        let info = parse_dds(&input).unwrap();
+        // 256x256 (32768) + 128x128 (8192) + 64x64 (2048) + 32x32 (512) + 16x16 (128) + 8x8 (32) + 4x4 (8) + 2x2 (8) + 1x1 (8) = 43704
+        assert_eq!(info.data_length, 43704);
+    }
+
+    #[test]
+    fn data_length_bc1_with_non_multiple_of_4_dimensions() {
+        let input = create_valid_bc1_dds_with_dimensions(17, 13, 1);
+        let info = parse_dds(&input).unwrap();
+        // (17+3)/4 = 5 blocks wide, (13+3)/4 = 4 blocks high
+        // 5 * 4 * 8 = 160 bytes
+        assert_eq!(info.data_length, 160);
+    }
+
+    #[test]
+    fn data_length_zero_dimensions_returns_zero() {
+        let mut input = create_valid_bc1_dds_with_dimensions(256, 256, 1);
+        // Set width to 0
+        let mut writer = unsafe { LittleEndianWriter::new(input.as_mut_ptr()) };
+        unsafe { writer.write_u32_at(0, DDS_WIDTH_OFFSET as isize) };
+        let info = parse_dds(&input).unwrap();
+        // Should return 0 for zero dimensions (0 * height * block_size = 0)
+        assert_eq!(info.data_length, 0);
+    }
+
+    #[test]
+    fn data_length_uncompressed_rgba32() {
+        let input = create_valid_rgba8888_dds_with_dimensions(16, 16, 1);
+        let info = parse_dds(&input).unwrap();
+        // 16x16 * 4 bytes per pixel = 1024 bytes
+        assert_eq!(info.data_length, 1024);
+    }
+
+    #[test]
+    fn data_length_uncompressed_with_mipmaps() {
+        let input = create_valid_rgba8888_dds_with_dimensions(4, 4, 3);
+        let info = parse_dds(&input).unwrap();
+        // 4x4 (64) + 2x2 (16) + 1x1 (4) = 84 bytes
+        assert_eq!(info.data_length, 84);
     }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_detection.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_detection.rs
@@ -27,7 +27,7 @@ mod tests {
     #[test]
     fn can_handle_accepts_valid_bc1_dds() {
         let handler = DdsHandler;
-        let valid_dds = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let valid_dds = create_valid_bc1_dds();
         assert!(handler.can_handle(&valid_dds, Some("dds")));
         assert!(handler.can_handle(&valid_dds, None)); // Should also work without extension
     }
@@ -42,21 +42,21 @@ mod tests {
     #[test]
     fn can_handle_rejects_wrong_extension() {
         let handler = DdsHandler;
-        let valid_dds = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let valid_dds = create_valid_bc1_dds();
         assert!(!handler.can_handle(&valid_dds, Some("txt")));
     }
 
     #[test]
     fn can_handle_accepts_minimum_valid_size() {
         let handler = DdsHandler;
-        let min_valid = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let min_valid = create_valid_bc1_dds();
         assert!(handler.can_handle(&min_valid, Some("dds")));
     }
 
     #[test]
     fn can_handle_rejects_just_under_minimum_size() {
         let handler = DdsHandler;
-        let too_small = create_valid_bc1_dds(DDS_HEADER_SIZE - 1);
+        let too_small = create_truncated_dds(DDS_HEADER_SIZE - 1);
         assert!(!handler.can_handle(&too_small, Some("dds")));
     }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_handler.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_handler.rs
@@ -140,7 +140,7 @@ impl FileFormatHandler for DdsHandler {
         }
 
         // Restore DDS magic
-        output[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
+        output[0..4].copy_from_slice(&DDS_MAGIC.to_le_bytes());
 
         // Copy the rest of the header (from byte 4 to data_offset)
         output[4..data_offset].copy_from_slice(&input[4..data_offset]);

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_handler.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_handler.rs
@@ -30,6 +30,7 @@ fn dds_format_to_transform_format(
         DdsFormat::BC7 => Err(FormatHandlerError::FormatNotImplemented(
             TransformFormat::Bc7,
         )),
+        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => Err(FormatHandlerError::UnknownFileFormat),
         DdsFormat::Unknown | DdsFormat::NotADds => Err(FormatHandlerError::UnknownFileFormat),
     }
 }
@@ -57,18 +58,35 @@ impl FileFormatHandler for DdsHandler {
         // Parse DDS header
         let info = parse_dds(input).ok_or(FormatHandlerError::InvalidInputFileHeader)?;
         let data_offset = info.data_offset as usize;
+        let data_length = info.data_length as usize;
+        let total_required = data_offset + data_length;
+
+        // Validate input buffer contains enough data for declared texture size
+        if input.len() < total_required {
+            return Err(FormatHandlerError::InputTooShortForStatedTextureSize {
+                required: total_required,
+                actual: input.len(),
+            }
+            .into());
+        }
 
         // Copy headers to output
         output[..data_offset].copy_from_slice(&input[..data_offset]);
 
-        // Convert DDS format to transform format and dispatch
+        // Convert DDS format to transform format and dispatch (only texture data)
         let transform_format = dds_format_to_transform_format(info.format)?;
         let header = dxt_lossless_transform_file_formats_api::dispatch_transform(
             transform_format,
-            &input[data_offset..],
-            &mut output[data_offset..],
+            &input[data_offset..data_offset + data_length],
+            &mut output[data_offset..data_offset + data_length],
             bundle,
         )?;
+
+        // Copy leftover data after texture data verbatim
+        let leftover_start = data_offset + data_length;
+        if input.len() > leftover_start {
+            output[leftover_start..].copy_from_slice(&input[leftover_start..]);
+        }
 
         // Embed transform header (overwrites DDS magic)
         // SAFETY: output.as_mut_ptr() is valid for writes of at least TRANSFORM_HEADER_SIZE bytes because:
@@ -109,6 +127,17 @@ impl FileFormatHandler for DdsHandler {
         let info =
             parse_dds_ignore_magic(input).ok_or(FormatHandlerError::InvalidRestoredFileHeader)?;
         let data_offset = info.data_offset as usize;
+        let data_length = info.data_length as usize;
+        let total_required = data_offset + data_length;
+
+        // Validate input buffer contains enough data for declared texture size
+        if input.len() < total_required {
+            return Err(FormatHandlerError::InputTooShortForStatedTextureSize {
+                required: total_required,
+                actual: input.len(),
+            }
+            .into());
+        }
 
         // Restore DDS magic
         output[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
@@ -116,12 +145,18 @@ impl FileFormatHandler for DdsHandler {
         // Copy the rest of the header (from byte 4 to data_offset)
         output[4..data_offset].copy_from_slice(&input[4..data_offset]);
 
-        // Dispatch untransform based on header format using separate input/output texture data
+        // Dispatch untransform based on header format (only texture data)
         dxt_lossless_transform_file_formats_api::dispatch_untransform(
             header,
-            &input[data_offset..],
-            &mut output[data_offset..],
+            &input[data_offset..data_offset + data_length],
+            &mut output[data_offset..data_offset + data_length],
         )?;
+
+        // Copy leftover data after texture data verbatim
+        let leftover_start = data_offset + data_length;
+        if input.len() > leftover_start {
+            output[leftover_start..].copy_from_slice(&input[leftover_start..]);
+        }
 
         Ok(())
     }
@@ -130,7 +165,7 @@ impl FileFormatHandler for DdsHandler {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dds::constants::{DDS_HEADER_SIZE, DDS_MAGIC};
+    use crate::dds::constants::DDS_HEADER_SIZE;
     use crate::test_prelude::*;
     use dxt_lossless_transform_api_common::estimate::NoEstimation;
     use dxt_lossless_transform_file_formats_api::{
@@ -144,7 +179,7 @@ mod tests {
     fn transform_bundle_rejects_output_buffer_too_small() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
-        let input = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let input = create_incomplete_bc1_dds(); // Header-only DDS for testing buffer validation
         let mut small_output = vec![0u8; input.len() - 1];
 
         let result = handler.transform_bundle(&input, &mut small_output, &bundle);
@@ -263,8 +298,8 @@ mod tests {
     fn transform_bundle_rejects_no_builder_for_bc1_format() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default(); // No builders provided
-        let input = create_valid_bc1_dds(DDS_HEADER_SIZE);
-        let mut output = [0u8; DDS_HEADER_SIZE];
+        let input = create_valid_bc1_dds_with_dimensions(64, 64, 1); // 64x64 BC1 texture
+        let mut output = vec![0u8; input.len()];
 
         let result = handler.transform_bundle(&input, &mut output, &bundle);
         assert!(result.is_err());
@@ -284,8 +319,8 @@ mod tests {
     fn transform_bundle_rejects_bc2_format_not_implemented() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
-        let bc2_input = create_valid_bc2_dds(DDS_HEADER_SIZE);
-        let mut output = [0u8; DDS_HEADER_SIZE];
+        let bc2_input = create_valid_bc2_dds(); // Valid BC2 DDS for testing format not implemented
+        let mut output = vec![0u8; bc2_input.len()];
 
         let result = handler.transform_bundle(&bc2_input, &mut output, &bundle);
         assert!(result.is_err());
@@ -307,8 +342,8 @@ mod tests {
     fn transform_bundle_rejects_bc3_format_not_implemented() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
-        let bc3_input = create_valid_bc3_dds(DDS_HEADER_SIZE);
-        let mut output = [0u8; DDS_HEADER_SIZE];
+        let bc3_input = create_valid_bc3_dds(); // Valid BC3 DDS for testing format not implemented
+        let mut output = vec![0u8; bc3_input.len()];
 
         let result = handler.transform_bundle(&bc3_input, &mut output, &bundle);
         assert!(result.is_err());
@@ -330,8 +365,8 @@ mod tests {
     fn transform_bundle_rejects_bc6h_format_not_implemented() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
-        let bc6h_input = create_valid_bc6h_dds(DDS_DX10_TOTAL_HEADER_SIZE);
-        let mut output = [0u8; DDS_DX10_TOTAL_HEADER_SIZE];
+        let bc6h_input = create_valid_bc6h_dds(); // Valid BC6H DDS for testing format not implemented
+        let mut output = vec![0u8; bc6h_input.len()];
 
         let result = handler.transform_bundle(&bc6h_input, &mut output, &bundle);
         assert!(result.is_err());
@@ -353,8 +388,8 @@ mod tests {
     fn transform_bundle_rejects_bc7_format_not_implemented() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
-        let bc7_input = create_valid_bc7_dds(DDS_DX10_TOTAL_HEADER_SIZE);
-        let mut output = [0u8; DDS_DX10_TOTAL_HEADER_SIZE];
+        let bc7_input = create_valid_bc7_dds(); // Valid BC7 DDS for testing format not implemented
+        let mut output = vec![0u8; bc7_input.len()];
 
         let result = handler.transform_bundle(&bc7_input, &mut output, &bundle);
         assert!(result.is_err());
@@ -376,8 +411,8 @@ mod tests {
     fn transform_bundle_rejects_unknown_format() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
-        let unknown_input = create_unknown_format_dds(DDS_HEADER_SIZE);
-        let mut output = [0u8; DDS_HEADER_SIZE];
+        let unknown_input = create_valid_unknown_format_dds(); // Valid unknown format DDS for testing
+        let mut output = vec![0u8; unknown_input.len()];
 
         let result = handler.transform_bundle(&unknown_input, &mut output, &bundle);
         assert!(result.is_err());
@@ -389,46 +424,89 @@ mod tests {
         }
     }
 
-    // Successful operation test
-
+    // Data length and leftover data tests
     #[test]
-    fn successful_bc1_transform_and_untransform_roundtrip() {
+    fn transform_and_untransform_preserves_leftover_data_roundtrip() {
         let handler = DdsHandler;
         let bundle = TransformBundle::<NoEstimation>::default_all();
 
-        // Create valid BC1 DDS with some texture data
-        let mut input = create_valid_bc1_dds(DDS_HEADER_SIZE + 64);
-
-        // Add some texture data
-        for x in 0..64 {
-            input[DDS_HEADER_SIZE + x] = (x % 256) as u8;
-        }
-
+        let leftover_data = b"Roundtrip preservation test data 123456!";
+        let input = create_bc1_dds_with_leftover_data(32, 32, leftover_data);
         let mut transformed = vec![0u8; input.len()];
         let mut restored = vec![0u8; input.len()];
 
         // Transform
         let transform_result = handler.transform_bundle(&input, &mut transformed, &bundle);
-        // Skip this test if BC1 API is not available
         if transform_result.is_err() {
-            return;
+            return; // Skip test if BC1 not available
         }
-
-        // Verify magic header was overwritten with transform data
-        assert_ne!(&transformed[0..4], &DDS_MAGIC.to_ne_bytes());
-        // Verify the rest of the header is preserved
-        assert_eq!(&transformed[4..DDS_HEADER_SIZE], &input[4..DDS_HEADER_SIZE]);
 
         // Untransform
         let untransform_result = handler.untransform(&transformed, &mut restored);
         assert!(
             untransform_result.is_ok(),
-            "Untransform failed: {untransform_result:?}",
+            "Untransform failed: {untransform_result:?}"
         );
 
-        // Verify magic header was restored
-        assert_eq!(&restored[0..4], &DDS_MAGIC.to_ne_bytes());
-        // Verify the rest of the data matches the original
-        assert_eq!(&restored[4..], &input[4..]);
+        // Verify complete roundtrip preserves all data including leftover
+        assert_eq!(restored, input);
+    }
+
+    #[test]
+    fn transform_bundle_rejects_insufficient_data_for_declared_size() {
+        // size as in width+height
+        let handler = DdsHandler;
+        let bundle = TransformBundle::<NoEstimation>::default_all();
+
+        // Create DDS that declares larger data size than available
+        let mut input = create_valid_bc1_dds_with_dimensions(64, 64, 1);
+        // Truncate the data to simulate insufficient buffer
+        input.truncate(input.len() - 100);
+        let mut output = vec![0u8; input.len()];
+
+        let result = handler.transform_bundle(&input, &mut output, &bundle);
+        assert!(result.is_err());
+
+        if let Err(TransformError::FormatHandler(
+            FormatHandlerError::InputTooShortForStatedTextureSize { .. },
+        )) = result
+        {
+            // Expected error type
+        } else {
+            panic!(
+                "Expected InputTooShortForStatedTextureSize error, got: {:?}",
+                result
+            );
+        }
+    }
+
+    #[test]
+    fn untransform_rejects_insufficient_data_for_declared_size() {
+        // size as in width+height
+        let handler = DdsHandler;
+
+        // Create a simulated transform that would require more data than provided
+        let mut transformed_data = create_valid_bc1_dds_with_dimensions(64, 64, 1);
+        // Overwrite magic with transform header (simulating transformed file)
+        transformed_data[0..4].copy_from_slice(&[0xFF, 0xFF, 0xFF, 0xFF]);
+        // Truncate to simulate insufficient data
+        transformed_data.truncate(transformed_data.len() - 50);
+
+        let mut output = vec![0u8; transformed_data.len()];
+
+        let result = handler.untransform(&transformed_data, &mut output);
+        assert!(result.is_err());
+
+        if let Err(TransformError::FormatHandler(
+            FormatHandlerError::InputTooShortForStatedTextureSize { .. },
+        )) = result
+        {
+            // Expected error type
+        } else {
+            panic!(
+                "Expected InputTooShortForStatedTextureSize error, got: {:?}",
+                result
+            );
+        }
     }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_untransform_detection.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_untransform_detection.rs
@@ -31,7 +31,7 @@ mod tests {
     #[test]
     fn can_handle_untransform_accepts_transformed_dds() {
         let handler = DdsHandler;
-        let mut transformed_dds = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let mut transformed_dds = create_valid_bc1_dds();
         // Overwrite magic with transform header
         transformed_dds[0..4].copy_from_slice(&[0xAB, 0xCD, 0xEF, 0x12]);
         assert!(handler.can_handle_untransform(&transformed_dds, Some("dds")));
@@ -41,7 +41,7 @@ mod tests {
     #[test]
     fn can_handle_untransform_rejects_wrong_extension() {
         let handler = DdsHandler;
-        let mut transformed_dds = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let mut transformed_dds = create_valid_bc1_dds();
         transformed_dds[0..4].copy_from_slice(&[0xAB, 0xCD, 0xEF, 0x12]);
         assert!(!handler.can_handle_untransform(&transformed_dds, Some("txt")));
     }
@@ -49,7 +49,7 @@ mod tests {
     #[test]
     fn can_handle_untransform_accepts_minimum_transformed_size() {
         let handler = DdsHandler;
-        let mut min_transformed = create_valid_bc1_dds(DDS_HEADER_SIZE);
+        let mut min_transformed = create_valid_bc1_dds();
         min_transformed[0..4].copy_from_slice(&[0xAB, 0xCD, 0xEF, 0x12]);
         assert!(handler.can_handle_untransform(&min_transformed, Some("dds")));
     }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -19,83 +19,336 @@ pub use std::is_x86_feature_detected;
 pub use rstest::rstest;
 
 // Common DDS test data helpers
-use crate::dds::constants::{DDS_HEADER_SIZE, DDS_MAGIC, DX10_HEADER_SIZE};
+use crate::dds::constants::*;
+use endian_writer::{EndianWriter, LittleEndianWriter};
 
 /// Total size of DDS header + DX10 header (used in tests)
 pub const DDS_DX10_TOTAL_HEADER_SIZE: usize = DDS_HEADER_SIZE + DX10_HEADER_SIZE;
 
-/// Helper function to create a valid DDS header with BC1 format
-pub fn create_valid_bc1_dds(size: usize) -> Vec<u8> {
-    let mut data = vec![0u8; size];
-    if size >= DDS_HEADER_SIZE {
-        data[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
-        // Set FOURCC to DXT1 (BC1)
-        data[0x54..0x58].copy_from_slice(b"DXT1");
-    }
-    data
-}
+// Import the existing DDS Parser functionality
+use crate::dds::parse_dds::*;
 
-/// Helper function to create a valid DDS header with BC2 format
-pub fn create_valid_bc2_dds(size: usize) -> Vec<u8> {
-    let mut data = vec![0u8; size];
-    if size >= DDS_HEADER_SIZE {
-        data[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
-        // Set FOURCC to DXT3 (BC2)
-        data[0x54..0x58].copy_from_slice(b"DXT3");
+/// Helper function to create a basic DDS header with common fields
+fn create_dds_header_base(
+    data: &mut [u8],
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+    is_dx10: bool,
+) {
+    let required_size = if is_dx10 {
+        DDS_DX10_TOTAL_HEADER_SIZE
+    } else {
+        DDS_HEADER_SIZE
+    };
+    if data.len() < required_size {
+        return;
     }
-    data
-}
 
-/// Helper function to create a valid DDS header with BC3 format
-pub fn create_valid_bc3_dds(size: usize) -> Vec<u8> {
-    let mut data = vec![0u8; size];
-    if size >= DDS_HEADER_SIZE {
-        data[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
-        // Set FOURCC to DXT5 (BC3)
-        data[0x54..0x58].copy_from_slice(b"DXT5");
-    }
-    data
-}
+    let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
 
-/// Helper function to create a valid DDS header with BC6H format (DX10 header)
-pub fn create_valid_bc6h_dds(size: usize) -> Vec<u8> {
-    let mut data = vec![0u8; size];
-    if size >= DDS_DX10_TOTAL_HEADER_SIZE {
-        data[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
-        // Set FOURCC to DX10
-        data[0x54..0x58].copy_from_slice(b"DX10");
-        // Set DXGI format to BC6H
-        unsafe {
-            (data.as_mut_ptr().add(0x80) as *mut u32)
-                .write_unaligned(crate::dds::constants::DXGI_FORMAT_BC6H_UF16);
+    unsafe {
+        // DDS magic
+        writer.write_u32_at(DDS_MAGIC, 0);
+        // Set header size (dwSize field at offset 4)
+        writer.write_u32_at(124, 4);
+
+        // Set flags to include required fields
+        let mut flags = DDSD_CAPS | DDSD_HEIGHT | DDSD_WIDTH | DDSD_PIXELFORMAT | DDSD_LINEARSIZE;
+        if mipmap_count > 1 {
+            flags |= DDSD_MIPMAPCOUNT;
+        }
+        writer.write_u32_at(flags, DDS_FLAGS_OFFSET as isize);
+
+        // Set dimensions
+        writer.write_u32_at(height, DDS_HEIGHT_OFFSET as isize);
+        writer.write_u32_at(width, DDS_WIDTH_OFFSET as isize);
+
+        // Set mipmap count if more than 1
+        if mipmap_count > 1 {
+            writer.write_u32_at(mipmap_count, DDS_MIPMAP_COUNT_OFFSET as isize);
         }
     }
-    data
 }
 
-/// Helper function to create a valid DDS header with BC7 format (DX10 header)
-pub fn create_valid_bc7_dds(size: usize) -> Vec<u8> {
-    let mut data = vec![0u8; size];
-    if size >= DDS_DX10_TOTAL_HEADER_SIZE {
-        data[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
-        // Set FOURCC to DX10
-        data[0x54..0x58].copy_from_slice(b"DX10");
-        // Set DXGI format to BC7
-        unsafe {
-            (data.as_mut_ptr().add(0x80) as *mut u32)
-                .write_unaligned(crate::dds::constants::DXGI_FORMAT_BC7_UNORM);
+/// Helper function to write pixel format flags for FOURCC-based formats
+fn write_fourcc_pixel_format(data: &mut [u8], fourcc: &[u8; 4]) {
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(fourcc);
+    unsafe {
+        let mut writer = LittleEndianWriter::new(data.as_mut_ptr());
+        writer.write_u32_at(DDPF_FOURCC, DDS_PIXELFORMAT_FLAGS_OFFSET as isize);
+    }
+}
+
+/// Helper function to write DX10 format information
+fn write_dx10_format(data: &mut [u8], dxgi_format: u32) {
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"DX10");
+    unsafe {
+        let mut writer = LittleEndianWriter::new(data.as_mut_ptr());
+        writer.write_u32_at(DDPF_FOURCC, DDS_PIXELFORMAT_FLAGS_OFFSET as isize);
+        writer.write_u32_at(dxgi_format, 0x80);
+    }
+}
+
+/// Helper function to write uncompressed pixel format information
+fn write_uncompressed_pixel_format(
+    data: &mut [u8],
+    red_mask: u32,
+    green_mask: u32,
+    blue_mask: u32,
+    alpha_mask: u32,
+) {
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"\0\0\0\0");
+    unsafe {
+        let mut writer = LittleEndianWriter::new(data.as_mut_ptr());
+        writer.write_u32_at(
+            DDPF_RGB | DDPF_ALPHAPIXELS,
+            DDS_PIXELFORMAT_FLAGS_OFFSET as isize,
+        );
+        writer.write_u32_at(32, DDS_PIXELFORMAT_RGBBITCOUNT_OFFSET as isize);
+        writer.write_u32_at(red_mask, DDS_PIXELFORMAT_RBITMASK_OFFSET as isize);
+        writer.write_u32_at(green_mask, DDS_PIXELFORMAT_GBITMASK_OFFSET as isize);
+        writer.write_u32_at(blue_mask, DDS_PIXELFORMAT_BBITMASK_OFFSET as isize);
+        writer.write_u32_at(alpha_mask, DDS_PIXELFORMAT_ABITMASK_OFFSET as isize);
+    }
+}
+
+/// Helper function to create a valid DDS with specified format and dimensions
+pub fn create_valid_dds_with_dimensions(
+    format: DdsFormat,
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+) -> Vec<u8> {
+    let (data_size, is_dx10) = match format {
+        DdsFormat::BC1 => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            false,
+        ),
+        DdsFormat::BC2 => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            false,
+        ),
+        DdsFormat::BC3 => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            false,
+        ),
+        DdsFormat::BC6H => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            true,
+        ),
+        DdsFormat::BC7 => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            true,
+        ),
+        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => {
+            // 32-bit uncompressed formats
+            (
+                calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4).unwrap_or(0)
+                    as usize,
+                false, // Use legacy format for uncompressed formats
+            )
+        }
+        DdsFormat::Unknown => {
+            // Unknown formats return 0 data size
+            (0, false)
+        }
+        DdsFormat::NotADds => (0, false), // Should not be used in tests
+    };
+
+    let header_size = if is_dx10 {
+        DDS_DX10_TOTAL_HEADER_SIZE
+    } else {
+        DDS_HEADER_SIZE
+    };
+    let total_size = header_size + data_size;
+    let mut data = vec![0u8; total_size];
+
+    create_dds_header_base(&mut data, width, height, mipmap_count, is_dx10);
+
+    // Set format-specific fields
+    match format {
+        DdsFormat::BC1 => {
+            write_fourcc_pixel_format(&mut data, b"DXT1");
+        }
+        DdsFormat::BC2 => {
+            write_fourcc_pixel_format(&mut data, b"DXT3");
+        }
+        DdsFormat::BC3 => {
+            write_fourcc_pixel_format(&mut data, b"DXT5");
+        }
+        DdsFormat::BC6H => {
+            write_dx10_format(&mut data, DXGI_FORMAT_BC6H_UF16);
+        }
+        DdsFormat::BC7 => {
+            write_dx10_format(&mut data, DXGI_FORMAT_BC7_UNORM);
+        }
+        DdsFormat::RGBA8888 => {
+            write_uncompressed_pixel_format(
+                &mut data,
+                RGBA8888_RED_MASK,
+                RGBA8888_GREEN_MASK,
+                RGBA8888_BLUE_MASK,
+                RGBA8888_ALPHA_MASK,
+            );
+        }
+        DdsFormat::ARGB8888 => {
+            write_uncompressed_pixel_format(
+                &mut data,
+                ARGB8888_RED_MASK,
+                ARGB8888_GREEN_MASK,
+                ARGB8888_BLUE_MASK,
+                ARGB8888_ALPHA_MASK,
+            );
+        }
+        DdsFormat::Unknown => {
+            write_fourcc_pixel_format(&mut data, b"UNKN");
+        }
+        DdsFormat::NotADds => {
+            // Should not be used in tests, but handle gracefully
+            return data;
         }
     }
+
+    // Fill texture data area with test pattern
+    #[allow(clippy::needless_range_loop)]
+    for x in header_size..data.len() {
+        data[x] = ((x - header_size) % 256) as u8;
+    }
+
     data
 }
 
-/// Helper function to create a valid DDS header with unknown format
-pub fn create_unknown_format_dds(size: usize) -> Vec<u8> {
-    let mut data = vec![0u8; size];
-    if size >= DDS_HEADER_SIZE {
-        data[0..4].copy_from_slice(&DDS_MAGIC.to_ne_bytes());
-        // Set FOURCC to unknown format
-        data[0x54..0x58].copy_from_slice(b"UNKN");
-    }
+/// Helper function to create a valid BC1 DDS with proper dimensions and data length
+pub fn create_valid_bc1_dds_with_dimensions(width: u32, height: u32, mipmap_count: u32) -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC1, width, height, mipmap_count)
+}
+
+/// Helper function to create a valid RGBA8888 DDS with proper dimensions and data length
+pub fn create_valid_rgba8888_dds_with_dimensions(
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+) -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::RGBA8888, width, height, mipmap_count)
+}
+
+/// Helper function to create a valid ARGB8888 DDS with proper dimensions and data length
+pub fn create_valid_argb8888_dds_with_dimensions(
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+) -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::ARGB8888, width, height, mipmap_count)
+}
+
+// Semantic helper functions for clearer test intent
+
+/// Creates a minimal valid BC1 DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC1 DDS for testing
+pub fn create_valid_bc1_dds() -> Vec<u8> {
+    create_valid_bc1_dds_with_dimensions(4, 4, 1)
+}
+
+/// Creates a minimal valid BC2 DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC2 DDS for testing
+pub fn create_valid_bc2_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC2, 4, 4, 1)
+}
+
+/// Creates a minimal valid BC3 DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC3 DDS for testing
+pub fn create_valid_bc3_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC3, 4, 4, 1)
+}
+
+/// Creates a minimal valid BC6H DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC6H DDS for testing
+pub fn create_valid_bc6h_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC6H, 4, 4, 1)
+}
+
+/// Creates a minimal valid BC7 DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC7 DDS for testing
+pub fn create_valid_bc7_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC7, 4, 4, 1)
+}
+
+/// Creates a minimal valid unknown format DDS file (1x1, unknown format)
+/// Use this when you just need any valid unknown format DDS for testing
+pub fn create_valid_unknown_format_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::Unknown, 1, 1, 1)
+}
+
+/// Creates an incomplete BC1 DDS file (header-only, no texture data)
+/// Use this to test error conditions where there's insufficient data
+pub fn create_incomplete_bc1_dds() -> Vec<u8> {
+    let mut data = vec![0u8; DDS_HEADER_SIZE];
+
+    // Set up a proper header but no texture data
+    create_dds_header_base(&mut data, 4, 4, 1, false);
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"DXT1");
+
     data
+}
+
+/// Creates an incomplete BC2 DDS file (header-only, no texture data)
+/// Use this to test error conditions where there's insufficient data
+pub fn create_incomplete_bc2_dds() -> Vec<u8> {
+    let mut data = vec![0u8; DDS_HEADER_SIZE];
+
+    create_dds_header_base(&mut data, 4, 4, 1, false);
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"DXT3");
+
+    data
+}
+
+/// Creates an incomplete BC3 DDS file (header-only, no texture data)
+/// Use this to test error conditions where there's insufficient data
+pub fn create_incomplete_bc3_dds() -> Vec<u8> {
+    let mut data = vec![0u8; DDS_HEADER_SIZE];
+
+    create_dds_header_base(&mut data, 4, 4, 1, false);
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"DXT5");
+
+    data
+}
+
+/// Creates an incomplete BC7 DDS file (header-only, no texture data)
+/// Use this to test error conditions where there's insufficient data
+pub fn create_incomplete_bc7_dds() -> Vec<u8> {
+    let mut data = vec![0u8; DDS_DX10_TOTAL_HEADER_SIZE];
+
+    create_dds_header_base(&mut data, 4, 4, 1, true);
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"DX10");
+    let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
+    unsafe { writer.write_u32_at(DXGI_FORMAT_BC7_UNORM, 0x80) };
+
+    data
+}
+
+/// Creates a DDS file that's too small to contain a complete header
+/// Use this to test error conditions for truncated files
+pub fn create_truncated_dds(size: usize) -> Vec<u8> {
+    let mut data = vec![0u8; size];
+
+    // Only set magic if there's room
+    if size >= 4 {
+        let mut writer = unsafe { LittleEndianWriter::new(data.as_mut_ptr()) };
+        unsafe { writer.write_u32_at(DDS_MAGIC, 0) };
+    }
+
+    data
+}
+
+/// Helper function to create a BC1 DDS with leftover data for testing
+pub fn create_bc1_dds_with_leftover_data(width: u32, height: u32, leftover_data: &[u8]) -> Vec<u8> {
+    let mut base_dds = create_valid_bc1_dds_with_dimensions(width, height, 1);
+    base_dds.extend_from_slice(leftover_data);
+    base_dds
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -13,6 +13,7 @@ extern crate std;
 pub use alloc::{boxed::Box, format, string::String, vec, vec::Vec};
 
 // Re-export std items for tests that need them
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 pub use std::is_x86_feature_detected;
 
 // External crates commonly used in tests


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing uncompressed DDS formats (RGBA8888 and ARGB8888).
  * DDS info now includes accurate texture data length calculation.

* **Bug Fixes**
  * Improved validation to ensure input buffer matches declared texture size, returning detailed errors if too short.
  * Texture data is now strictly processed according to declared offsets and lengths, with leftover data preserved.

* **Documentation**
  * Expanded and clarified documentation for implementing custom file format handlers and DDS parsing.
  * Added detailed implementation checklists and security considerations.

* **Tests**
  * Enhanced and refactored test helpers for more realistic DDS data creation and error scenarios.
  * Added new tests for uncompressed formats, buffer size validation, and data preservation.

* **Chores**
  * Added new dependencies for endian-aware reading and writing.
  * Introduced big endian testing steps in verification instructions and templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->