### PR TITLE
Changed: Don't ignore warnings when building with `debug-endian`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -107,7 +107,6 @@ jobs:
         with:
           toolchain: stable
           cache: false
-          rustflags: ""
 
       - name: Setup Rust Caching
         uses: Swatinem/rust-cache@v2
@@ -121,7 +120,7 @@ jobs:
         run: RUSTFLAGS="" cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Validate Cross-Endian Transformations
-        run: RUSTFLAGS="" cargo run --bin dxt-lossless-transform-cli --features debug-endian -- debug-endian
+        run: cargo run --bin dxt-lossless-transform-cli --features debug-endian -- debug-endian
 
   build-cli:
     strategy:

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_endian/endian_test.rs
@@ -66,7 +66,11 @@ fn is_supported_format(file_path: &Path) -> Result<bool, EndianTestError> {
 fn get_test_files() -> Result<Vec<fs::DirEntry>, EndianTestError> {
     use crate::util::find_all_files;
 
-    let assets_dir = std::env::current_dir()?.join("assets").join("tests");
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
+    let assets_dir = workspace_root.join("assets").join("tests");
     let mut entries = Vec::new();
 
     find_all_files(&assets_dir, &mut entries)?;
@@ -126,7 +130,10 @@ pub fn run_all_endian_tests() -> Result<Vec<EndianTestResult>, EndianTestError> 
 /// Run endianness test for a single file
 fn run_single_endian_test(test_file: &fs::DirEntry) -> Result<EndianTestResult, EndianTestError> {
     // Create isolated temporary directories with random names in project-relative location
-    let project_root = std::env::current_dir()?;
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let tmp_base = project_root.join("tmp");
     fs::create_dir_all(&tmp_base)?;
 
@@ -216,7 +223,10 @@ fn run_transform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = std::env::current_dir()?;
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")
@@ -255,7 +265,10 @@ fn run_untransform_command(
     output_file: &Path,
 ) -> Result<bool, EndianTestError> {
     // Set target-specific cargo target directory to prevent artifact collisions
-    let project_root = std::env::current_dir()?;
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .unwrap();
     let target_dir = project_root.join("target").join(format!("cross-{target}"));
 
     let output = Command::new("cross")


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->
