### PR TITLE
Rename: ARGB8888 -> BGRA8888 throughout the source code

### DIFF
--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
@@ -1,7 +1,5 @@
 //! BCx format-specific embeddable implementations.
 
-#[allow(dead_code)]
-mod argb8888;
 mod bc1;
 mod bc2;
 #[allow(dead_code)]
@@ -9,11 +7,13 @@ mod bc3; // code not ready, placeholder
 #[allow(dead_code)]
 mod bc7; // code not ready, placeholder
 #[allow(dead_code)]
+mod bgra8888;
+#[allow(dead_code)]
 mod rgba8888;
 
-pub(crate) use argb8888::EmbeddableArgb8888Details;
 pub(crate) use bc1::EmbeddableBc1Details;
 pub(crate) use bc2::EmbeddableBc2Details;
+pub(crate) use bgra8888::EmbeddableBgra8888Details;
 pub(crate) use rgba8888::EmbeddableRgba8888Details;
 
 use super::{EmbedError, TransformFormat, TransformHeader};

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
@@ -70,10 +70,10 @@ pub use transform_format::TransformFormat;
 
 // Internal re-exports (used only within file-formats-api crate)
 pub(super) use embed_error::EmbedError;
-#[allow(unused_imports)]
-pub(super) use formats::EmbeddableArgb8888Details;
 pub(super) use formats::EmbeddableBc1Details;
 pub(super) use formats::EmbeddableBc2Details;
+#[allow(unused_imports)]
+pub(super) use formats::EmbeddableBgra8888Details;
 #[allow(unused_imports)]
 pub(super) use formats::EmbeddableRgba8888Details;
 
@@ -172,7 +172,7 @@ mod tests {
         );
         assert_eq!(
             TransformFormat::from_u8(0x06),
-            Some(TransformFormat::Argb8888)
+            Some(TransformFormat::Bgra8888)
         );
         assert_eq!(TransformFormat::from_u8(0x0F), None);
 
@@ -182,7 +182,7 @@ mod tests {
         assert_eq!(TransformFormat::Bc7.to_u8(), 0x03);
         assert_eq!(TransformFormat::Bc6H.to_u8(), 0x04);
         assert_eq!(TransformFormat::Rgba8888.to_u8(), 0x05);
-        assert_eq!(TransformFormat::Argb8888.to_u8(), 0x06);
+        assert_eq!(TransformFormat::Bgra8888.to_u8(), 0x06);
     }
 
     #[test]

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
@@ -20,8 +20,8 @@ pub enum TransformFormat {
     Bc6H = 0x04,
     /// RGBA8888 format transform
     Rgba8888 = 0x05,
-    /// ARGB8888 format transform
-    Argb8888 = 0x06,
+    /// BGRA8888 format transform
+    Bgra8888 = 0x06,
 }
 
 impl TransformFormat {
@@ -38,7 +38,7 @@ impl TransformFormat {
             0x03 => Some(Self::Bc7),
             0x04 => Some(Self::Bc6H),
             0x05 => Some(Self::Rgba8888),
-            0x06 => Some(Self::Argb8888),
+            0x06 => Some(Self::Bgra8888),
             _ => None,
         }
     }
@@ -52,7 +52,7 @@ impl TransformFormat {
             Self::Bc7 => 0x03,
             Self::Bc6H => 0x04,
             Self::Rgba8888 => 0x05,
-            Self::Argb8888 => 0x06,
+            Self::Bgra8888 => 0x06,
         }
     }
 }

--- a/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
+++ b/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
@@ -46,8 +46,8 @@ pub enum TransformFormatFilter {
     Bc6H,
     /// Extract only RGBA8888 pixels
     Rgba8888,
-    /// Extract only ARGB8888 pixels
-    Argb8888,
+    /// Extract only BGRA8888 pixels
+    Bgra8888,
     /// Extract all supported [`TransformFormat`]s
     All,
 }
@@ -63,7 +63,7 @@ impl TransformFormatFilter {
                 | (TransformFormatFilter::Bc7, TransformFormat::Bc7)
                 | (TransformFormatFilter::Bc6H, TransformFormat::Bc6H)
                 | (TransformFormatFilter::Rgba8888, TransformFormat::Rgba8888)
-                | (TransformFormatFilter::Argb8888, TransformFormat::Argb8888)
+                | (TransformFormatFilter::Bgra8888, TransformFormat::Bgra8888)
                 | (TransformFormatFilter::All, _)
         )
     }
@@ -80,10 +80,10 @@ impl core::str::FromStr for TransformFormatFilter {
             "bc7" => Ok(TransformFormatFilter::Bc7),
             "bc6h" => Ok(TransformFormatFilter::Bc6H),
             "rgba8888" => Ok(TransformFormatFilter::Rgba8888),
-            "argb8888" => Ok(TransformFormatFilter::Argb8888),
+            "bgra8888" => Ok(TransformFormatFilter::Bgra8888),
             "all" => Ok(TransformFormatFilter::All),
             _ => Err(format!(
-                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, argb8888, all"
+                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, bgra8888, all"
             )),
         }
     }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -94,8 +94,8 @@ pub(crate) const RGBA8888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const RGBA8888_BLUE_MASK: u32 = 0x00FF0000;
 pub(crate) const RGBA8888_ALPHA_MASK: u32 = 0xFF000000;
 
-// B8G8R8A8_UNORM: R=byte2, G=byte1, B=byte0, A=byte3 (0xAAGGRRBB)
-pub(crate) const ARGB8888_RED_MASK: u32 = 0x00FF0000;
-pub(crate) const ARGB8888_GREEN_MASK: u32 = 0x0000FF00;
-pub(crate) const ARGB8888_BLUE_MASK: u32 = 0x000000FF;
-pub(crate) const ARGB8888_ALPHA_MASK: u32 = 0xFF000000;
+// B8G8R8A8_UNORM: R=byte2, G=byte1, B=byte0, A=byte3 (0xAARRGGBB)
+pub(crate) const BGRA8888_RED_MASK: u32 = 0x00FF0000;
+pub(crate) const BGRA8888_GREEN_MASK: u32 = 0x0000FF00;
+pub(crate) const BGRA8888_BLUE_MASK: u32 = 0x000000FF;
+pub(crate) const BGRA8888_ALPHA_MASK: u32 = 0xFF000000;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -21,8 +21,8 @@ pub enum DdsFormat {
     BC7 = 6,
     /// RGBA8888 format (32-bit with alpha)
     RGBA8888 = 7,
-    /// ARGB8888 format (32-bit with alpha, different byte order)
-    ARGB8888 = 8,
+    /// BGRA8888 format (32-bit with alpha, different byte order)
+    BGRA8888 = 8,
 }
 
 /// The information of the DDS file supplied to the reader.
@@ -113,7 +113,7 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
             | DXGI_FORMAT_R8G8B8A8_SINT => DdsFormat::RGBA8888,
             DXGI_FORMAT_B8G8R8A8_UNORM
             | DXGI_FORMAT_B8G8R8A8_TYPELESS
-            | DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => DdsFormat::ARGB8888,
+            | DXGI_FORMAT_B8G8R8A8_UNORM_SRGB => DdsFormat::BGRA8888,
             _ => DdsFormat::Unknown,
         };
 
@@ -183,13 +183,13 @@ fn detect_uncompressed_format(data: &[u8]) -> DdsFormat {
                 {
                     DdsFormat::RGBA8888
                 }
-                // Check for ARGB8888 (B8G8R8A8_UNORM)
-                else if r_mask == ARGB8888_RED_MASK
-                    && g_mask == ARGB8888_GREEN_MASK
-                    && b_mask == ARGB8888_BLUE_MASK
-                    && a_mask == ARGB8888_ALPHA_MASK
+                // Check for BGRA8888 (B8G8R8A8_UNORM)
+                else if r_mask == BGRA8888_RED_MASK
+                    && g_mask == BGRA8888_GREEN_MASK
+                    && b_mask == BGRA8888_BLUE_MASK
+                    && a_mask == BGRA8888_ALPHA_MASK
                 {
-                    DdsFormat::ARGB8888
+                    DdsFormat::BGRA8888
                 } else {
                     DdsFormat::Unknown
                 }
@@ -229,7 +229,7 @@ fn calculate_data_length(format: DdsFormat, data: &[u8]) -> Option<u32> {
         DdsFormat::BC1 | DdsFormat::BC2 | DdsFormat::BC3 | DdsFormat::BC6H | DdsFormat::BC7 => {
             calculate_data_length_for_block_compression(format, width, height, mipmap_count)
         }
-        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => {
+        DdsFormat::RGBA8888 | DdsFormat::BGRA8888 => {
             // 32-bit formats (4 bytes per pixel)
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
         }
@@ -285,7 +285,7 @@ pub(crate) fn calculate_data_length_for_block_compression(
 
             Some(total_size)
         }
-        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => {
+        DdsFormat::RGBA8888 | DdsFormat::BGRA8888 => {
             // 32-bit uncompressed formats
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
         }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
@@ -103,13 +103,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_transform_format_argb8888_supported() {
+    fn test_get_transform_format_bgra8888_supported() {
         let handler = super::super::DdsHandler;
-        let dds_data = create_valid_argb8888_dds_with_dimensions(64, 64, 1);
+        let dds_data = create_valid_bgra8888_dds_with_dimensions(64, 64, 1);
 
         let result = handler.get_transform_format(&dds_data, TransformFormatFilter::All);
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Some(TransformFormat::Argb8888));
+        assert_eq!(result.unwrap(), Some(TransformFormat::Bgra8888));
     }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
@@ -31,7 +31,7 @@ use dxt_lossless_transform_file_formats_api::{
 /// - BC6H - known but unimplemented
 /// - BC7 - known but unimplemented
 /// - RGBA8888 - implemented
-/// - ARGB8888 - implemented
+/// - BGRA8888 - implemented
 ///
 /// # Unsupported Formats
 ///
@@ -72,7 +72,7 @@ pub(crate) fn dds_format_to_transform_format(
             }
         }
         DdsFormat::RGBA8888 => Ok(TransformFormat::Rgba8888),
-        DdsFormat::ARGB8888 => Ok(TransformFormat::Argb8888),
+        DdsFormat::BGRA8888 => Ok(TransformFormat::Bgra8888),
         DdsFormat::NotADds | DdsFormat::Unknown => Err(TransformError::FormatHandler(
             FormatHandlerError::UnknownFileFormat,
         )),
@@ -98,8 +98,8 @@ mod tests {
             TransformFormat::Rgba8888
         );
         assert_eq!(
-            dds_format_to_transform_format(DdsFormat::ARGB8888, false).unwrap(),
-            TransformFormat::Argb8888
+            dds_format_to_transform_format(DdsFormat::BGRA8888, false).unwrap(),
+            TransformFormat::Bgra8888
         );
         assert_eq!(
             dds_format_to_transform_format(DdsFormat::BC1, true).unwrap(),
@@ -114,8 +114,8 @@ mod tests {
             TransformFormat::Rgba8888
         );
         assert_eq!(
-            dds_format_to_transform_format(DdsFormat::ARGB8888, true).unwrap(),
-            TransformFormat::Argb8888
+            dds_format_to_transform_format(DdsFormat::BGRA8888, true).unwrap(),
+            TransformFormat::Bgra8888
         );
     }
 

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -147,7 +147,7 @@ pub fn create_valid_dds_with_dimensions(
                 .unwrap_or(0) as usize,
             true,
         ),
-        DdsFormat::RGBA8888 | DdsFormat::ARGB8888 => {
+        DdsFormat::RGBA8888 | DdsFormat::BGRA8888 => {
             // 32-bit uncompressed formats
             (
                 calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4).unwrap_or(0)
@@ -198,13 +198,13 @@ pub fn create_valid_dds_with_dimensions(
                 RGBA8888_ALPHA_MASK,
             );
         }
-        DdsFormat::ARGB8888 => {
+        DdsFormat::BGRA8888 => {
             write_uncompressed_pixel_format(
                 &mut data,
-                ARGB8888_RED_MASK,
-                ARGB8888_GREEN_MASK,
-                ARGB8888_BLUE_MASK,
-                ARGB8888_ALPHA_MASK,
+                BGRA8888_RED_MASK,
+                BGRA8888_GREEN_MASK,
+                BGRA8888_BLUE_MASK,
+                BGRA8888_ALPHA_MASK,
             );
         }
         DdsFormat::Unknown => {
@@ -239,13 +239,13 @@ pub fn create_valid_rgba8888_dds_with_dimensions(
     create_valid_dds_with_dimensions(DdsFormat::RGBA8888, width, height, mipmap_count)
 }
 
-/// Helper function to create a valid ARGB8888 DDS with proper dimensions and data length
-pub fn create_valid_argb8888_dds_with_dimensions(
+/// Helper function to create a valid BGRA8888 DDS with proper dimensions and data length
+pub fn create_valid_bgra8888_dds_with_dimensions(
     width: u32,
     height: u32,
     mipmap_count: u32,
 ) -> Vec<u8> {
-    create_valid_dds_with_dimensions(DdsFormat::ARGB8888, width, height, mipmap_count)
+    create_valid_dds_with_dimensions(DdsFormat::BGRA8888, width, height, mipmap_count)
 }
 
 // Semantic helper functions for clearer test intent

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
@@ -44,8 +44,8 @@ enum FormatKey {
     Bc6H = 5,
     /// RGBA8888 format transform (TransformFormat::Rgba8888 = 0x05 -> FormatKey = 6)
     Rgba8888 = 6,
-    /// ARGB8888 format transform (TransformFormat::Argb8888 = 0x06 -> FormatKey = 7)
-    Argb8888 = 7,
+    /// BGRA8888 format transform (TransformFormat::Bgra8888 = 0x06 -> FormatKey = 7)
+    Bgra8888 = 7,
 }
 
 impl From<Option<TransformFormat>> for FormatKey {
@@ -60,7 +60,7 @@ impl From<Option<TransformFormat>> for FormatKey {
                     TransformFormat::Bc7 => Self::Bc7,           // 0x03 -> 4
                     TransformFormat::Bc6H => Self::Bc6H,         // 0x04 -> 5
                     TransformFormat::Rgba8888 => Self::Rgba8888, // 0x05 -> 6
-                    TransformFormat::Argb8888 => Self::Argb8888, // 0x06 -> 7
+                    TransformFormat::Bgra8888 => Self::Bgra8888, // 0x06 -> 7
                     _ => Self::Unknown, // Handle any future variants as unknown
                 }
             }
@@ -80,7 +80,7 @@ impl FormatKey {
             Self::Bc7 => "Bc7",
             Self::Bc6H => "Bc6H",
             Self::Rgba8888 => "Rgba8888",
-            Self::Argb8888 => "Argb8888",
+            Self::Bgra8888 => "Bgra8888",
         }
     }
 }


### PR DESCRIPTION
I made an error in the mask the first time, I wouldn't make it again 😉

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * All references to the ARGB8888 pixel format have been renamed to BGRA8888 across the application, including enums, structs, constants, test functions, and documentation.
  * Public APIs, test helpers, and internal details now consistently use BGRA8888 for 32-bit pixel formats with alpha channel.
  * No changes to application logic or control flow; updates are limited to naming and documentation for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->