### PR TITLE
Added: BC4, BC5 Support to TransformHeader and Debug Tools

### DIFF
--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc4.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc4.rs
@@ -1,0 +1,279 @@
+//! BC4 format file format support.
+//!
+//! This module provides BC4-specific implementations of the file format traits.
+//! BC4 is a single-channel compressed format, typically used for alpha or grayscale data.
+
+use super::EmbeddableTransformDetails;
+use crate::embed::{EmbedError, TransformFormat, TransformHeader};
+use bitfield::bitfield;
+
+/// BC4 transform settings for single-channel compression.
+///
+/// BC4 is a single-channel format so it has simpler settings compared to color formats.
+/// This is a placeholder structure until the BC4 core crate is implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Bc4TransformSettings {
+    /// Whether to apply endpoint optimization
+    pub optimize_endpoints: bool,
+}
+
+impl Bc4TransformSettings {
+    /// Create default BC4 transform settings
+    pub fn new() -> Self {
+        Self {
+            optimize_endpoints: false,
+        }
+    }
+
+    /// Create BC4 settings with specified endpoint optimization
+    pub fn with_endpoint_optimization(optimize: bool) -> Self {
+        Self {
+            optimize_endpoints: optimize,
+        }
+    }
+
+    /// Get all possible combinations of BC4 settings for testing
+    pub fn all_combinations() -> impl Iterator<Item = Self> {
+        [false, true]
+            .into_iter()
+            .map(|optimize_endpoints| Self { optimize_endpoints })
+    }
+}
+
+impl Default for Bc4TransformSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Header version for BC4 format
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Bc4HeaderVersion {
+    /// Initial version - supports endpoint optimization
+    InitialVersion = 0,
+}
+
+impl Bc4HeaderVersion {
+    /// Convert from u32 value
+    fn from_u32(value: u32) -> Result<Self, EmbedError> {
+        match value {
+            0 => Ok(Self::InitialVersion),
+            _ => Err(EmbedError::CorruptedEmbeddedData),
+        }
+    }
+
+    /// Convert to u32 value  
+    fn to_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+bitfield! {
+    /// Packed BC4 transform data for storage in headers.
+    ///
+    /// Bit layout (within the 28-bit format data):
+    /// - Bits 0-1: Header version (2 bits)
+    /// - Bit 2: Optimize endpoints flag (1 bit)
+    /// - Bits 3-27: Reserved for future use (25 bits)
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+    struct Bc4TransformHeaderData(u32);
+    impl Debug;
+    u32;
+
+    /// Header version (2 bits)
+    header_version, set_header_version: 1, 0;
+    /// Whether to optimize endpoints (1 bit)
+    optimize_endpoints, set_optimize_endpoints: 2;
+    /// Reserved for future use (25 bits)
+    reserved, set_reserved: 27, 3;
+}
+
+impl Bc4TransformHeaderData {
+    /// Create [`Bc4TransformHeaderData`] from [`Bc4TransformSettings`]
+    fn from_transform_settings(settings: &Bc4TransformSettings) -> Self {
+        let mut header = Self::default();
+        header.set_header_version(Bc4HeaderVersion::InitialVersion.to_u32());
+        header.set_optimize_endpoints(settings.optimize_endpoints);
+        header.set_reserved(0);
+        header
+    }
+
+    /// Convert [`Bc4TransformHeaderData`] to [`Bc4TransformSettings`]
+    fn to_transform_settings(self) -> Result<Bc4TransformSettings, EmbedError> {
+        // Validate version (from_u32 will error on invalid version)
+        let _version = Bc4HeaderVersion::from_u32(self.header_version())?;
+
+        // Reserved bits should be zero for forward compatibility
+        if self.reserved() != 0 {
+            return Err(EmbedError::CorruptedEmbeddedData);
+        }
+
+        Ok(Bc4TransformSettings {
+            optimize_endpoints: self.optimize_endpoints(),
+        })
+    }
+}
+
+/// BC4 transform details for embedding in headers.
+///
+/// Contains settings for BC4 single-channel compression processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EmbeddableBc4Details(Bc4TransformSettings);
+
+impl EmbeddableTransformDetails for EmbeddableBc4Details {
+    const FORMAT: TransformFormat = TransformFormat::Bc4;
+
+    fn pack(&self) -> u32 {
+        Bc4TransformHeaderData::from_transform_settings(&self.0).0
+    }
+
+    fn unpack(data: u32) -> Result<Self, EmbedError> {
+        Ok(Self(Bc4TransformHeaderData(data).to_transform_settings()?))
+    }
+}
+
+impl EmbeddableBc4Details {
+    /// Create new BC4 details with default settings (no optimization)
+    pub fn new() -> Self {
+        Self(Bc4TransformSettings::new())
+    }
+
+    /// Create new BC4 details with specified endpoint optimization setting
+    pub fn with_endpoint_optimization(optimize: bool) -> Self {
+        Self(Bc4TransformSettings::with_endpoint_optimization(optimize))
+    }
+
+    /// Convert to a [`TransformHeader`]
+    pub fn to_header(self) -> TransformHeader {
+        crate::embed::TransformHeader::new(Self::FORMAT, self.pack())
+    }
+
+    /// Create from core BC4 transform settings (internal use only)
+    pub(crate) fn from_settings(settings: Bc4TransformSettings) -> Self {
+        Self(settings)
+    }
+
+    /// Convert to core BC4 transform settings (internal use only)
+    pub(crate) fn to_settings(self) -> Bc4TransformSettings {
+        self.0
+    }
+}
+
+impl Default for EmbeddableBc4Details {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bc4_details_default() {
+        let details = EmbeddableBc4Details::new();
+        // Test that default details can be created
+        assert_eq!(
+            details,
+            EmbeddableBc4Details::with_endpoint_optimization(false)
+        );
+    }
+
+    #[test]
+    fn test_bc4_details_with_optimization() {
+        let details_true = EmbeddableBc4Details::with_endpoint_optimization(true);
+        let details_false = EmbeddableBc4Details::with_endpoint_optimization(false);
+
+        // Test that different optimization settings create different details
+        assert_ne!(details_true, details_false);
+    }
+
+    #[test]
+    fn test_bc4_pack_unpack_roundtrip() {
+        let original = EmbeddableBc4Details::with_endpoint_optimization(true);
+        let packed = original.pack();
+        let unpacked = EmbeddableBc4Details::unpack(packed).unwrap();
+
+        assert_eq!(original, unpacked);
+    }
+
+    #[test]
+    fn test_bc4_header_roundtrip() {
+        let details = EmbeddableBc4Details::with_endpoint_optimization(true);
+        let header = details.to_header();
+
+        assert_eq!(header.format(), Some(TransformFormat::Bc4));
+
+        let recovered = EmbeddableBc4Details::from_header(header).unwrap();
+        assert_eq!(details, recovered);
+    }
+
+    #[test]
+    fn test_roundtrip_all_possible_transform_details() {
+        for settings in Bc4TransformSettings::all_combinations() {
+            let embeddable = EmbeddableBc4Details::from_settings(settings);
+
+            let packed = embeddable.pack();
+            let recovered = EmbeddableBc4Details::unpack(packed).unwrap();
+            assert_eq!(
+                settings,
+                recovered.to_settings(),
+                "Failed for settings {settings:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_header_version_and_reserved_fields() {
+        let settings = Bc4TransformSettings {
+            optimize_endpoints: true,
+        };
+
+        let header = Bc4TransformHeaderData::from_transform_settings(&settings);
+
+        // Verify version is set correctly
+        assert_eq!(
+            header.header_version(),
+            Bc4HeaderVersion::InitialVersion.to_u32()
+        );
+        // Verify reserved field is set to zero
+        assert_eq!(header.reserved(), 0);
+
+        // Verify actual data fields are set correctly
+        assert!(header.optimize_endpoints());
+    }
+
+    #[test]
+    fn test_invalid_header_version() {
+        // Create header with invalid version
+        let mut invalid_header = Bc4TransformHeaderData::default();
+        invalid_header.set_header_version(3); // Invalid version (only 0 is valid)
+
+        // Should fail to convert to transform settings due to invalid version
+        assert_eq!(
+            invalid_header.to_transform_settings(),
+            Err(EmbedError::CorruptedEmbeddedData)
+        );
+    }
+
+    #[test]
+    fn test_invalid_reserved_bits() {
+        // Create header with non-zero reserved bits
+        let mut invalid_header = Bc4TransformHeaderData::default();
+        invalid_header.set_header_version(Bc4HeaderVersion::InitialVersion.to_u32());
+        invalid_header.set_reserved(1); // Should be zero
+
+        // Should fail to convert due to non-zero reserved bits
+        assert_eq!(
+            invalid_header.to_transform_settings(),
+            Err(EmbedError::CorruptedEmbeddedData)
+        );
+    }
+
+    #[test]
+    fn test_format_association() {
+        // Verify the format association is correct
+        assert_eq!(EmbeddableBc4Details::FORMAT, TransformFormat::Bc4);
+    }
+}

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc4.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc4.rs
@@ -13,22 +13,22 @@ use bitfield::bitfield;
 /// This is a placeholder structure until the BC4 core crate is implemented.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Bc4TransformSettings {
-    /// Whether to apply endpoint optimization
-    pub optimize_endpoints: bool,
+    /// Whether to split alpha_0 and alpha_1 into separate arrays
+    pub split_endpoints: bool,
 }
 
 impl Bc4TransformSettings {
     /// Create default BC4 transform settings
     pub fn new() -> Self {
         Self {
-            optimize_endpoints: false,
+            split_endpoints: false,
         }
     }
 
-    /// Create BC4 settings with specified endpoint optimization
-    pub fn with_endpoint_optimization(optimize: bool) -> Self {
+    /// Create BC4 settings with specified endpoint splitting
+    pub fn with_split_endpoints(split: bool) -> Self {
         Self {
-            optimize_endpoints: optimize,
+            split_endpoints: split,
         }
     }
 
@@ -36,7 +36,7 @@ impl Bc4TransformSettings {
     pub fn all_combinations() -> impl Iterator<Item = Self> {
         [false, true]
             .into_iter()
-            .map(|optimize_endpoints| Self { optimize_endpoints })
+            .map(|split_endpoints| Self { split_endpoints })
     }
 }
 
@@ -50,7 +50,7 @@ impl Default for Bc4TransformSettings {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 enum Bc4HeaderVersion {
-    /// Initial version - supports endpoint optimization
+    /// Initial version - supports endpoint splitting
     InitialVersion = 0,
 }
 
@@ -74,7 +74,7 @@ bitfield! {
     ///
     /// Bit layout (within the 28-bit format data):
     /// - Bits 0-1: Header version (2 bits)
-    /// - Bit 2: Optimize endpoints flag (1 bit)
+    /// - Bit 2: Split endpoints flag (1 bit)
     /// - Bits 3-27: Reserved for future use (25 bits)
     #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
     struct Bc4TransformHeaderData(u32);
@@ -83,8 +83,8 @@ bitfield! {
 
     /// Header version (2 bits)
     header_version, set_header_version: 1, 0;
-    /// Whether to optimize endpoints (1 bit)
-    optimize_endpoints, set_optimize_endpoints: 2;
+    /// Whether to split endpoints (1 bit)
+    split_endpoints, set_split_endpoints: 2;
     /// Reserved for future use (25 bits)
     reserved, set_reserved: 27, 3;
 }
@@ -94,7 +94,7 @@ impl Bc4TransformHeaderData {
     fn from_transform_settings(settings: &Bc4TransformSettings) -> Self {
         let mut header = Self::default();
         header.set_header_version(Bc4HeaderVersion::InitialVersion.to_u32());
-        header.set_optimize_endpoints(settings.optimize_endpoints);
+        header.set_split_endpoints(settings.split_endpoints);
         header.set_reserved(0);
         header
     }
@@ -110,7 +110,7 @@ impl Bc4TransformHeaderData {
         }
 
         Ok(Bc4TransformSettings {
-            optimize_endpoints: self.optimize_endpoints(),
+            split_endpoints: self.split_endpoints(),
         })
     }
 }
@@ -139,9 +139,9 @@ impl EmbeddableBc4Details {
         Self(Bc4TransformSettings::new())
     }
 
-    /// Create new BC4 details with specified endpoint optimization setting
-    pub fn with_endpoint_optimization(optimize: bool) -> Self {
-        Self(Bc4TransformSettings::with_endpoint_optimization(optimize))
+    /// Create new BC4 details with specified endpoint splitting setting
+    pub fn with_split_endpoints(split: bool) -> Self {
+        Self(Bc4TransformSettings::with_split_endpoints(split))
     }
 
     /// Convert to a [`TransformHeader`]
@@ -174,24 +174,21 @@ mod tests {
     fn test_bc4_details_default() {
         let details = EmbeddableBc4Details::new();
         // Test that default details can be created
-        assert_eq!(
-            details,
-            EmbeddableBc4Details::with_endpoint_optimization(false)
-        );
+        assert_eq!(details, EmbeddableBc4Details::with_split_endpoints(false));
     }
 
     #[test]
     fn test_bc4_details_with_optimization() {
-        let details_true = EmbeddableBc4Details::with_endpoint_optimization(true);
-        let details_false = EmbeddableBc4Details::with_endpoint_optimization(false);
+        let details_true = EmbeddableBc4Details::with_split_endpoints(true);
+        let details_false = EmbeddableBc4Details::with_split_endpoints(false);
 
-        // Test that different optimization settings create different details
+        // Test that different split settings create different details
         assert_ne!(details_true, details_false);
     }
 
     #[test]
     fn test_bc4_pack_unpack_roundtrip() {
-        let original = EmbeddableBc4Details::with_endpoint_optimization(true);
+        let original = EmbeddableBc4Details::with_split_endpoints(true);
         let packed = original.pack();
         let unpacked = EmbeddableBc4Details::unpack(packed).unwrap();
 
@@ -200,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_bc4_header_roundtrip() {
-        let details = EmbeddableBc4Details::with_endpoint_optimization(true);
+        let details = EmbeddableBc4Details::with_split_endpoints(true);
         let header = details.to_header();
 
         assert_eq!(header.format(), Some(TransformFormat::Bc4));
@@ -227,7 +224,7 @@ mod tests {
     #[test]
     fn test_header_version_and_reserved_fields() {
         let settings = Bc4TransformSettings {
-            optimize_endpoints: true,
+            split_endpoints: true,
         };
 
         let header = Bc4TransformHeaderData::from_transform_settings(&settings);
@@ -241,7 +238,7 @@ mod tests {
         assert_eq!(header.reserved(), 0);
 
         // Verify actual data fields are set correctly
-        assert!(header.optimize_endpoints());
+        assert!(header.split_endpoints());
     }
 
     #[test]

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc5.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/bc5.rs
@@ -1,0 +1,279 @@
+//! BC5 format file format support.
+//!
+//! This module provides BC5-specific implementations of the file format traits.
+//! BC5 is a dual-channel compressed format, typically used for normal maps (red and green channels).
+
+use super::EmbeddableTransformDetails;
+use crate::embed::{EmbedError, TransformFormat, TransformHeader};
+use bitfield::bitfield;
+
+/// BC5 transform settings for dual-channel compression.
+///
+/// BC5 is a dual-channel format (red and green) commonly used for normal maps.
+/// This is a placeholder structure until the BC5 core crate is implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Bc5TransformSettings {
+    /// Whether to apply endpoint optimization
+    pub optimize_endpoints: bool,
+}
+
+impl Bc5TransformSettings {
+    /// Create default BC5 transform settings
+    pub fn new() -> Self {
+        Self {
+            optimize_endpoints: false,
+        }
+    }
+
+    /// Create BC5 settings with specified endpoint optimization
+    pub fn with_endpoint_optimization(optimize: bool) -> Self {
+        Self {
+            optimize_endpoints: optimize,
+        }
+    }
+
+    /// Get all possible combinations of BC5 settings for testing
+    pub fn all_combinations() -> impl Iterator<Item = Self> {
+        [false, true]
+            .into_iter()
+            .map(|optimize_endpoints| Self { optimize_endpoints })
+    }
+}
+
+impl Default for Bc5TransformSettings {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Header version for BC5 format
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Bc5HeaderVersion {
+    /// Initial version - supports endpoint optimization
+    InitialVersion = 0,
+}
+
+impl Bc5HeaderVersion {
+    /// Convert from u32 value
+    fn from_u32(value: u32) -> Result<Self, EmbedError> {
+        match value {
+            0 => Ok(Self::InitialVersion),
+            _ => Err(EmbedError::CorruptedEmbeddedData),
+        }
+    }
+
+    /// Convert to u32 value  
+    fn to_u32(self) -> u32 {
+        self as u32
+    }
+}
+
+bitfield! {
+    /// Packed BC5 transform data for storage in headers.
+    ///
+    /// Bit layout (within the 28-bit format data):
+    /// - Bits 0-1: Header version (2 bits)
+    /// - Bit 2: Optimize endpoints flag (1 bit)
+    /// - Bits 3-27: Reserved for future use (25 bits)
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+    struct Bc5TransformHeaderData(u32);
+    impl Debug;
+    u32;
+
+    /// Header version (2 bits)
+    header_version, set_header_version: 1, 0;
+    /// Whether to optimize endpoints (1 bit)
+    optimize_endpoints, set_optimize_endpoints: 2;
+    /// Reserved for future use (25 bits)
+    reserved, set_reserved: 27, 3;
+}
+
+impl Bc5TransformHeaderData {
+    /// Create [`Bc5TransformHeaderData`] from [`Bc5TransformSettings`]
+    fn from_transform_settings(settings: &Bc5TransformSettings) -> Self {
+        let mut header = Self::default();
+        header.set_header_version(Bc5HeaderVersion::InitialVersion.to_u32());
+        header.set_optimize_endpoints(settings.optimize_endpoints);
+        header.set_reserved(0);
+        header
+    }
+
+    /// Convert [`Bc5TransformHeaderData`] to [`Bc5TransformSettings`]
+    fn to_transform_settings(self) -> Result<Bc5TransformSettings, EmbedError> {
+        // Validate version (from_u32 will error on invalid version)
+        let _version = Bc5HeaderVersion::from_u32(self.header_version())?;
+
+        // Reserved bits should be zero for forward compatibility
+        if self.reserved() != 0 {
+            return Err(EmbedError::CorruptedEmbeddedData);
+        }
+
+        Ok(Bc5TransformSettings {
+            optimize_endpoints: self.optimize_endpoints(),
+        })
+    }
+}
+
+/// BC5 transform details for embedding in headers.
+///
+/// Contains settings for BC5 dual-channel compression processing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct EmbeddableBc5Details(Bc5TransformSettings);
+
+impl EmbeddableTransformDetails for EmbeddableBc5Details {
+    const FORMAT: TransformFormat = TransformFormat::Bc5;
+
+    fn pack(&self) -> u32 {
+        Bc5TransformHeaderData::from_transform_settings(&self.0).0
+    }
+
+    fn unpack(data: u32) -> Result<Self, EmbedError> {
+        Ok(Self(Bc5TransformHeaderData(data).to_transform_settings()?))
+    }
+}
+
+impl EmbeddableBc5Details {
+    /// Create new BC5 details with default settings (no optimization)
+    pub fn new() -> Self {
+        Self(Bc5TransformSettings::new())
+    }
+
+    /// Create new BC5 details with specified endpoint optimization setting
+    pub fn with_endpoint_optimization(optimize: bool) -> Self {
+        Self(Bc5TransformSettings::with_endpoint_optimization(optimize))
+    }
+
+    /// Convert to a [`TransformHeader`]
+    pub fn to_header(self) -> TransformHeader {
+        crate::embed::TransformHeader::new(Self::FORMAT, self.pack())
+    }
+
+    /// Create from core BC5 transform settings (internal use only)
+    pub(crate) fn from_settings(settings: Bc5TransformSettings) -> Self {
+        Self(settings)
+    }
+
+    /// Convert to core BC5 transform settings (internal use only)
+    pub(crate) fn to_settings(self) -> Bc5TransformSettings {
+        self.0
+    }
+}
+
+impl Default for EmbeddableBc5Details {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_bc5_details_default() {
+        let details = EmbeddableBc5Details::new();
+        // Test that default details can be created
+        assert_eq!(
+            details,
+            EmbeddableBc5Details::with_endpoint_optimization(false)
+        );
+    }
+
+    #[test]
+    fn test_bc5_details_with_optimization() {
+        let details_true = EmbeddableBc5Details::with_endpoint_optimization(true);
+        let details_false = EmbeddableBc5Details::with_endpoint_optimization(false);
+
+        // Test that different optimization settings create different details
+        assert_ne!(details_true, details_false);
+    }
+
+    #[test]
+    fn test_bc5_pack_unpack_roundtrip() {
+        let original = EmbeddableBc5Details::with_endpoint_optimization(true);
+        let packed = original.pack();
+        let unpacked = EmbeddableBc5Details::unpack(packed).unwrap();
+
+        assert_eq!(original, unpacked);
+    }
+
+    #[test]
+    fn test_bc5_header_roundtrip() {
+        let details = EmbeddableBc5Details::with_endpoint_optimization(true);
+        let header = details.to_header();
+
+        assert_eq!(header.format(), Some(TransformFormat::Bc5));
+
+        let recovered = EmbeddableBc5Details::from_header(header).unwrap();
+        assert_eq!(details, recovered);
+    }
+
+    #[test]
+    fn test_roundtrip_all_possible_transform_details() {
+        for settings in Bc5TransformSettings::all_combinations() {
+            let embeddable = EmbeddableBc5Details::from_settings(settings);
+
+            let packed = embeddable.pack();
+            let recovered = EmbeddableBc5Details::unpack(packed).unwrap();
+            assert_eq!(
+                settings,
+                recovered.to_settings(),
+                "Failed for settings {settings:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn test_header_version_and_reserved_fields() {
+        let settings = Bc5TransformSettings {
+            optimize_endpoints: true,
+        };
+
+        let header = Bc5TransformHeaderData::from_transform_settings(&settings);
+
+        // Verify version is set correctly
+        assert_eq!(
+            header.header_version(),
+            Bc5HeaderVersion::InitialVersion.to_u32()
+        );
+        // Verify reserved field is set to zero
+        assert_eq!(header.reserved(), 0);
+
+        // Verify actual data fields are set correctly
+        assert!(header.optimize_endpoints());
+    }
+
+    #[test]
+    fn test_invalid_header_version() {
+        // Create header with invalid version
+        let mut invalid_header = Bc5TransformHeaderData::default();
+        invalid_header.set_header_version(3); // Invalid version (only 0 is valid)
+
+        // Should fail to convert to transform settings due to invalid version
+        assert_eq!(
+            invalid_header.to_transform_settings(),
+            Err(EmbedError::CorruptedEmbeddedData)
+        );
+    }
+
+    #[test]
+    fn test_invalid_reserved_bits() {
+        // Create header with non-zero reserved bits
+        let mut invalid_header = Bc5TransformHeaderData::default();
+        invalid_header.set_header_version(Bc5HeaderVersion::InitialVersion.to_u32());
+        invalid_header.set_reserved(1); // Should be zero
+
+        // Should fail to convert due to non-zero reserved bits
+        assert_eq!(
+            invalid_header.to_transform_settings(),
+            Err(EmbedError::CorruptedEmbeddedData)
+        );
+    }
+
+    #[test]
+    fn test_format_association() {
+        // Verify the format association is correct
+        assert_eq!(EmbeddableBc5Details::FORMAT, TransformFormat::Bc5);
+    }
+}

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
@@ -5,6 +5,8 @@ mod bc2;
 #[allow(dead_code)]
 mod bc3; // code not ready, placeholder
 #[allow(dead_code)]
+mod bc4; // code not ready, placeholder
+#[allow(dead_code)]
 mod bc7; // code not ready, placeholder
 #[allow(dead_code)]
 mod bgr888;
@@ -15,6 +17,7 @@ mod rgba8888;
 
 pub(crate) use bc1::EmbeddableBc1Details;
 pub(crate) use bc2::EmbeddableBc2Details;
+pub(crate) use bc4::EmbeddableBc4Details;
 pub(crate) use bgr888::EmbeddableBgr888Details;
 pub(crate) use bgra8888::EmbeddableBgra8888Details;
 pub(crate) use rgba8888::EmbeddableRgba8888Details;

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/formats/mod.rs
@@ -7,6 +7,8 @@ mod bc3; // code not ready, placeholder
 #[allow(dead_code)]
 mod bc4; // code not ready, placeholder
 #[allow(dead_code)]
+mod bc5; // code not ready, placeholder
+#[allow(dead_code)]
 mod bc7; // code not ready, placeholder
 #[allow(dead_code)]
 mod bgr888;
@@ -18,6 +20,7 @@ mod rgba8888;
 pub(crate) use bc1::EmbeddableBc1Details;
 pub(crate) use bc2::EmbeddableBc2Details;
 pub(crate) use bc4::EmbeddableBc4Details;
+pub(crate) use bc5::EmbeddableBc5Details;
 pub(crate) use bgr888::EmbeddableBgr888Details;
 pub(crate) use bgra8888::EmbeddableBgra8888Details;
 pub(crate) use rgba8888::EmbeddableRgba8888Details;

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
@@ -75,6 +75,8 @@ pub(super) use formats::EmbeddableBc2Details;
 #[allow(unused_imports)]
 pub(super) use formats::EmbeddableBc4Details;
 #[allow(unused_imports)]
+pub(super) use formats::EmbeddableBc5Details;
+#[allow(unused_imports)]
 pub(super) use formats::EmbeddableBgr888Details;
 #[allow(unused_imports)]
 pub(super) use formats::EmbeddableBgra8888Details;
@@ -183,6 +185,7 @@ mod tests {
             Some(TransformFormat::Bgr888)
         );
         assert_eq!(TransformFormat::from_u8(0x08), Some(TransformFormat::Bc4));
+        assert_eq!(TransformFormat::from_u8(0x09), Some(TransformFormat::Bc5));
         assert_eq!(TransformFormat::from_u8(0x0F), None);
 
         assert_eq!(TransformFormat::Bc1.to_u8(), 0x00);
@@ -194,6 +197,7 @@ mod tests {
         assert_eq!(TransformFormat::Bgra8888.to_u8(), 0x06);
         assert_eq!(TransformFormat::Bgr888.to_u8(), 0x07);
         assert_eq!(TransformFormat::Bc4.to_u8(), 0x08);
+        assert_eq!(TransformFormat::Bc5.to_u8(), 0x09);
     }
 
     #[test]

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/mod.rs
@@ -73,6 +73,8 @@ pub(super) use embed_error::EmbedError;
 pub(super) use formats::EmbeddableBc1Details;
 pub(super) use formats::EmbeddableBc2Details;
 #[allow(unused_imports)]
+pub(super) use formats::EmbeddableBc4Details;
+#[allow(unused_imports)]
 pub(super) use formats::EmbeddableBgr888Details;
 #[allow(unused_imports)]
 pub(super) use formats::EmbeddableBgra8888Details;
@@ -180,6 +182,7 @@ mod tests {
             TransformFormat::from_u8(0x07),
             Some(TransformFormat::Bgr888)
         );
+        assert_eq!(TransformFormat::from_u8(0x08), Some(TransformFormat::Bc4));
         assert_eq!(TransformFormat::from_u8(0x0F), None);
 
         assert_eq!(TransformFormat::Bc1.to_u8(), 0x00);
@@ -190,6 +193,7 @@ mod tests {
         assert_eq!(TransformFormat::Rgba8888.to_u8(), 0x05);
         assert_eq!(TransformFormat::Bgra8888.to_u8(), 0x06);
         assert_eq!(TransformFormat::Bgr888.to_u8(), 0x07);
+        assert_eq!(TransformFormat::Bc4.to_u8(), 0x08);
     }
 
     #[test]

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
@@ -24,6 +24,8 @@ pub enum TransformFormat {
     Bgra8888 = 0x06,
     /// BGR888 format transform
     Bgr888 = 0x07,
+    /// BC4 format transform
+    Bc4 = 0x08,
 }
 
 impl TransformFormat {
@@ -42,6 +44,7 @@ impl TransformFormat {
             0x05 => Some(Self::Rgba8888),
             0x06 => Some(Self::Bgra8888),
             0x07 => Some(Self::Bgr888),
+            0x08 => Some(Self::Bc4),
             _ => None,
         }
     }
@@ -57,6 +60,7 @@ impl TransformFormat {
             Self::Rgba8888 => 0x05,
             Self::Bgra8888 => 0x06,
             Self::Bgr888 => 0x07,
+            Self::Bc4 => 0x08,
         }
     }
 }

--- a/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
+++ b/projects/api/dxt-lossless-transform-file-formats-api/src/embed/transform_format.rs
@@ -26,6 +26,8 @@ pub enum TransformFormat {
     Bgr888 = 0x07,
     /// BC4 format transform
     Bc4 = 0x08,
+    /// BC5 format transform
+    Bc5 = 0x09,
 }
 
 impl TransformFormat {
@@ -45,6 +47,7 @@ impl TransformFormat {
             0x06 => Some(Self::Bgra8888),
             0x07 => Some(Self::Bgr888),
             0x08 => Some(Self::Bc4),
+            0x09 => Some(Self::Bc5),
             _ => None,
         }
     }
@@ -61,6 +64,7 @@ impl TransformFormat {
             Self::Bgra8888 => 0x06,
             Self::Bgr888 => 0x07,
             Self::Bc4 => 0x08,
+            Self::Bc5 => 0x09,
         }
     }
 }

--- a/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
+++ b/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
@@ -40,6 +40,8 @@ pub enum TransformFormatFilter {
     Bc2,
     /// Extract only BC3 blocks
     Bc3,
+    /// Extract only BC4 blocks
+    Bc4,
     /// Extract only BC7 blocks
     Bc7,
     /// Extract only BC6H blocks
@@ -62,6 +64,7 @@ impl TransformFormatFilter {
             (TransformFormatFilter::Bc1, TransformFormat::Bc1)
                 | (TransformFormatFilter::Bc2, TransformFormat::Bc2)
                 | (TransformFormatFilter::Bc3, TransformFormat::Bc3)
+                | (TransformFormatFilter::Bc4, TransformFormat::Bc4)
                 | (TransformFormatFilter::Bc7, TransformFormat::Bc7)
                 | (TransformFormatFilter::Bc6H, TransformFormat::Bc6H)
                 | (TransformFormatFilter::Rgba8888, TransformFormat::Rgba8888)
@@ -80,6 +83,7 @@ impl core::str::FromStr for TransformFormatFilter {
             "bc1" => Ok(TransformFormatFilter::Bc1),
             "bc2" => Ok(TransformFormatFilter::Bc2),
             "bc3" => Ok(TransformFormatFilter::Bc3),
+            "bc4" => Ok(TransformFormatFilter::Bc4),
             "bc7" => Ok(TransformFormatFilter::Bc7),
             "bc6h" => Ok(TransformFormatFilter::Bc6H),
             "rgba8888" => Ok(TransformFormatFilter::Rgba8888),
@@ -87,7 +91,7 @@ impl core::str::FromStr for TransformFormatFilter {
             "bgr888" => Ok(TransformFormatFilter::Bgr888),
             "all" => Ok(TransformFormatFilter::All),
             _ => Err(format!(
-                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc7, bc6h, rgba8888, bgra8888, bgr888, all"
+                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc4, bc7, bc6h, rgba8888, bgra8888, bgr888, all"
             )),
         }
     }

--- a/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
+++ b/projects/core/dxt-lossless-transform-file-formats-debug/src/block_extraction.rs
@@ -42,6 +42,8 @@ pub enum TransformFormatFilter {
     Bc3,
     /// Extract only BC4 blocks
     Bc4,
+    /// Extract only BC5 blocks
+    Bc5,
     /// Extract only BC7 blocks
     Bc7,
     /// Extract only BC6H blocks
@@ -65,6 +67,7 @@ impl TransformFormatFilter {
                 | (TransformFormatFilter::Bc2, TransformFormat::Bc2)
                 | (TransformFormatFilter::Bc3, TransformFormat::Bc3)
                 | (TransformFormatFilter::Bc4, TransformFormat::Bc4)
+                | (TransformFormatFilter::Bc5, TransformFormat::Bc5)
                 | (TransformFormatFilter::Bc7, TransformFormat::Bc7)
                 | (TransformFormatFilter::Bc6H, TransformFormat::Bc6H)
                 | (TransformFormatFilter::Rgba8888, TransformFormat::Rgba8888)
@@ -84,6 +87,7 @@ impl core::str::FromStr for TransformFormatFilter {
             "bc2" => Ok(TransformFormatFilter::Bc2),
             "bc3" => Ok(TransformFormatFilter::Bc3),
             "bc4" => Ok(TransformFormatFilter::Bc4),
+            "bc5" => Ok(TransformFormatFilter::Bc5),
             "bc7" => Ok(TransformFormatFilter::Bc7),
             "bc6h" => Ok(TransformFormatFilter::Bc6H),
             "rgba8888" => Ok(TransformFormatFilter::Rgba8888),
@@ -91,7 +95,7 @@ impl core::str::FromStr for TransformFormatFilter {
             "bgr888" => Ok(TransformFormatFilter::Bgr888),
             "all" => Ok(TransformFormatFilter::All),
             _ => Err(format!(
-                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc4, bc7, bc6h, rgba8888, bgra8888, bgr888, all"
+                "Invalid TransformFormat filter: {s}. Valid types are: bc1, bc2, bc3, bc4, bc5, bc7, bc6h, rgba8888, bgra8888, bgr888, all"
             )),
         }
     }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -7,6 +7,7 @@ pub(crate) const DDS_MAGIC: u32 = 0x20534444; // 'DDS ' in little-endian
 /// Offset of the FOURCC header used in DX9 and below.
 pub(crate) const FOURCC_OFFSET: usize = 0x54;
 
+// https://learn.microsoft.com/en-us/windows/win32/direct3ddds/dx-graphics-dds-pguide
 pub(crate) const FOURCC_DXT1: u32 = 0x31545844; // 'DXT1' in little-endian
 pub(crate) const FOURCC_DXT2: u32 = 0x32545844; // 'DXT2' in little-endian
 pub(crate) const FOURCC_DXT3: u32 = 0x33545844; // 'DXT3' in little-endian
@@ -14,9 +15,13 @@ pub(crate) const FOURCC_DXT4: u32 = 0x34545844; // 'DXT4' in little-endian
 pub(crate) const FOURCC_DXT5: u32 = 0x35545844; // 'DXT5' in little-endian
 pub(crate) const FOURCC_BC4U: u32 = 0x55344342; // 'BC4U' in little-endian
 pub(crate) const FOURCC_BC4S: u32 = 0x53344342; // 'BC4S' in little-endian
+
 /// 'ATI1' in little-endian - unofficial FourCC used by some 3rd party libraries,
 /// but not recognized by D3DX
 pub(crate) const FOURCC_ATI1: u32 = 0x31495441;
+pub(crate) const FOURCC_BC5U: u32 = 0x55354342; // 'BC5U' in little-endian - unofficial FourCC
+pub(crate) const FOURCC_BC5S: u32 = 0x53354342; // 'BC5S' in little-endian
+pub(crate) const FOURCC_ATI2: u32 = 0x32495441; // 'ATI2' in little-endian
 pub(crate) const FOURCC_DX10: u32 = 0x30315844; // 'DX10' in little-endian
 
 /// Offset of the DXGI format header used in DX10 and above.
@@ -38,6 +43,10 @@ pub(crate) const DXGI_FORMAT_BC3_UNORM_SRGB: u32 = 78;
 pub(crate) const DXGI_FORMAT_BC4_TYPELESS: u32 = 79;
 pub(crate) const DXGI_FORMAT_BC4_UNORM: u32 = 80;
 pub(crate) const DXGI_FORMAT_BC4_SNORM: u32 = 81;
+
+pub(crate) const DXGI_FORMAT_BC5_TYPELESS: u32 = 82;
+pub(crate) const DXGI_FORMAT_BC5_UNORM: u32 = 83;
+pub(crate) const DXGI_FORMAT_BC5_SNORM: u32 = 84;
 
 pub(crate) const DXGI_FORMAT_BC6H_TYPELESS: u32 = 94;
 pub(crate) const DXGI_FORMAT_BC6H_UF16: u32 = 95;
@@ -98,7 +107,7 @@ pub(crate) const DDS_PIXELFORMAT_ABITMASK_OFFSET: usize = 0x68;
 
 // Because of Little Endian, the masks here are reversed.
 // Common pixel format bit masks (verified with TexConv)
-// R8G8B8A8_UNORM: R=byte0, G=byte1, B=byte2, A=byte3
+// R8G8B8A8_UNORM / D3DFMT_A8B8G8R8: R=byte0, G=byte1, B=byte2, A=byte3
 pub(crate) const RGBA8888_RED_MASK: u32 = 0x000000FF;
 pub(crate) const RGBA8888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const RGBA8888_BLUE_MASK: u32 = 0x00FF0000;
@@ -110,7 +119,7 @@ pub(crate) const BGRA8888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const BGRA8888_BLUE_MASK: u32 = 0x000000FF;
 pub(crate) const BGRA8888_ALPHA_MASK: u32 = 0xFF000000;
 
-// B8G8R8 (BGR888): R=byte2, G=byte1, B=byte0
+// B8G8R8 (BGR888): R=byte2, G=byte1, B=byte0 (D3DFMT_R8G8B8 : From D3D9 Big Endian Naming Era)
 pub(crate) const BGR888_RED_MASK: u32 = 0x00FF0000;
 pub(crate) const BGR888_GREEN_MASK: u32 = 0x0000FF00;
 pub(crate) const BGR888_BLUE_MASK: u32 = 0x000000FF;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/constants.rs
@@ -12,6 +12,11 @@ pub(crate) const FOURCC_DXT2: u32 = 0x32545844; // 'DXT2' in little-endian
 pub(crate) const FOURCC_DXT3: u32 = 0x33545844; // 'DXT3' in little-endian
 pub(crate) const FOURCC_DXT4: u32 = 0x34545844; // 'DXT4' in little-endian
 pub(crate) const FOURCC_DXT5: u32 = 0x35545844; // 'DXT5' in little-endian
+pub(crate) const FOURCC_BC4U: u32 = 0x55344342; // 'BC4U' in little-endian
+pub(crate) const FOURCC_BC4S: u32 = 0x53344342; // 'BC4S' in little-endian
+/// 'ATI1' in little-endian - unofficial FourCC used by some 3rd party libraries,
+/// but not recognized by D3DX
+pub(crate) const FOURCC_ATI1: u32 = 0x31495441;
 pub(crate) const FOURCC_DX10: u32 = 0x30315844; // 'DX10' in little-endian
 
 /// Offset of the DXGI format header used in DX10 and above.
@@ -29,6 +34,10 @@ pub(crate) const DXGI_FORMAT_BC2_UNORM_SRGB: u32 = 75;
 pub(crate) const DXGI_FORMAT_BC3_TYPELESS: u32 = 76;
 pub(crate) const DXGI_FORMAT_BC3_UNORM: u32 = 77;
 pub(crate) const DXGI_FORMAT_BC3_UNORM_SRGB: u32 = 78;
+
+pub(crate) const DXGI_FORMAT_BC4_TYPELESS: u32 = 79;
+pub(crate) const DXGI_FORMAT_BC4_UNORM: u32 = 80;
+pub(crate) const DXGI_FORMAT_BC4_SNORM: u32 = 81;
 
 pub(crate) const DXGI_FORMAT_BC6H_TYPELESS: u32 = 94;
 pub(crate) const DXGI_FORMAT_BC6H_UF16: u32 = 95;

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -25,6 +25,8 @@ pub enum DdsFormat {
     BGRA8888 = 8,
     /// BGR888 format (24-bit RGB)
     BGR888 = 9,
+    /// BC4 format (single channel)
+    BC4 = 10,
 }
 
 /// The information of the DDS file supplied to the reader.
@@ -131,6 +133,7 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
                 FOURCC_DXT1 => DdsFormat::BC1,
                 FOURCC_DXT2 | FOURCC_DXT3 => DdsFormat::BC2,
                 FOURCC_DXT4 | FOURCC_DXT5 => DdsFormat::BC3,
+                FOURCC_BC4U | FOURCC_BC4S | FOURCC_ATI1 => DdsFormat::BC4,
                 _ => DdsFormat::Unknown,
             }
         } else if (pixel_flags & DDPF_RGB) != 0 {
@@ -240,7 +243,12 @@ fn calculate_data_length(format: DdsFormat, data: &[u8]) -> Option<u32> {
 
     // For block-compressed formats, use the dimension-based calculation
     match format {
-        DdsFormat::BC1 | DdsFormat::BC2 | DdsFormat::BC3 | DdsFormat::BC6H | DdsFormat::BC7 => {
+        DdsFormat::BC1
+        | DdsFormat::BC2
+        | DdsFormat::BC3
+        | DdsFormat::BC4
+        | DdsFormat::BC6H
+        | DdsFormat::BC7 => {
             calculate_data_length_for_block_compression(format, width, height, mipmap_count)
         }
         DdsFormat::RGBA8888 | DdsFormat::BGRA8888 => {
@@ -272,12 +280,18 @@ pub(crate) fn calculate_data_length_for_block_compression(
 ) -> Option<u32> {
     // Calculate data size based on format type
     match format {
-        DdsFormat::BC1 | DdsFormat::BC2 | DdsFormat::BC3 | DdsFormat::BC6H | DdsFormat::BC7 => {
+        DdsFormat::BC1
+        | DdsFormat::BC2
+        | DdsFormat::BC3
+        | DdsFormat::BC4
+        | DdsFormat::BC6H
+        | DdsFormat::BC7 => {
             // Block-compressed formats
             let block_size = match format {
                 DdsFormat::BC1 => 8,   // DXT1: 8 bytes per 4x4 block
                 DdsFormat::BC2 => 16,  // DXT2/3: 16 bytes per 4x4 block
                 DdsFormat::BC3 => 16,  // DXT4/5: 16 bytes per 4x4 block
+                DdsFormat::BC4 => 8,   // BC4: 8 bytes per 4x4 block
                 DdsFormat::BC6H => 16, // BC6H: 16 bytes per 4x4 block
                 DdsFormat::BC7 => 16,  // BC7: 16 bytes per 4x4 block
                 _ => unsafe { unreachable_unchecked() },

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/dds/parse_dds.rs
@@ -27,6 +27,8 @@ pub enum DdsFormat {
     BGR888 = 9,
     /// BC4 format (single channel)
     BC4 = 10,
+    /// BC5 format (dual channel)
+    BC5 = 11,
 }
 
 /// The information of the DDS file supplied to the reader.
@@ -103,6 +105,12 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
             DXGI_FORMAT_BC3_TYPELESS | DXGI_FORMAT_BC3_UNORM | DXGI_FORMAT_BC3_UNORM_SRGB => {
                 DdsFormat::BC3
             }
+            DXGI_FORMAT_BC4_TYPELESS | DXGI_FORMAT_BC4_UNORM | DXGI_FORMAT_BC4_SNORM => {
+                DdsFormat::BC4
+            }
+            DXGI_FORMAT_BC5_TYPELESS | DXGI_FORMAT_BC5_UNORM | DXGI_FORMAT_BC5_SNORM => {
+                DdsFormat::BC5
+            }
             DXGI_FORMAT_BC6H_TYPELESS | DXGI_FORMAT_BC6H_UF16 | DXGI_FORMAT_BC6H_SF16 => {
                 DdsFormat::BC6H
             }
@@ -134,6 +142,7 @@ pub fn parse_dds_ignore_magic(data: &[u8]) -> Option<DdsInfo> {
                 FOURCC_DXT2 | FOURCC_DXT3 => DdsFormat::BC2,
                 FOURCC_DXT4 | FOURCC_DXT5 => DdsFormat::BC3,
                 FOURCC_BC4U | FOURCC_BC4S | FOURCC_ATI1 => DdsFormat::BC4,
+                FOURCC_BC5U | FOURCC_BC5S | FOURCC_ATI2 => DdsFormat::BC5,
                 _ => DdsFormat::Unknown,
             }
         } else if (pixel_flags & DDPF_RGB) != 0 {
@@ -247,6 +256,7 @@ fn calculate_data_length(format: DdsFormat, data: &[u8]) -> Option<u32> {
         | DdsFormat::BC2
         | DdsFormat::BC3
         | DdsFormat::BC4
+        | DdsFormat::BC5
         | DdsFormat::BC6H
         | DdsFormat::BC7 => {
             calculate_data_length_for_block_compression(format, width, height, mipmap_count)
@@ -284,6 +294,7 @@ pub(crate) fn calculate_data_length_for_block_compression(
         | DdsFormat::BC2
         | DdsFormat::BC3
         | DdsFormat::BC4
+        | DdsFormat::BC5
         | DdsFormat::BC6H
         | DdsFormat::BC7 => {
             // Block-compressed formats
@@ -292,6 +303,7 @@ pub(crate) fn calculate_data_length_for_block_compression(
                 DdsFormat::BC2 => 16,  // DXT2/3: 16 bytes per 4x4 block
                 DdsFormat::BC3 => 16,  // DXT4/5: 16 bytes per 4x4 block
                 DdsFormat::BC4 => 8,   // BC4: 8 bytes per 4x4 block
+                DdsFormat::BC5 => 16,  // BC5: 16 bytes per 4x4 block
                 DdsFormat::BC6H => 16, // BC6H: 16 bytes per 4x4 block
                 DdsFormat::BC7 => 16,  // BC7: 16 bytes per 4x4 block
                 _ => unsafe { unreachable_unchecked() },

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
@@ -123,4 +123,15 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(TransformFormat::Bgr888));
     }
+
+    #[test]
+    fn test_get_transform_format_bc4_supported() {
+        let handler = super::super::DdsHandler;
+        let dds_data = create_valid_bc4_dds_with_dimensions(64, 64, 1);
+
+        let result = handler.get_transform_format(&dds_data, TransformFormatFilter::All);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(TransformFormat::Bc4));
+    }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/file_format_check.rs
@@ -134,4 +134,15 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), Some(TransformFormat::Bc4));
     }
+
+    #[test]
+    fn test_get_transform_format_bc5_supported() {
+        let handler = super::super::DdsHandler;
+        let dds_data = create_valid_bc5_dds_with_dimensions(64, 64, 1);
+
+        let result = handler.get_transform_format(&dds_data, TransformFormatFilter::All);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Some(TransformFormat::Bc5));
+    }
 }

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
@@ -54,6 +54,15 @@ pub(crate) fn dds_format_to_transform_format(
                 ))
             }
         }
+        DdsFormat::BC4 => {
+            if allow_unimplemented {
+                Ok(TransformFormat::Bc4)
+            } else {
+                Err(TransformError::FormatHandler(
+                    FormatHandlerError::FormatNotImplemented(TransformFormat::Bc4),
+                ))
+            }
+        }
         DdsFormat::BC6H => {
             if allow_unimplemented {
                 Ok(TransformFormat::Bc6H)
@@ -136,6 +145,10 @@ mod tests {
             TransformFormat::Bc3
         );
         assert_eq!(
+            dds_format_to_transform_format(DdsFormat::BC4, true).unwrap(),
+            TransformFormat::Bc4
+        );
+        assert_eq!(
             dds_format_to_transform_format(DdsFormat::BC6H, true).unwrap(),
             TransformFormat::Bc6H
         );
@@ -152,6 +165,12 @@ mod tests {
                 TransformFormat::Bc3,
             ))) => {}
             _ => panic!("Expected FormatNotImplemented for BC3"),
+        }
+        match dds_format_to_transform_format(DdsFormat::BC4, false) {
+            Err(TransformError::FormatHandler(FormatHandlerError::FormatNotImplemented(
+                TransformFormat::Bc4,
+            ))) => {}
+            _ => panic!("Expected FormatNotImplemented for BC4"),
         }
         match dds_format_to_transform_format(DdsFormat::BC6H, false) {
             Err(TransformError::FormatHandler(FormatHandlerError::FormatNotImplemented(

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
@@ -28,11 +28,13 @@ use dxt_lossless_transform_file_formats_api::{
 /// - BC1 (DXT1) - implemented
 /// - BC2 (DXT2/3) - implemented
 /// - BC3 (DXT4/5) - known but unimplemented
+/// - BC4 - known but unimplemented
+/// - BC5 - known but unimplemented
 /// - BC6H - known but unimplemented
 /// - BC7 - known but unimplemented
-/// - RGBA8888 - implemented
-/// - BGRA8888 - implemented
-/// - BGR888 - implemented
+/// - RGBA8888 - known but unimplemented
+/// - BGRA8888 - known but unimplemented
+/// - BGR888 - known but unimplemented
 ///
 /// # Unsupported Formats
 ///

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/handler/format_conversion.rs
@@ -63,6 +63,15 @@ pub(crate) fn dds_format_to_transform_format(
                 ))
             }
         }
+        DdsFormat::BC5 => {
+            if allow_unimplemented {
+                Ok(TransformFormat::Bc5)
+            } else {
+                Err(TransformError::FormatHandler(
+                    FormatHandlerError::FormatNotImplemented(TransformFormat::Bc5),
+                ))
+            }
+        }
         DdsFormat::BC6H => {
             if allow_unimplemented {
                 Ok(TransformFormat::Bc6H)
@@ -149,6 +158,10 @@ mod tests {
             TransformFormat::Bc4
         );
         assert_eq!(
+            dds_format_to_transform_format(DdsFormat::BC5, true).unwrap(),
+            TransformFormat::Bc5
+        );
+        assert_eq!(
             dds_format_to_transform_format(DdsFormat::BC6H, true).unwrap(),
             TransformFormat::Bc6H
         );
@@ -171,6 +184,12 @@ mod tests {
                 TransformFormat::Bc4,
             ))) => {}
             _ => panic!("Expected FormatNotImplemented for BC4"),
+        }
+        match dds_format_to_transform_format(DdsFormat::BC5, false) {
+            Err(TransformError::FormatHandler(FormatHandlerError::FormatNotImplemented(
+                TransformFormat::Bc5,
+            ))) => {}
+            _ => panic!("Expected FormatNotImplemented for BC5"),
         }
         match dds_format_to_transform_format(DdsFormat::BC6H, false) {
             Err(TransformError::FormatHandler(FormatHandlerError::FormatNotImplemented(

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -159,6 +159,11 @@ pub fn create_valid_dds_with_dimensions(
                 .unwrap_or(0) as usize,
             false,
         ),
+        DdsFormat::BC5 => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            false,
+        ),
         DdsFormat::BC6H => (
             calculate_data_length_for_block_compression(format, width, height, mipmap_count)
                 .unwrap_or(0) as usize,
@@ -215,6 +220,9 @@ pub fn create_valid_dds_with_dimensions(
         }
         DdsFormat::BC4 => {
             write_fourcc_pixel_format(&mut data, b"BC4U");
+        }
+        DdsFormat::BC5 => {
+            write_fourcc_pixel_format(&mut data, b"BC5U");
         }
         DdsFormat::BC6H => {
             write_dx10_format(&mut data, DXGI_FORMAT_BC6H_UF16);
@@ -327,6 +335,17 @@ pub fn create_valid_bc4_dds_with_dimensions(width: u32, height: u32, mipmap_coun
 /// Use this when you just need any valid BC4 DDS for testing
 pub fn create_valid_bc4_dds() -> Vec<u8> {
     create_valid_dds_with_dimensions(DdsFormat::BC4, 4, 4, 1)
+}
+
+/// Helper function to create a valid BC5 DDS with proper dimensions and data length
+pub fn create_valid_bc5_dds_with_dimensions(width: u32, height: u32, mipmap_count: u32) -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC5, width, height, mipmap_count)
+}
+
+/// Creates a minimal valid BC5 DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC5 DDS for testing
+pub fn create_valid_bc5_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC5, 4, 4, 1)
 }
 
 /// Creates a minimal valid BC6H DDS file (4x4, single mipmap)

--- a/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
+++ b/projects/extensions/file-formats/dxt-lossless-transform-dds/src/test_prelude.rs
@@ -154,6 +154,11 @@ pub fn create_valid_dds_with_dimensions(
                 .unwrap_or(0) as usize,
             false,
         ),
+        DdsFormat::BC4 => (
+            calculate_data_length_for_block_compression(format, width, height, mipmap_count)
+                .unwrap_or(0) as usize,
+            false,
+        ),
         DdsFormat::BC6H => (
             calculate_data_length_for_block_compression(format, width, height, mipmap_count)
                 .unwrap_or(0) as usize,
@@ -207,6 +212,9 @@ pub fn create_valid_dds_with_dimensions(
         }
         DdsFormat::BC3 => {
             write_fourcc_pixel_format(&mut data, b"DXT5");
+        }
+        DdsFormat::BC4 => {
+            write_fourcc_pixel_format(&mut data, b"BC4U");
         }
         DdsFormat::BC6H => {
             write_dx10_format(&mut data, DXGI_FORMAT_BC6H_UF16);
@@ -308,6 +316,17 @@ pub fn create_valid_bc2_dds() -> Vec<u8> {
 /// Use this when you just need any valid BC3 DDS for testing
 pub fn create_valid_bc3_dds() -> Vec<u8> {
     create_valid_dds_with_dimensions(DdsFormat::BC3, 4, 4, 1)
+}
+
+/// Helper function to create a valid BC4 DDS with proper dimensions and data length
+pub fn create_valid_bc4_dds_with_dimensions(width: u32, height: u32, mipmap_count: u32) -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC4, width, height, mipmap_count)
+}
+
+/// Creates a minimal valid BC4 DDS file (4x4, single mipmap)
+/// Use this when you just need any valid BC4 DDS for testing
+pub fn create_valid_bc4_dds() -> Vec<u8> {
+    create_valid_dds_with_dimensions(DdsFormat::BC4, 4, 4, 1)
 }
 
 /// Creates a minimal valid BC6H DDS file (4x4, single mipmap)

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
@@ -50,6 +50,8 @@ enum FormatKey {
     Bgr888 = 8,
     /// BC4 format transform (TransformFormat::Bc4 = 0x08 -> FormatKey = 9)
     Bc4 = 9,
+    /// BC5 format transform (TransformFormat::Bc5 = 0x09 -> FormatKey = 10)
+    Bc5 = 10,
 }
 
 impl From<Option<TransformFormat>> for FormatKey {
@@ -67,6 +69,7 @@ impl From<Option<TransformFormat>> for FormatKey {
                     TransformFormat::Bgra8888 => Self::Bgra8888, // 0x06 -> 7
                     TransformFormat::Bgr888 => Self::Bgr888,     // 0x07 -> 8
                     TransformFormat::Bc4 => Self::Bc4,           // 0x08 -> 9
+                    TransformFormat::Bc5 => Self::Bc5,           // 0x09 -> 10
                     _ => Self::Unknown, // Handle any future variants as unknown
                 }
             }
@@ -89,6 +92,7 @@ impl FormatKey {
             Self::Bgra8888 => "Bgra8888",
             Self::Bgr888 => "Bgr888",
             Self::Bc4 => "Bc4",
+            Self::Bc5 => "Bc5",
         }
     }
 }

--- a/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
+++ b/projects/tools/dxt-lossless-transform-cli/src/commands/debug_format_analysis.rs
@@ -48,6 +48,8 @@ enum FormatKey {
     Bgra8888 = 7,
     /// BGR888 format transform (TransformFormat::Bgr888 = 0x07 -> FormatKey = 8)
     Bgr888 = 8,
+    /// BC4 format transform (TransformFormat::Bc4 = 0x08 -> FormatKey = 9)
+    Bc4 = 9,
 }
 
 impl From<Option<TransformFormat>> for FormatKey {
@@ -64,6 +66,7 @@ impl From<Option<TransformFormat>> for FormatKey {
                     TransformFormat::Rgba8888 => Self::Rgba8888, // 0x05 -> 6
                     TransformFormat::Bgra8888 => Self::Bgra8888, // 0x06 -> 7
                     TransformFormat::Bgr888 => Self::Bgr888,     // 0x07 -> 8
+                    TransformFormat::Bc4 => Self::Bc4,           // 0x08 -> 9
                     _ => Self::Unknown, // Handle any future variants as unknown
                 }
             }
@@ -85,6 +88,7 @@ impl FormatKey {
             Self::Rgba8888 => "Rgba8888",
             Self::Bgra8888 => "Bgra8888",
             Self::Bgr888 => "Bgr888",
+            Self::Bc4 => "Bc4",
         }
     }
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/Sewer56/dxt-lossless-transform/blob/main/docs/CONTRIBUTING.md
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for BC4 and BC5 compression formats across the API, debug tools, and DDS file handling.
  * BC4 and BC5 formats can now be parsed, identified, and analyzed in DDS files and CLI debug tools.
  * New helper functions and constants for BC4/BC5 are available for test creation and format recognition.

* **Bug Fixes**
  * Improved error handling and validation when working with BC4 and BC5 headers and formats.

* **Documentation**
  * Enhanced comments and documentation to clarify new BC4/BC5 constants and format handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->