### PR TITLE
Changed: Use `CARGO_MANIFEST_DIR` instead of cwd

### DIFF
--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
@@ -62,19 +62,21 @@ fn is_supported_format(file_path: &Path) -> Result<bool, EndianTestError> {
     }
 }
 
+/// Helper function to navigate up multiple parent directories
+fn go_up_parents(path: &Path, levels: usize) -> &Path {
+    let mut current = path;
+    for _ in 0..levels {
+        current = current.parent().unwrap();
+    }
+    current
+}
+
 /// Get all .dds files from the assets test directory
 fn get_test_files() -> Result<Vec<fs::DirEntry>, EndianTestError> {
     use crate::util::find_all_files;
 
-    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .join("assets")
-        .join("tests");
+    let workspace_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
+    let assets_dir = workspace_root.join("assets").join("tests");
     let mut entries = Vec::new();
 
     find_all_files(&assets_dir, &mut entries)?;
@@ -134,13 +136,7 @@ pub fn run_all_endian_tests() -> Result<Vec<EndianTestResult>, EndianTestError> 
 /// Run endianness test for a single file
 fn run_single_endian_test(test_file: &fs::DirEntry) -> Result<EndianTestResult, EndianTestError> {
     // Create isolated temporary directories with random names in project-relative location
-    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap();
+    let project_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
     let tmp_base = project_root.join("tmp");
     fs::create_dir_all(&tmp_base)?;
 
@@ -230,13 +226,7 @@ fn run_transform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap();
+    let project_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")
@@ -275,13 +265,7 @@ fn run_untransform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap()
-        .parent()
-        .unwrap();
+    let project_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
@@ -66,7 +66,15 @@ fn is_supported_format(file_path: &Path) -> Result<bool, EndianTestError> {
 fn get_test_files() -> Result<Vec<fs::DirEntry>, EndianTestError> {
     use crate::util::find_all_files;
 
-    let assets_dir = std::env::current_dir()?.join("assets").join("tests");
+    let assets_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .join("assets")
+        .join("tests");
     let mut entries = Vec::new();
 
     find_all_files(&assets_dir, &mut entries)?;
@@ -126,7 +134,13 @@ pub fn run_all_endian_tests() -> Result<Vec<EndianTestResult>, EndianTestError> 
 /// Run endianness test for a single file
 fn run_single_endian_test(test_file: &fs::DirEntry) -> Result<EndianTestResult, EndianTestError> {
     // Create isolated temporary directories with random names in project-relative location
-    let project_root = std::env::current_dir()?;
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
     let tmp_base = project_root.join("tmp");
     fs::create_dir_all(&tmp_base)?;
 
@@ -216,7 +230,13 @@ fn run_transform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = std::env::current_dir()?;
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")
@@ -255,7 +275,13 @@ fn run_untransform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = std::env::current_dir()?;
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap()
+        .parent()
+        .unwrap();
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
@@ -62,20 +62,14 @@ fn is_supported_format(file_path: &Path) -> Result<bool, EndianTestError> {
     }
 }
 
-/// Helper function to navigate up multiple parent directories
-fn go_up_parents(path: &Path, levels: usize) -> &Path {
-    let mut current = path;
-    for _ in 0..levels {
-        current = current.parent().unwrap();
-    }
-    current
-}
-
 /// Get all .dds files from the assets test directory
 fn get_test_files() -> Result<Vec<fs::DirEntry>, EndianTestError> {
     use crate::util::find_all_files;
 
-    let workspace_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let assets_dir = workspace_root.join("assets").join("tests");
     let mut entries = Vec::new();
 
@@ -136,7 +130,10 @@ pub fn run_all_endian_tests() -> Result<Vec<EndianTestResult>, EndianTestError> 
 /// Run endianness test for a single file
 fn run_single_endian_test(test_file: &fs::DirEntry) -> Result<EndianTestResult, EndianTestError> {
     // Create isolated temporary directories with random names in project-relative location
-    let project_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let tmp_base = project_root.join("tmp");
     fs::create_dir_all(&tmp_base)?;
 
@@ -226,7 +223,10 @@ fn run_transform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")
@@ -265,7 +265,10 @@ fn run_untransform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = go_up_parents(Path::new(env!("CARGO_MANIFEST_DIR")), 3);
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the method for locating the project root directory, ensuring more consistent and reliable path resolution throughout the tool. No changes to user-facing features or workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->