### PR TITLE
Added: BC2 file-formats-api Support for Transform/Untransform & Bundles

### DIFF
--- a/projects/api/dxt-lossless-transform-file-formats-api/src/bundle/bc1.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/bundle/bc1.rs
@@ -57,10 +57,9 @@ where
                     Bc1Error::InvalidLength(len) => {
                         TransformError::Bc1(Bc1Error::InvalidLength(len))
                     }
-                    dxt_lossless_transform_bc1_api::Bc1Error::OutputBufferTooSmall {
-                        needed,
-                        actual,
-                    } => TransformError::Bc1(Bc1Error::OutputBufferTooSmall { needed, actual }),
+                    Bc1Error::OutputBufferTooSmall { needed, actual } => {
+                        TransformError::Bc1(Bc1Error::OutputBufferTooSmall { needed, actual })
+                    }
                     Bc1Error::AllocationFailed => TransformError::Bc1(Bc1Error::AllocationFailed),
                     Bc1Error::SizeEstimationFailed(err) => TransformError::Bc1(
                         Bc1Error::SizeEstimationFailed(alloc::format!("{err:?}")),

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/bundle/bc2.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/bundle/bc2.rs
@@ -1,4 +1,72 @@
-//! BC2 transform builder implementation (placeholder).
+//! BC2 transform builder implementation.
 
-/// BC2 transform builder (placeholder type for future implementation)
-pub(super) struct Bc2TransformBuilder;
+extern crate alloc;
+
+use crate::error::TransformError;
+use dxt_lossless_transform_api_common::estimate::NoEstimation;
+use dxt_lossless_transform_api_common::estimate::SizeEstimationOperations;
+use dxt_lossless_transform_bc2::Bc2TransformSettings;
+use dxt_lossless_transform_bc2_api::Bc2Error;
+use dxt_lossless_transform_bc2_api::{Bc2AutoTransformBuilder, Bc2ManualTransformBuilder};
+
+/// BC2 transform builder that transparently supports both manual and automatic optimization.
+///
+/// This enum wraps both [`Bc2ManualTransformBuilder`] and [`Bc2AutoTransformBuilder`]
+/// to provide a unified interface for BC2 transformation operations.
+pub(super) enum Bc2Builder<T = NoEstimation>
+where
+    T: SizeEstimationOperations,
+{
+    /// Manual transform builder with explicit configuration
+    Manual(Bc2ManualTransformBuilder),
+    /// Automatic transform builder with size estimation optimization
+    Auto(Bc2AutoTransformBuilder<T>),
+}
+
+impl<T> Bc2Builder<T>
+where
+    T: SizeEstimationOperations,
+    T::Error: core::fmt::Debug,
+{
+    /// Transform a slice and return the transform details.
+    ///
+    /// This method handles both manual and automatic transform builders transparently.
+    /// For automatic builders, it will find the optimal settings and apply them.
+    /// For manual builders, it will use the pre-configured settings.
+    ///
+    /// # Parameters
+    /// - `input`: Input texture data to transform
+    /// - `output`: Output buffer for transformed data (must be at least the same size as input)
+    ///
+    /// # Returns
+    /// The transform settings that were used, which can be embedded in the file header.
+    pub(super) fn transform_slice_with_details(
+        &self,
+        input: &[u8],
+        output: &mut [u8],
+    ) -> Result<Bc2TransformSettings, TransformError> {
+        match self {
+            Bc2Builder::Manual(builder) => {
+                // Get settings before transforming
+                let settings = builder.get_settings();
+                builder.transform(input, output)?;
+                Ok(settings)
+            }
+            Bc2Builder::Auto(builder) => {
+                let settings = builder.transform(input, output).map_err(|e| match e {
+                    Bc2Error::InvalidLength(len) => {
+                        TransformError::Bc2(Bc2Error::InvalidLength(len))
+                    }
+                    Bc2Error::OutputBufferTooSmall { needed, actual } => {
+                        TransformError::Bc2(Bc2Error::OutputBufferTooSmall { needed, actual })
+                    }
+                    Bc2Error::AllocationFailed => TransformError::Bc2(Bc2Error::AllocationFailed),
+                    Bc2Error::SizeEstimationFailed(err) => TransformError::Bc2(
+                        Bc2Error::SizeEstimationFailed(alloc::format!("{err:?}")),
+                    ),
+                })?;
+                Ok(settings.get_settings())
+            }
+        }
+    }
+}

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/bundle/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/bundle/mod.rs
@@ -158,7 +158,7 @@ where
                 let details = builder
                     .transform_slice_with_details(input_texture_data, output_texture_data)?;
 
-                crate::embed::formats::EmbeddableBc2Details::from_settings(details).to_header()
+                crate::embed::EmbeddableBc2Details::from_settings(details).to_header()
             }
             _ => {
                 return Err(TransformError::UnknownTransformFormat);

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc2.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc2.rs
@@ -3,6 +3,8 @@
 use super::EmbeddableTransformDetails;
 use crate::embed::{EmbedError, TransformFormat};
 use bitfield::bitfield;
+use dxt_lossless_transform_bc2::Bc2TransformSettings;
+use dxt_lossless_transform_common::color_565::YCoCgVariant;
 
 /// Header version for BC2 format
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,7 +32,9 @@ bitfield! {
     ///
     /// Bit layout (within the 28-bit format data):
     /// - Bits 0-1: Header version (2 bits)
-    /// - Bits 2-27: Reserved for future use (26 bits)
+    /// - Bit 2: Split colour endpoints (1 bit)
+    /// - Bits 3-4: Decorrelation mode (2 bits, [`YCoCgVariant`] as u8)
+    /// - Bits 5-27: Reserved for future use (23 bits)
     #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
      struct Bc2TransformHeaderData(u32);
     impl Debug;
@@ -38,33 +42,163 @@ bitfield! {
 
     /// Header version (2 bits)
     header_version, set_header_version: 1, 0;
-    /// Reserved bits for future use (26 bits)
-    reserved, set_reserved: 27, 2;
+    /// Split colour endpoints flag (1 bit)
+    split_colour_endpoints, set_split_colour_endpoints: 2;
+    /// Decorrelation mode (2 bits)
+    decorrelation_mode, set_decorrelation_mode: 4, 3;
+    /// Reserved bits for future use (23 bits)
+    reserved, set_reserved: 27, 5;
 }
 
 /// BC2 transform details that can be stored in file headers
 ///
-/// BC2 currently has no configurable options, so this is just a marker type.
+/// Contains the BC2 transform settings that were used during compression.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-struct EmbeddableBc2Details;
+pub(crate) struct EmbeddableBc2Details(Bc2TransformSettings);
+
+impl Bc2TransformHeaderData {
+    /// Convert [`YCoCgVariant`] to u32 representation
+    fn variant_to_u32(variant: YCoCgVariant) -> u32 {
+        match variant {
+            // These are 1:1 mappings at time of writing, so a no-op.
+            YCoCgVariant::Variant1 => 0,
+            YCoCgVariant::Variant2 => 1,
+            YCoCgVariant::Variant3 => 2,
+            YCoCgVariant::None => 3,
+        }
+    }
+
+    /// Convert u32 to [`YCoCgVariant`]
+    fn u32_to_variant(value: u32) -> Result<YCoCgVariant, EmbedError> {
+        match value {
+            0 => Ok(YCoCgVariant::Variant1),
+            1 => Ok(YCoCgVariant::Variant2),
+            2 => Ok(YCoCgVariant::Variant3),
+            3 => Ok(YCoCgVariant::None),
+            _ => Err(EmbedError::CorruptedEmbeddedData),
+        }
+    }
+
+    /// Create [`Bc2TransformHeaderData`] from [`Bc2TransformSettings`]
+    fn from_transform_settings(settings: &Bc2TransformSettings) -> Self {
+        let mut header = Self::default();
+        header.set_header_version(Bc2HeaderVersion::InitialVersion.to_u32());
+        header.set_decorrelation_mode(Self::variant_to_u32(settings.decorrelation_mode));
+        header.set_split_colour_endpoints(settings.split_colour_endpoints);
+        header.set_reserved(0);
+        header
+    }
+
+    /// Convert [`Bc2TransformHeaderData`] to [`Bc2TransformSettings`]
+    fn to_transform_settings(self) -> Result<Bc2TransformSettings, EmbedError> {
+        // Validate version (from_u32 will error on invalid version)
+        let _version = Bc2HeaderVersion::from_u32(self.header_version())?;
+        let decorrelation_mode = Self::u32_to_variant(self.decorrelation_mode())?;
+
+        Ok(Bc2TransformSettings {
+            decorrelation_mode,
+            split_colour_endpoints: self.split_colour_endpoints(),
+        })
+    }
+}
 
 impl EmbeddableTransformDetails for EmbeddableBc2Details {
     const FORMAT: TransformFormat = TransformFormat::Bc2;
 
     fn pack(&self) -> u32 {
-        let mut header = Bc2TransformHeaderData::default();
-        header.set_header_version(Bc2HeaderVersion::InitialVersion.to_u32());
-        header.set_reserved(0);
-        header.0
+        Bc2TransformHeaderData::from_transform_settings(&self.0).0
     }
 
     fn unpack(data: u32) -> Result<Self, EmbedError> {
-        let header = Bc2TransformHeaderData(data);
+        Ok(Self(Bc2TransformHeaderData(data).to_transform_settings()?))
+    }
+}
 
-        // Validate version
-        let _version = Bc2HeaderVersion::from_u32(header.header_version())?;
+impl EmbeddableBc2Details {
+    /// Create a [`TransformHeader`] from this embeddable BC2 details (internal use only).
+    ///
+    /// [`TransformHeader`]: crate::embed::TransformHeader
+    pub(crate) fn to_header(self) -> crate::embed::TransformHeader {
+        crate::embed::TransformHeader::new(Self::FORMAT, self.pack())
+    }
 
-        // BC2 currently has no configurable options
-        Ok(Self)
+    /// Create embeddable details from BC2 transform settings.
+    ///
+    /// # Parameters
+    /// - `settings`: The BC2 transform settings to embed
+    ///
+    /// # Returns
+    /// Embeddable details containing the settings
+    pub(crate) fn from_settings(settings: Bc2TransformSettings) -> Self {
+        Self(settings)
+    }
+
+    /// Get the BC2 transform settings from the embeddable details.
+    ///
+    /// # Returns
+    /// The BC2 transform settings contained in this instance
+    pub(crate) fn get_settings(&self) -> Bc2TransformSettings {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_roundtrip_all_possible_transform_details() {
+        for settings in Bc2TransformSettings::all_combinations() {
+            let embeddable = EmbeddableBc2Details::from_settings(settings);
+
+            let packed = embeddable.pack();
+            let recovered = EmbeddableBc2Details::unpack(packed).unwrap();
+            assert_eq!(
+                settings,
+                recovered.get_settings(),
+                "Failed for settings {settings:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_header_version_and_reserved_fields() {
+        let settings = Bc2TransformSettings {
+            decorrelation_mode: YCoCgVariant::Variant1,
+            split_colour_endpoints: true,
+        };
+
+        let header = Bc2TransformHeaderData::from_transform_settings(&settings);
+
+        // Verify version is set correctly
+        assert_eq!(
+            header.header_version(),
+            Bc2HeaderVersion::InitialVersion.to_u32()
+        );
+        // Verify reserved field is set to zero
+        assert_eq!(header.reserved(), 0);
+
+        // Verify actual data fields are set correctly
+        assert!(header.split_colour_endpoints());
+        assert_eq!(header.decorrelation_mode(), 0); // Variant1 = 0
+    }
+
+    #[test]
+    fn test_invalid_header_version() {
+        // Create header with invalid version
+        let mut invalid_header = Bc2TransformHeaderData::default();
+        invalid_header.set_header_version(3); // Invalid version (only 0 is valid)
+
+        // Should fail to convert to transform settings due to invalid version
+        assert_eq!(
+            invalid_header.to_transform_settings(),
+            Err(EmbedError::CorruptedEmbeddedData)
+        );
+    }
+
+    #[test]
+    fn test_format_association() {
+        // Verify the format association is correct
+        assert_eq!(EmbeddableBc2Details::FORMAT, TransformFormat::Bc2);
     }
 }

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
@@ -1,14 +1,14 @@
 //! BCx format-specific embeddable implementations.
 
 mod bc1;
-#[allow(dead_code)]
-mod bc2; // code not ready, placeholder
+mod bc2;
 #[allow(dead_code)]
 mod bc3; // code not ready, placeholder
 #[allow(dead_code)]
 mod bc7; // code not ready, placeholder
 
 pub(crate) use bc1::EmbeddableBc1Details;
+pub(crate) use bc2::EmbeddableBc2Details;
 
 use super::{EmbedError, TransformFormat, TransformHeader};
 

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
@@ -71,6 +71,7 @@ pub use transform_format::TransformFormat;
 // Internal re-exports (used only within file-formats-api crate)
 pub(super) use embed_error::EmbedError;
 pub(super) use formats::EmbeddableBc1Details;
+pub(super) use formats::EmbeddableBc2Details;
 
 /// Size of the transform header in bytes.
 ///

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/error.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/error.rs
@@ -66,6 +66,10 @@ pub enum TransformError {
     #[error("BC1 transform error: {0}")]
     Bc1(#[from] dxt_lossless_transform_bc1_api::Bc1Error),
 
+    /// BC2 transform error
+    #[error("BC2 transform error: {0}")]
+    Bc2(#[from] dxt_lossless_transform_bc2_api::Bc2Error<alloc::string::String>),
+
     /// Unrecognized transform format in header - the transform header contains an unsupported format variant
     #[error("Unrecognized or unsupported transform format in header")]
     UnknownTransformFormat,


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added full support for BC2 texture format transformation and untransformation, including manual and automatic optimization modes.
  * Enhanced BC2 transform settings can now be embedded and extracted from texture headers, enabling round-trip serialization and validation.
  * Users can configure BC2 transform builders and process BC2 textures alongside BC1.
* **Bug Fixes**
  * Improved error handling for BC2 transformations with detailed error messages and validation.
* **Documentation**
  * Updated comments and documentation to reflect expanded support for BC2 format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->