### PR TITLE
Added: Support for recognising Bgr888

### DIFF
--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
@@ -9,11 +9,14 @@ mod bc7; // code not ready, placeholder
 #[allow(dead_code)]
 mod bgra8888;
 #[allow(dead_code)]
+mod rgb888;
+#[allow(dead_code)]
 mod rgba8888;
 
 pub(crate) use bc1::EmbeddableBc1Details;
 pub(crate) use bc2::EmbeddableBc2Details;
 pub(crate) use bgra8888::EmbeddableBgra8888Details;
+pub(crate) use rgb888::EmbeddableRgb888Details;
 pub(crate) use rgba8888::EmbeddableRgba8888Details;
 
 use super::{EmbedError, TransformFormat, TransformHeader};

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
@@ -7,16 +7,16 @@ mod bc3; // code not ready, placeholder
 #[allow(dead_code)]
 mod bc7; // code not ready, placeholder
 #[allow(dead_code)]
-mod bgra8888;
+mod bgr888;
 #[allow(dead_code)]
-mod rgb888;
+mod bgra8888;
 #[allow(dead_code)]
 mod rgba8888;
 
 pub(crate) use bc1::EmbeddableBc1Details;
 pub(crate) use bc2::EmbeddableBc2Details;
+pub(crate) use bgr888::EmbeddableBgr888Details;
 pub(crate) use bgra8888::EmbeddableBgra8888Details;
-pub(crate) use rgb888::EmbeddableRgb888Details;
 pub(crate) use rgba8888::EmbeddableRgba8888Details;
 
 use super::{EmbedError, TransformFormat, TransformHeader};

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/rgb888.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/rgb888.rs
@@ -1,0 +1,148 @@
+//! RGB888 format file format support.
+//!
+//! This module provides RGB888-specific implementations of the file format traits.
+//! Since RGB888 is an uncompressed format, no actual transformation is performed,
+//! but decorrelation can still be applied.
+
+use super::EmbeddableTransformDetails;
+use crate::embed::{EmbedError, TransformFormat, TransformHeader};
+use bitfield::bitfield;
+
+/// Header version for RGB888 format
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Rgb888HeaderVersion {
+    /// Initial version - supports decorrelation
+    InitialVersion = 0,
+}
+
+impl Rgb888HeaderVersion {
+    /// Convert from u32 value
+    fn from_u32(value: u32) -> Result<Self, EmbedError> {
+        match value {
+            0 => Ok(Self::InitialVersion),
+            _ => Err(EmbedError::CorruptedEmbeddedData),
+        }
+    }
+
+    /// Convert to u32 value  
+    fn to_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+bitfield! {
+    /// Packed RGB888 transform data for storage in headers.
+    ///
+    /// Bit layout (within the 28-bit format data):
+    /// - Bits 0-1: Header version (2 bits)
+    /// - Bit 2: Decorrelation flag (1 bit)
+    /// - Bits 3-27: Reserved for future use (25 bits)
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+    struct Rgb888TransformHeaderData(u32);
+    impl Debug;
+    u32;
+
+    /// Header version (2 bits)
+    header_version, set_header_version: 1, 0;
+    /// Whether to apply decorrelation (1 bit)
+    decorrelation, set_decorrelation: 2;
+    /// Reserved for future use (25 bits)
+    reserved, set_reserved: 27, 3;
+}
+
+/// RGB888 transform details for embedding in headers.
+///
+/// Contains settings for RGB888 pixel processing, primarily decorrelation options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EmbeddableRgb888Details(Rgb888TransformHeaderData);
+
+impl EmbeddableRgb888Details {
+    /// Create new RGB888 details with default settings (no decorrelation)
+    pub fn new() -> Self {
+        Self::with_decorrelation(false)
+    }
+
+    /// Create new RGB888 details with specified decorrelation setting
+    pub fn with_decorrelation(decorrelation: bool) -> Self {
+        let mut data = Rgb888TransformHeaderData::default();
+        data.set_header_version(Rgb888HeaderVersion::InitialVersion.to_u32());
+        data.set_decorrelation(decorrelation);
+        data.set_reserved(0);
+        Self(data)
+    }
+
+    /// Convert to a [`TransformHeader`]
+    pub fn to_header(self) -> TransformHeader {
+        crate::embed::TransformHeader::new(Self::FORMAT, self.pack())
+    }
+}
+
+impl Default for EmbeddableRgb888Details {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EmbeddableTransformDetails for EmbeddableRgb888Details {
+    const FORMAT: TransformFormat = TransformFormat::Rgb888;
+
+    fn pack(&self) -> u32 {
+        self.0 .0
+    }
+
+    fn unpack(data: u32) -> Result<Self, EmbedError> {
+        let header_data = Rgb888TransformHeaderData(data);
+
+        // Validate header version
+        Rgb888HeaderVersion::from_u32(header_data.header_version())?;
+
+        // Reserved bits should be zero for forward compatibility
+        if header_data.reserved() != 0 {
+            return Err(EmbedError::CorruptedEmbeddedData);
+        }
+
+        Ok(Self(header_data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rgb888_details_default() {
+        let details = EmbeddableRgb888Details::new();
+        // Test that default details can be created
+        assert_eq!(details, EmbeddableRgb888Details::with_decorrelation(false));
+    }
+
+    #[test]
+    fn test_rgb888_details_with_decorrelation() {
+        let details_true = EmbeddableRgb888Details::with_decorrelation(true);
+        let details_false = EmbeddableRgb888Details::with_decorrelation(false);
+
+        // Test that different decorrelation settings create different details
+        assert_ne!(details_true, details_false);
+    }
+
+    #[test]
+    fn test_rgb888_pack_unpack_roundtrip() {
+        let original = EmbeddableRgb888Details::with_decorrelation(true);
+        let packed = original.pack();
+        let unpacked = EmbeddableRgb888Details::unpack(packed).unwrap();
+
+        assert_eq!(original, unpacked);
+    }
+
+    #[test]
+    fn test_rgb888_header_roundtrip() {
+        let details = EmbeddableRgb888Details::with_decorrelation(true);
+        let header = details.to_header();
+
+        assert_eq!(header.format(), Some(TransformFormat::Rgb888));
+
+        let recovered = EmbeddableRgb888Details::from_header(header).unwrap();
+        assert_eq!(details, recovered);
+    }
+}

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
@@ -75,6 +75,8 @@ pub(super) use formats::EmbeddableBc2Details;
 #[allow(unused_imports)]
 pub(super) use formats::EmbeddableBgra8888Details;
 #[allow(unused_imports)]
+pub(super) use formats::EmbeddableRgb888Details;
+#[allow(unused_imports)]
 pub(super) use formats::EmbeddableRgba8888Details;
 
 /// Size of the transform header in bytes.
@@ -174,6 +176,10 @@ mod tests {
             TransformFormat::from_u8(0x06),
             Some(TransformFormat::Bgra8888)
         );
+        assert_eq!(
+            TransformFormat::from_u8(0x07),
+            Some(TransformFormat::Rgb888)
+        );
         assert_eq!(TransformFormat::from_u8(0x0F), None);
 
         assert_eq!(TransformFormat::Bc1.to_u8(), 0x00);
@@ -183,6 +189,7 @@ mod tests {
         assert_eq!(TransformFormat::Bc6H.to_u8(), 0x04);
         assert_eq!(TransformFormat::Rgba8888.to_u8(), 0x05);
         assert_eq!(TransformFormat::Bgra8888.to_u8(), 0x06);
+        assert_eq!(TransformFormat::Rgb888.to_u8(), 0x07);
     }
 
     #[test]

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
@@ -73,9 +73,9 @@ pub(super) use embed_error::EmbedError;
 pub(super) use formats::EmbeddableBc1Details;
 pub(super) use formats::EmbeddableBc2Details;
 #[allow(unused_imports)]
-pub(super) use formats::EmbeddableBgra8888Details;
+pub(super) use formats::EmbeddableBgr888Details;
 #[allow(unused_imports)]
-pub(super) use formats::EmbeddableRgb888Details;
+pub(super) use formats::EmbeddableBgra8888Details;
 #[allow(unused_imports)]
 pub(super) use formats::EmbeddableRgba8888Details;
 
@@ -178,7 +178,7 @@ mod tests {
         );
         assert_eq!(
             TransformFormat::from_u8(0x07),
-            Some(TransformFormat::Rgb888)
+            Some(TransformFormat::Bgr888)
         );
         assert_eq!(TransformFormat::from_u8(0x0F), None);
 
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(TransformFormat::Bc6H.to_u8(), 0x04);
         assert_eq!(TransformFormat::Rgba8888.to_u8(), 0x05);
         assert_eq!(TransformFormat::Bgra8888.to_u8(), 0x06);
-        assert_eq!(TransformFormat::Rgb888.to_u8(), 0x07);
+        assert_eq!(TransformFormat::Bgr888.to_u8(), 0x07);
     }
 
     #[test]

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
@@ -22,8 +22,8 @@ pub enum TransformFormat {
     Rgba8888 = 0x05,
     /// BGRA8888 format transform
     Bgra8888 = 0x06,
-    /// RGB888 format transform
-    Rgb888 = 0x07,
+    /// BGR888 format transform
+    Bgr888 = 0x07,
 }
 
 impl TransformFormat {
@@ -41,7 +41,7 @@ impl TransformFormat {
             0x04 => Some(Self::Bc6H),
             0x05 => Some(Self::Rgba8888),
             0x06 => Some(Self::Bgra8888),
-            0x07 => Some(Self::Rgb888),
+            0x07 => Some(Self::Bgr888),
             _ => None,
         }
     }
@@ -56,7 +56,7 @@ impl TransformFormat {
             Self::Bc6H => 0x04,
             Self::Rgba8888 => 0x05,
             Self::Bgra8888 => 0x06,
-            Self::Rgb888 => 0x07,
+            Self::Bgr888 => 0x07,
         }
     }
 }

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
@@ -22,6 +22,8 @@ pub enum TransformFormat {
     Rgba8888 = 0x05,
     /// BGRA8888 format transform
     Bgra8888 = 0x06,
+    /// RGB888 format transform
+    Rgb888 = 0x07,
 }
 
 impl TransformFormat {
@@ -39,6 +41,7 @@ impl TransformFormat {
             0x04 => Some(Self::Bc6H),
             0x05 => Some(Self::Rgba8888),
             0x06 => Some(Self::Bgra8888),
+            0x07 => Some(Self::Rgb888),
             _ => None,
         }
     }
@@ -53,6 +56,7 @@ impl TransformFormat {
             Self::Bc6H => 0x04,
             Self::Rgba8888 => 0x05,
             Self::Bgra8888 => 0x06,
+            Self::Rgb888 => 0x07,
         }
     }
 }

--- a/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
+++ b/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
@@ -48,6 +48,8 @@ pub enum TransformFormatFilter {
     Rgba8888,
     /// Extract only BGRA8888 pixels
     Bgra8888,
+    /// Extract only RGB888 pixels
+    Rgb888,
     /// Extract all supported [`TransformFormat`]s
     All,
 }
@@ -64,6 +66,7 @@ impl TransformFormatFilter {
                 | (TransformFormatFilter::Bc6H, TransformFormat::Bc6H)
                 | (TransformFormatFilter::Rgba8888, TransformFormat::Rgba8888)
                 | (TransformFormatFilter::Bgra8888, TransformFormat::Bgra8888)
+                | (TransformFormatFilter::Rgb888, TransformFormat::Rgb888)
                 | (TransformFormatFilter::All, _)
         )
     }
@@ -81,9 +84,10 @@ impl core::str::FromStr for TransformFormatFilter {
             "bc6h" => Ok(TransformFormatFilter::Bc6H),
             "rgba8888" => Ok(TransformFormatFilter::Rgba8888),
             "bgra8888" => Ok(TransformFormatFilter::Bgra8888),
+            "rgb888" => Ok(TransformFormatFilter::Rgb888),
             "all" => Ok(TransformFormatFilter::All),
             _ => Err(format!(
-                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, bgra8888, all"
+                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, bgra8888, rgb888, all"
             )),
         }
     }

--- a/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
+++ b/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
@@ -48,8 +48,8 @@ pub enum TransformFormatFilter {
     Rgba8888,
     /// Extract only BGRA8888 pixels
     Bgra8888,
-    /// Extract only RGB888 pixels
-    Rgb888,
+    /// Extract only BGR888 pixels
+    Bgr888,
     /// Extract all supported [`TransformFormat`]s
     All,
 }
@@ -66,7 +66,7 @@ impl TransformFormatFilter {
                 | (TransformFormatFilter::Bc6H, TransformFormat::Bc6H)
                 | (TransformFormatFilter::Rgba8888, TransformFormat::Rgba8888)
                 | (TransformFormatFilter::Bgra8888, TransformFormat::Bgra8888)
-                | (TransformFormatFilter::Rgb888, TransformFormat::Rgb888)
+                | (TransformFormatFilter::Bgr888, TransformFormat::Bgr888)
                 | (TransformFormatFilter::All, _)
         )
     }
@@ -84,10 +84,10 @@ impl core::str::FromStr for TransformFormatFilter {
             "bc6h" => Ok(TransformFormatFilter::Bc6H),
             "rgba8888" => Ok(TransformFormatFilter::Rgba8888),
             "bgra8888" => Ok(TransformFormatFilter::Bgra8888),
-            "rgb888" => Ok(TransformFormatFilter::Rgb888),
+            "bgr888" => Ok(TransformFormatFilter::Bgr888),
             "all" => Ok(TransformFormatFilter::All),
             _ => Err(format!(
-                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, bgra8888, rgb888, all"
+                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, bgra8888, bgr888, all"
             )),
         }
     }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -87,20 +87,21 @@ pub(crate) const DDS_PIXELFORMAT_GBITMASK_OFFSET: usize = 0x60;
 pub(crate) const DDS_PIXELFORMAT_BBITMASK_OFFSET: usize = 0x64;
 pub(crate) const DDS_PIXELFORMAT_ABITMASK_OFFSET: usize = 0x68;
 
+// Because of Little Endian, the masks here are reversed.
 // Common pixel format bit masks (verified with TexConv)
-// R8G8B8A8_UNORM: R=byte0, G=byte1, B=byte2, A=byte3 (0xAABBGGRR)
+// R8G8B8A8_UNORM: R=byte0, G=byte1, B=byte2, A=byte3
 pub(crate) const RGBA8888_RED_MASK: u32 = 0x000000FF;
 pub(crate) const RGBA8888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const RGBA8888_BLUE_MASK: u32 = 0x00FF0000;
 pub(crate) const RGBA8888_ALPHA_MASK: u32 = 0xFF000000;
 
-// B8G8R8A8_UNORM: R=byte2, G=byte1, B=byte0, A=byte3 (0xAARRGGBB)
+// B8G8R8A8_UNORM: R=byte2, G=byte1, B=byte0, A=byte3
 pub(crate) const BGRA8888_RED_MASK: u32 = 0x00FF0000;
 pub(crate) const BGRA8888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const BGRA8888_BLUE_MASK: u32 = 0x000000FF;
 pub(crate) const BGRA8888_ALPHA_MASK: u32 = 0xFF000000;
 
-// R8G8B8 (RGB888): R=byte2, G=byte1, B=byte0 (0x00RRGGBB)
-pub(crate) const RGB888_RED_MASK: u32 = 0x00FF0000;
-pub(crate) const RGB888_GREEN_MASK: u32 = 0x0000FF00;
-pub(crate) const RGB888_BLUE_MASK: u32 = 0x000000FF;
+// B8G8R8 (BGR888): R=byte2, G=byte1, B=byte0
+pub(crate) const BGR888_RED_MASK: u32 = 0x00FF0000;
+pub(crate) const BGR888_GREEN_MASK: u32 = 0x0000FF00;
+pub(crate) const BGR888_BLUE_MASK: u32 = 0x000000FF;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -99,3 +99,8 @@ pub(crate) const BGRA8888_RED_MASK: u32 = 0x00FF0000;
 pub(crate) const BGRA8888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const BGRA8888_BLUE_MASK: u32 = 0x000000FF;
 pub(crate) const BGRA8888_ALPHA_MASK: u32 = 0xFF000000;
+
+// R8G8B8 (RGB888): R=byte2, G=byte1, B=byte0 (0x00RRGGBB)
+pub(crate) const RGB888_RED_MASK: u32 = 0x00FF0000;
+pub(crate) const RGB888_GREEN_MASK: u32 = 0x0000FF00;
+pub(crate) const RGB888_BLUE_MASK: u32 = 0x000000FF;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -23,8 +23,8 @@ pub enum DdsFormat {
     RGBA8888 = 7,
     /// BGRA8888 format (32-bit with alpha, different byte order)
     BGRA8888 = 8,
-    /// RGB888 format (24-bit RGB)
-    RGB888 = 9,
+    /// BGR888 format (24-bit RGB)
+    BGR888 = 9,
 }
 
 /// The information of the DDS file supplied to the reader.
@@ -175,13 +175,13 @@ fn detect_uncompressed_format(data: &[u8]) -> DdsFormat {
 
     match rgb_bit_count {
         24 => {
-            // RGB888: 24-bit RGB format
-            if r_mask == RGB888_RED_MASK
-                && g_mask == RGB888_GREEN_MASK
-                && b_mask == RGB888_BLUE_MASK
+            // BGR888: 24-bit RGB format
+            if r_mask == BGR888_RED_MASK
+                && g_mask == BGR888_GREEN_MASK
+                && b_mask == BGR888_BLUE_MASK
                 && a_mask == 0x00000000
             {
-                DdsFormat::RGB888
+                DdsFormat::BGR888
             } else {
                 DdsFormat::Unknown
             }
@@ -247,7 +247,7 @@ fn calculate_data_length(format: DdsFormat, data: &[u8]) -> Option<u32> {
             // 32-bit formats (4 bytes per pixel)
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
         }
-        DdsFormat::RGB888 => {
+        DdsFormat::BGR888 => {
             // 24-bit format (3 bytes per pixel)
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 3)
         }
@@ -307,7 +307,7 @@ pub(crate) fn calculate_data_length_for_block_compression(
             // 32-bit uncompressed formats
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
         }
-        DdsFormat::RGB888 => {
+        DdsFormat::BGR888 => {
             // 24-bit uncompressed format
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 3)
         }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -23,6 +23,8 @@ pub enum DdsFormat {
     RGBA8888 = 7,
     /// BGRA8888 format (32-bit with alpha, different byte order)
     BGRA8888 = 8,
+    /// RGB888 format (24-bit RGB)
+    RGB888 = 9,
 }
 
 /// The information of the DDS file supplied to the reader.
@@ -172,6 +174,18 @@ fn detect_uncompressed_format(data: &[u8]) -> DdsFormat {
     let a_mask = unsafe { reader.read_u32_at(DDS_PIXELFORMAT_ABITMASK_OFFSET as isize) };
 
     match rgb_bit_count {
+        24 => {
+            // RGB888: 24-bit RGB format
+            if r_mask == RGB888_RED_MASK
+                && g_mask == RGB888_GREEN_MASK
+                && b_mask == RGB888_BLUE_MASK
+                && a_mask == 0x00000000
+            {
+                DdsFormat::RGB888
+            } else {
+                DdsFormat::Unknown
+            }
+        }
         32 => {
             // For 32-bit formats, check if alpha channel is present
             if (pixel_flags & DDPF_ALPHAPIXELS) != 0 {
@@ -233,6 +247,10 @@ fn calculate_data_length(format: DdsFormat, data: &[u8]) -> Option<u32> {
             // 32-bit formats (4 bytes per pixel)
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
         }
+        DdsFormat::RGB888 => {
+            // 24-bit format (3 bytes per pixel)
+            calculate_data_length_for_pixel_formats(width, height, mipmap_count, 3)
+        }
         DdsFormat::Unknown => {
             // Try to determine from pixel format for uncompressed formats
             calculate_uncompressed_data_length(data, width, height, mipmap_count)
@@ -288,6 +306,10 @@ pub(crate) fn calculate_data_length_for_block_compression(
         DdsFormat::RGBA8888 | DdsFormat::BGRA8888 => {
             // 32-bit uncompressed formats
             calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4)
+        }
+        DdsFormat::RGB888 => {
+            // 24-bit uncompressed format
+            calculate_data_length_for_pixel_formats(width, height, mipmap_count, 3)
         }
         DdsFormat::Unknown => {
             // Don't make assumptions about unknown formats - return 0

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
@@ -114,13 +114,13 @@ mod tests {
     }
 
     #[test]
-    fn test_get_transform_format_rgb888_supported() {
+    fn test_get_transform_format_bgr888_supported() {
         let handler = super::super::DdsHandler;
-        let dds_data = create_valid_rgb888_dds_with_dimensions(64, 64, 1);
+        let dds_data = create_valid_bgr888_dds_with_dimensions(64, 64, 1);
 
         let result = handler.get_transform_format(&dds_data, TransformFormatFilter::All);
 
         assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Some(TransformFormat::Rgb888));
+        assert_eq!(result.unwrap(), Some(TransformFormat::Bgr888));
     }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
@@ -112,4 +112,15 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(TransformFormat::Bgra8888));
     }
+
+    #[test]
+    fn test_get_transform_format_rgb888_supported() {
+        let handler = super::super::DdsHandler;
+        let dds_data = create_valid_rgb888_dds_with_dimensions(64, 64, 1);
+
+        let result = handler.get_transform_format(&dds_data, TransformFormatFilter::All);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(TransformFormat::Rgb888));
+    }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
@@ -32,7 +32,7 @@ use dxt_lossless_transform_file_formats_api::{
 /// - BC7 - known but unimplemented
 /// - RGBA8888 - implemented
 /// - BGRA8888 - implemented
-/// - RGB888 - implemented
+/// - BGR888 - implemented
 ///
 /// # Unsupported Formats
 ///
@@ -74,7 +74,7 @@ pub(crate) fn dds_format_to_transform_format(
         }
         DdsFormat::RGBA8888 => Ok(TransformFormat::Rgba8888),
         DdsFormat::BGRA8888 => Ok(TransformFormat::Bgra8888),
-        DdsFormat::RGB888 => Ok(TransformFormat::Rgb888),
+        DdsFormat::BGR888 => Ok(TransformFormat::Bgr888),
         DdsFormat::NotADds | DdsFormat::Unknown => Err(TransformError::FormatHandler(
             FormatHandlerError::UnknownFileFormat,
         )),
@@ -104,8 +104,8 @@ mod tests {
             TransformFormat::Bgra8888
         );
         assert_eq!(
-            dds_format_to_transform_format(DdsFormat::RGB888, false).unwrap(),
-            TransformFormat::Rgb888
+            dds_format_to_transform_format(DdsFormat::BGR888, false).unwrap(),
+            TransformFormat::Bgr888
         );
         assert_eq!(
             dds_format_to_transform_format(DdsFormat::BC1, true).unwrap(),
@@ -124,8 +124,8 @@ mod tests {
             TransformFormat::Bgra8888
         );
         assert_eq!(
-            dds_format_to_transform_format(DdsFormat::RGB888, true).unwrap(),
-            TransformFormat::Rgb888
+            dds_format_to_transform_format(DdsFormat::BGR888, true).unwrap(),
+            TransformFormat::Bgr888
         );
     }
 

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
@@ -32,6 +32,7 @@ use dxt_lossless_transform_file_formats_api::{
 /// - BC7 - known but unimplemented
 /// - RGBA8888 - implemented
 /// - BGRA8888 - implemented
+/// - RGB888 - implemented
 ///
 /// # Unsupported Formats
 ///
@@ -73,6 +74,7 @@ pub(crate) fn dds_format_to_transform_format(
         }
         DdsFormat::RGBA8888 => Ok(TransformFormat::Rgba8888),
         DdsFormat::BGRA8888 => Ok(TransformFormat::Bgra8888),
+        DdsFormat::RGB888 => Ok(TransformFormat::Rgb888),
         DdsFormat::NotADds | DdsFormat::Unknown => Err(TransformError::FormatHandler(
             FormatHandlerError::UnknownFileFormat,
         )),
@@ -102,6 +104,10 @@ mod tests {
             TransformFormat::Bgra8888
         );
         assert_eq!(
+            dds_format_to_transform_format(DdsFormat::RGB888, false).unwrap(),
+            TransformFormat::Rgb888
+        );
+        assert_eq!(
             dds_format_to_transform_format(DdsFormat::BC1, true).unwrap(),
             TransformFormat::Bc1
         );
@@ -116,6 +122,10 @@ mod tests {
         assert_eq!(
             dds_format_to_transform_format(DdsFormat::BGRA8888, true).unwrap(),
             TransformFormat::Bgra8888
+        );
+        assert_eq!(
+            dds_format_to_transform_format(DdsFormat::RGB888, true).unwrap(),
+            TransformFormat::Rgb888
         );
     }
 

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -114,13 +114,13 @@ fn write_uncompressed_pixel_format(
     }
 }
 
-/// Helper function to write RGB888 pixel format information (24-bit, no alpha)
-fn write_rgb888_pixel_format(data: &mut [u8], red_mask: u32, green_mask: u32, blue_mask: u32) {
+/// Helper function to write BGR888 pixel format information (24-bit, no alpha)
+fn write_bgr888_pixel_format(data: &mut [u8], red_mask: u32, green_mask: u32, blue_mask: u32) {
     data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"\0\0\0\0");
     unsafe {
         let mut writer = LittleEndianWriter::new(data.as_mut_ptr());
         writer.write_u32_at(
-            DDPF_RGB, // No alpha pixels flag for RGB888
+            DDPF_RGB, // No alpha pixels flag for BGR888
             DDS_PIXELFORMAT_FLAGS_OFFSET as isize,
         );
         writer.write_u32_at(24, DDS_PIXELFORMAT_RGBBITCOUNT_OFFSET as isize); // 24-bit
@@ -172,7 +172,7 @@ pub fn create_valid_dds_with_dimensions(
                 false, // Use legacy format for uncompressed formats
             )
         }
-        DdsFormat::RGB888 => {
+        DdsFormat::BGR888 => {
             // 24-bit uncompressed format
             (
                 calculate_data_length_for_pixel_formats(width, height, mipmap_count, 3).unwrap_or(0)
@@ -232,12 +232,12 @@ pub fn create_valid_dds_with_dimensions(
                 BGRA8888_ALPHA_MASK,
             );
         }
-        DdsFormat::RGB888 => {
-            write_rgb888_pixel_format(
+        DdsFormat::BGR888 => {
+            write_bgr888_pixel_format(
                 &mut data,
-                RGB888_RED_MASK,
-                RGB888_GREEN_MASK,
-                RGB888_BLUE_MASK,
+                BGR888_RED_MASK,
+                BGR888_GREEN_MASK,
+                BGR888_BLUE_MASK,
             );
         }
         DdsFormat::Unknown => {
@@ -281,13 +281,13 @@ pub fn create_valid_bgra8888_dds_with_dimensions(
     create_valid_dds_with_dimensions(DdsFormat::BGRA8888, width, height, mipmap_count)
 }
 
-/// Helper function to create a valid RGB888 DDS with proper dimensions and data length
-pub fn create_valid_rgb888_dds_with_dimensions(
+/// Helper function to create a valid BGR888 DDS with proper dimensions and data length
+pub fn create_valid_bgr888_dds_with_dimensions(
     width: u32,
     height: u32,
     mipmap_count: u32,
 ) -> Vec<u8> {
-    create_valid_dds_with_dimensions(DdsFormat::RGB888, width, height, mipmap_count)
+    create_valid_dds_with_dimensions(DdsFormat::BGR888, width, height, mipmap_count)
 }
 
 // Semantic helper functions for clearer test intent

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -114,6 +114,23 @@ fn write_uncompressed_pixel_format(
     }
 }
 
+/// Helper function to write RGB888 pixel format information (24-bit, no alpha)
+fn write_rgb888_pixel_format(data: &mut [u8], red_mask: u32, green_mask: u32, blue_mask: u32) {
+    data[FOURCC_OFFSET..FOURCC_OFFSET + 4].copy_from_slice(b"\0\0\0\0");
+    unsafe {
+        let mut writer = LittleEndianWriter::new(data.as_mut_ptr());
+        writer.write_u32_at(
+            DDPF_RGB, // No alpha pixels flag for RGB888
+            DDS_PIXELFORMAT_FLAGS_OFFSET as isize,
+        );
+        writer.write_u32_at(24, DDS_PIXELFORMAT_RGBBITCOUNT_OFFSET as isize); // 24-bit
+        writer.write_u32_at(red_mask, DDS_PIXELFORMAT_RBITMASK_OFFSET as isize);
+        writer.write_u32_at(green_mask, DDS_PIXELFORMAT_GBITMASK_OFFSET as isize);
+        writer.write_u32_at(blue_mask, DDS_PIXELFORMAT_BBITMASK_OFFSET as isize);
+        writer.write_u32_at(0, DDS_PIXELFORMAT_ABITMASK_OFFSET as isize); // No alpha mask
+    }
+}
+
 /// Helper function to create a valid DDS with specified format and dimensions
 pub fn create_valid_dds_with_dimensions(
     format: DdsFormat,
@@ -151,6 +168,14 @@ pub fn create_valid_dds_with_dimensions(
             // 32-bit uncompressed formats
             (
                 calculate_data_length_for_pixel_formats(width, height, mipmap_count, 4).unwrap_or(0)
+                    as usize,
+                false, // Use legacy format for uncompressed formats
+            )
+        }
+        DdsFormat::RGB888 => {
+            // 24-bit uncompressed format
+            (
+                calculate_data_length_for_pixel_formats(width, height, mipmap_count, 3).unwrap_or(0)
                     as usize,
                 false, // Use legacy format for uncompressed formats
             )
@@ -207,6 +232,14 @@ pub fn create_valid_dds_with_dimensions(
                 BGRA8888_ALPHA_MASK,
             );
         }
+        DdsFormat::RGB888 => {
+            write_rgb888_pixel_format(
+                &mut data,
+                RGB888_RED_MASK,
+                RGB888_GREEN_MASK,
+                RGB888_BLUE_MASK,
+            );
+        }
         DdsFormat::Unknown => {
             write_fourcc_pixel_format(&mut data, b"UNKN");
         }
@@ -246,6 +279,15 @@ pub fn create_valid_bgra8888_dds_with_dimensions(
     mipmap_count: u32,
 ) -> Vec<u8> {
     create_valid_dds_with_dimensions(DdsFormat::BGRA8888, width, height, mipmap_count)
+}
+
+/// Helper function to create a valid RGB888 DDS with proper dimensions and data length
+pub fn create_valid_rgb888_dds_with_dimensions(
+    width: u32,
+    height: u32,
+    mipmap_count: u32,
+) -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::RGB888, width, height, mipmap_count)
 }
 
 // Semantic helper functions for clearer test intent

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
@@ -46,8 +46,8 @@ enum FormatKey {
     Rgba8888 = 6,
     /// BGRA8888 format transform (TransformFormat::Bgra8888 = 0x06 -> FormatKey = 7)
     Bgra8888 = 7,
-    /// RGB888 format transform (TransformFormat::Rgb888 = 0x07 -> FormatKey = 8)
-    Rgb888 = 8,
+    /// BGR888 format transform (TransformFormat::Bgr888 = 0x07 -> FormatKey = 8)
+    Bgr888 = 8,
 }
 
 impl From<Option<TransformFormat>> for FormatKey {
@@ -63,7 +63,7 @@ impl From<Option<TransformFormat>> for FormatKey {
                     TransformFormat::Bc6H => Self::Bc6H,         // 0x04 -> 5
                     TransformFormat::Rgba8888 => Self::Rgba8888, // 0x05 -> 6
                     TransformFormat::Bgra8888 => Self::Bgra8888, // 0x06 -> 7
-                    TransformFormat::Rgb888 => Self::Rgb888,     // 0x07 -> 8
+                    TransformFormat::Bgr888 => Self::Bgr888,     // 0x07 -> 8
                     _ => Self::Unknown, // Handle any future variants as unknown
                 }
             }
@@ -84,7 +84,7 @@ impl FormatKey {
             Self::Bc6H => "Bc6H",
             Self::Rgba8888 => "Rgba8888",
             Self::Bgra8888 => "Bgra8888",
-            Self::Rgb888 => "Rgb888",
+            Self::Bgr888 => "Bgr888",
         }
     }
 }

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
@@ -46,6 +46,8 @@ enum FormatKey {
     Rgba8888 = 6,
     /// BGRA8888 format transform (TransformFormat::Bgra8888 = 0x06 -> FormatKey = 7)
     Bgra8888 = 7,
+    /// RGB888 format transform (TransformFormat::Rgb888 = 0x07 -> FormatKey = 8)
+    Rgb888 = 8,
 }
 
 impl From<Option<TransformFormat>> for FormatKey {
@@ -61,6 +63,7 @@ impl From<Option<TransformFormat>> for FormatKey {
                     TransformFormat::Bc6H => Self::Bc6H,         // 0x04 -> 5
                     TransformFormat::Rgba8888 => Self::Rgba8888, // 0x05 -> 6
                     TransformFormat::Bgra8888 => Self::Bgra8888, // 0x06 -> 7
+                    TransformFormat::Rgb888 => Self::Rgb888,     // 0x07 -> 8
                     _ => Self::Unknown, // Handle any future variants as unknown
                 }
             }
@@ -81,6 +84,7 @@ impl FormatKey {
             Self::Bc6H => "Bc6H",
             Self::Rgba8888 => "Rgba8888",
             Self::Bgra8888 => "Bgra8888",
+            Self::Rgb888 => "Rgb888",
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the BGR888 (24-bit RGB) file format across the API, CLI tool, and DDS extension modules.
  * Users can now analyze, detect, and process BGR888 pixel formats in DDS files.
  * The CLI tool and debug utilities recognize and display BGR888 format details.

* **Bug Fixes**
  * Improved format detection and data length calculations for 24-bit BGR888 images.

* **Tests**
  * Added comprehensive unit tests for BGR888 format detection, conversion, and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->